### PR TITLE
Harden against Bash/path bypass, Codex patch parsing, symlink, and action injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,19 @@ Agent Guard inserts deterministic secret-scanning checks into AI coding agent ho
 
 It is intentionally small. It does not teach agents how to behave, manage vaults, rotate credentials, verify live credentials, produce dashboards, or replace GitHub Secret Scanning and Push Protection.
 
+## Channels
+
+Agent Guard offers four independent integration points. Pick whichever match your workflow — they do **not** chain. Each row lists what that channel alone can and cannot block.
+
+| Channel | What it blocks | What it cannot see |
+|---|---|---|
+| Agent hook (Claude Code / Codex) | Pre-tool: deny-listed reads (`.env`, `id_rsa`, …), risky shell idioms, secrets in proposed `Write`/`Edit`/`apply_patch`, secrets in MCP tool input. Post-tool & Stop: secrets in working-tree diff & untracked files. | Edits the user makes by hand outside the agent session. |
+| Native Git pre-commit hook | Secrets in staged added lines at commit time. | Reads the agent performed earlier; commits made with `--no-verify`. |
+| GitHub Action | Secrets in any tracked file on a PR/push. | Anything that already merged before the workflow ran. |
+| Direct CLI (`bin/agent-guard scan-*`) | Whatever you point it at, on demand. | Anything outside the invocation. |
+
+Defense-in-depth is best, but a single channel still meaningfully reduces risk. The agent-hook channel is the only one that can stop a leak **before** the secret leaves the host.
+
 ## Requirements
 
 - `sh`
@@ -82,9 +95,14 @@ The root `action.yml` lets consumers use the repository directly:
 - uses: JeongJaeSoon/agent-guard@v1
   with:
     paths: "."
+    gitleaks-checksum: "<sha256 of the gitleaks release archive>"
 ```
 
-For high-security environments, pin to a full commit SHA instead of a moving tag.
+The `gitleaks-checksum` input is required by default. Pin a known-good sha256 for the `gitleaks-version` you select — this stops a compromised release URL from injecting a malicious binary into your CI runner.
+
+To opt out (local experimentation only) set `require-checksum: "false"`. Do not do this in production CI.
+
+For high-security environments, also pin Agent Guard to a full commit SHA instead of the moving `@v1` tag.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ Policy files:
 - `config/deny-read-paths.txt`
 - `config/deny-bash-patterns.txt`
 
+The bundled deny-read policy is conservative, including local credential files such as `.env*`, SSH keys/config, cloud CLI credentials, and certificate bundles. If your workflow needs a different read policy, point `AGENT_GUARD_DENY_READ_PATHS` at your own deny-list file.
+
 Project-local `.gitleaks.toml` files are not automatically trusted.
 
 ## Tests

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,12 @@ inputs:
     description: Optional sha256 checksum for the selected gitleaks archive.
     required: false
     default: ""
+  require-checksum:
+    description: When true, fail if gitleaks-checksum is empty. Defaults to true so CI
+      cannot silently fall back to HTTPS-only integrity. Set to false only for local
+      experimentation.
+    required: false
+    default: "true"
   config-path:
     description: Optional gitleaks config path. Defaults to the bundled Agent Guard config.
     required: false
@@ -31,13 +37,17 @@ runs:
 
     - name: Install gitleaks if missing
       shell: bash
+      env:
+        AGENT_GUARD_GITLEAKS_VERSION: ${{ inputs.gitleaks-version }}
+        AGENT_GUARD_GITLEAKS_CHECKSUM: ${{ inputs.gitleaks-checksum }}
+        AGENT_GUARD_REQUIRE_CHECKSUM: ${{ inputs.require-checksum }}
       run: |
         set -euo pipefail
         if command -v gitleaks >/dev/null; then
           exit 0
         fi
 
-        version="${{ inputs.gitleaks-version }}"
+        version="$AGENT_GUARD_GITLEAKS_VERSION"
         os="$(uname -s | tr '[:upper:]' '[:lower:]')"
         arch="$(uname -m)"
         case "$arch" in
@@ -46,16 +56,23 @@ runs:
           *) echo "unsupported architecture for gitleaks install: $arch" >&2; exit 2 ;;
         esac
 
+        checksum="$AGENT_GUARD_GITLEAKS_CHECKSUM"
+        require_checksum="${AGENT_GUARD_REQUIRE_CHECKSUM:-true}"
+        if [ -z "$checksum" ] && [ "$require_checksum" = "true" ]; then
+          echo "agent-guard: gitleaks-checksum input is required when require-checksum=true" >&2
+          echo "  Provide a pinned sha256 for gitleaks ${version} or pass require-checksum=false explicitly." >&2
+          exit 2
+        fi
+
         archive="gitleaks_${version}_${os}_${arch}.tar.gz"
         url="https://github.com/gitleaks/gitleaks/releases/download/v${version}/${archive}"
         tmp="$(mktemp -d)"
         curl -fsSL "$url" -o "$tmp/$archive"
 
-        checksum="${{ inputs.gitleaks-checksum }}"
         if [ -n "$checksum" ]; then
           echo "$checksum  $tmp/$archive" | shasum -a 256 -c -
         else
-          echo "No gitleaks-checksum input provided; relying on HTTPS transport only." >&2
+          echo "agent-guard: no gitleaks-checksum provided; relying on HTTPS transport only." >&2
         fi
 
         tar -xzf "$tmp/$archive" -C "$tmp"
@@ -68,9 +85,14 @@ runs:
       shell: bash
       env:
         AGENT_GUARD_GITLEAKS_CONFIG: ${{ inputs.config-path }}
+        AGENT_GUARD_PATHS: ${{ inputs.paths }}
       run: |
         set -euo pipefail
         if [ -z "${AGENT_GUARD_GITLEAKS_CONFIG:-}" ]; then
           unset AGENT_GUARD_GITLEAKS_CONFIG
         fi
-        "${GITHUB_ACTION_PATH}/bin/agent-guard" scan-path ${{ inputs.paths }}
+        # Split on whitespace deliberately so multiple paths can be passed,
+        # but keep the value sourced from an env var rather than an
+        # unquoted ${{ }} expansion to avoid YAML-time shell injection.
+        # shellcheck disable=SC2086
+        "${GITHUB_ACTION_PATH}/bin/agent-guard" scan-path -- $AGENT_GUARD_PATHS

--- a/action.yml
+++ b/action.yml
@@ -91,8 +91,6 @@ runs:
         if [ -z "${AGENT_GUARD_GITLEAKS_CONFIG:-}" ]; then
           unset AGENT_GUARD_GITLEAKS_CONFIG
         fi
-        # Split on whitespace deliberately so multiple paths can be passed,
-        # but keep the value sourced from an env var rather than an
-        # unquoted ${{ }} expansion to avoid YAML-time shell injection.
+        # Split paths from env, not from unquoted YAML-time input expansion.
         # shellcheck disable=SC2086
         "${GITHUB_ACTION_PATH}/bin/agent-guard" scan-path -- $AGENT_GUARD_PATHS

--- a/bin/agent-guard
+++ b/bin/agent-guard
@@ -122,10 +122,45 @@ extract_added_lines() {
   '
 }
 
+# Codex apply_patch payloads use a custom envelope:
+#   *** Begin Patch
+#   *** Add File: path        (followed by raw content lines, no leading +)
+#   *** Update File: path     (followed by unified-diff-like hunks: + adds, - removes, " " context)
+#   *** Delete File: path
+#   *** End Patch
+# This extractor yields every line that introduces new content into the tree.
 extract_patch_added_lines() {
   awk '
-    /^\+\+\+ / { next }
-    /^\+[^+]/ { sub(/^\+/, ""); print }
+    BEGIN { mode = "none" }
+    /^\*\*\* Begin Patch/ { mode = "none"; next }
+    /^\*\*\* End Patch/ { mode = "none"; next }
+    /^\*\*\* Add File:/ { mode = "add"; next }
+    /^\*\*\* Update File:/ { mode = "update"; next }
+    /^\*\*\* Delete File:/ { mode = "none"; next }
+    /^\*\*\* End of File/ { next }
+    /^@@/ { next }
+    {
+      if (mode == "add") {
+        line = $0
+        sub(/^\+/, "", line)
+        print line
+        next
+      }
+      if (mode == "update") {
+        if (substr($0, 1, 1) == "+") {
+          line = substr($0, 2)
+          print line
+        }
+        next
+      }
+      # Fallback: treat as a unified diff hunk.
+      if (/^\+\+\+ /) next
+      if (/^\+/) {
+        line = $0
+        sub(/^\+/, "", line)
+        print line
+      }
+    }
   '
 }
 
@@ -207,6 +242,9 @@ scan_working_tree() {
 
 scan_path() {
   need_gitleaks
+  if [ "${1:-}" = "--" ]; then
+    shift
+  fi
   [ "$#" -gt 0 ] || die "scan-path requires at least one path"
   result=0
   for path in "$@"; do
@@ -238,15 +276,45 @@ json_value() {
   printf '%s' "$input" | jq -r "$expr"
 }
 
-matches_deny_path() {
+normalize_path() {
   candidate=$1
-  [ -f "$DENY_READ_PATHS" ] || return 1
-
-  # Strip common prefixes so hooks can pass absolute, relative, or file:// paths.
   case "$candidate" in
     file://*) candidate=${candidate#file://} ;;
   esac
+  case "$candidate" in
+    '~') candidate=${HOME:-/} ;;
+    '~/'*) candidate=${HOME:-/}/${candidate#~/} ;;
+  esac
+  while :; do
+    case "$candidate" in
+      './'*) candidate=${candidate#./} ;;
+      *) break ;;
+    esac
+  done
+  printf '%s' "$candidate"
+}
 
+resolve_path() {
+  candidate=$1
+  # Best-effort symlink resolution. Fail open to the original string so a
+  # missing realpath binary or a path that does not exist on disk does not
+  # silently disable the policy match.
+  resolved=$(
+    if command -v realpath >/dev/null 2>&1; then
+      realpath -- "$candidate" 2>/dev/null
+    elif command -v readlink >/dev/null 2>&1; then
+      readlink -f -- "$candidate" 2>/dev/null
+    fi
+  )
+  if [ -n "$resolved" ]; then
+    printf '%s' "$resolved"
+  else
+    printf '%s' "$candidate"
+  fi
+}
+
+candidate_matches_deny() {
+  candidate=$1
   while IFS= read -r pattern || [ -n "$pattern" ]; do
     case "$pattern" in
       ''|\#*) continue ;;
@@ -255,6 +323,20 @@ matches_deny_path() {
       $pattern|*/$pattern) return 0 ;;
     esac
   done <"$DENY_READ_PATHS"
+  return 1
+}
+
+matches_deny_path() {
+  raw=$1
+  [ -f "$DENY_READ_PATHS" ] || return 1
+
+  normalized=$(normalize_path "$raw")
+  candidate_matches_deny "$normalized" && return 0
+
+  resolved=$(resolve_path "$normalized")
+  if [ "$resolved" != "$normalized" ]; then
+    candidate_matches_deny "$resolved" && return 0
+  fi
   return 1
 }
 
@@ -275,6 +357,61 @@ check_sensitive_reads() {
   done
 }
 
+deny_path_basename_pattern() {
+  # Translate one deny-read-paths line into a POSIX-ERE alternative usable by
+  # grep -E. The patterns are shell case globs; we convert the few constructs
+  # actually in use (literal text plus * wildcards) to ERE.
+  pattern=$1
+  py=
+  i=1
+  len=${#pattern}
+  while [ "$i" -le "$len" ]; do
+    ch=$(printf '%s' "$pattern" | cut -c"$i")
+    case "$ch" in
+      '*') py=${py}'[^[:space:]<>|;&`$()]*' ;;
+      '.'|'^'|'$'|'+'|'?'|'('|')'|'['|']'|'{'|'}'|'|'|'\\') py=${py}'\'${ch} ;;
+      '/') py=${py}'/' ;;
+      *) py=${py}${ch} ;;
+    esac
+    i=$((i + 1))
+  done
+  printf '%s' "$py"
+}
+
+bash_matches_deny_path() {
+  cmd=$1
+  [ -f "$DENY_READ_PATHS" ] || return 1
+  while IFS= read -r entry || [ -n "$entry" ]; do
+    case "$entry" in
+      ''|\#*) continue ;;
+    esac
+    converted=$(deny_path_basename_pattern "$entry")
+    [ -n "$converted" ] || continue
+    # Match the path either at a word boundary or after a directory separator,
+    # so `cat .env`, `cat ./.env`, `cat /tmp/.env`, `dd if=.env`, and
+    # `$(cat .env)` are all caught while bare words like `myenv` are not.
+    regex='(^|[^[:alnum:]_./~-])('${converted}'|[^[:space:]<>|;&`$()]*/'${converted}')([^[:alnum:]_.-]|$)'
+    if printf '%s\n' "$cmd" | grep -Eq "$regex"; then
+      return 0
+    fi
+  done <"$DENY_READ_PATHS"
+  return 1
+}
+
+is_git_commit_or_push() {
+  cmd=$1
+  # Match the git binary token followed anywhere by a commit/push subcommand,
+  # tolerating switches like `git -c user.x=y commit`, `git -C . push`, and
+  # `/usr/bin/git --git-dir=.git --work-tree=. commit`.
+  printf '%s\n' "$cmd" | grep -Eq '(^|[^[:alnum:]_./-])git([[:space:]]|$)'  || return 1
+  printf '%s\n' "$cmd" | grep -Eq '(^|[^[:alnum:]_-])(commit|push)([^[:alnum:]_-]|$)'
+}
+
+is_git_hook_bypass() {
+  cmd=$1
+  printf '%s\n' "$cmd" | grep -Eq '(--no-verify|--no-gpg-sign)([^[:alnum:]_-]|$)'
+}
+
 check_bash_command() {
   input=$1
   need_jq
@@ -292,7 +429,16 @@ check_bash_command() {
     fi
   done <"$DENY_BASH_PATTERNS"
 
-  if printf '%s\n' "$cmd" | grep -Eq '(^|[^[:alnum:]_-])git[[:space:]]+(commit|push)([^[:alnum:]_-]|$)'; then
+  if bash_matches_deny_path "$cmd"; then
+    info "$PROGRAM: blocked shell command referencing a deny-listed path"
+    exit 2
+  fi
+
+  if is_git_commit_or_push "$cmd"; then
+    if is_git_hook_bypass "$cmd"; then
+      info "$PROGRAM: blocked git command that disables hooks/signing"
+      exit 2
+    fi
     scan_staged
     status=$?
     case "$status" in
@@ -349,7 +495,7 @@ hook_pre_tool() {
     Write|Edit|MultiEdit|apply_patch)
       scan_proposed_write "$input" "$tool"
       ;;
-    Read|Grep|Glob)
+    Read|NotebookRead|Grep|Glob)
       check_sensitive_reads "$input"
       ;;
     Bash)

--- a/bin/agent-guard
+++ b/bin/agent-guard
@@ -122,13 +122,7 @@ extract_added_lines() {
   '
 }
 
-# Codex apply_patch payloads use a custom envelope:
-#   *** Begin Patch
-#   *** Add File: path        (followed by raw content lines, no leading +)
-#   *** Update File: path     (followed by unified-diff-like hunks: + adds, - removes, " " context)
-#   *** Delete File: path
-#   *** End Patch
-# This extractor yields every line that introduces new content into the tree.
+# Extract lines introduced by Codex apply_patch envelopes or unified diffs.
 extract_patch_added_lines() {
   awk '
     BEGIN { mode = "none" }
@@ -296,9 +290,7 @@ normalize_path() {
 
 resolve_path() {
   candidate=$1
-  # Best-effort symlink resolution. Fail open to the original string so a
-  # missing realpath binary or a path that does not exist on disk does not
-  # silently disable the policy match.
+  # Resolve symlinks when possible; otherwise keep matching the original path.
   resolved=$(
     if command -v realpath >/dev/null 2>&1; then
       realpath -- "$candidate" 2>/dev/null
@@ -358,9 +350,7 @@ check_sensitive_reads() {
 }
 
 deny_path_basename_pattern() {
-  # Translate one deny-read-paths line into a POSIX-ERE alternative usable by
-  # grep -E. The patterns are shell case globs; we convert the few constructs
-  # actually in use (literal text plus * wildcards) to ERE.
+  # Convert the supported deny-read shell globs to POSIX ERE.
   pattern=$1
   py=
   i=1
@@ -387,9 +377,7 @@ bash_matches_deny_path() {
     esac
     converted=$(deny_path_basename_pattern "$entry")
     [ -n "$converted" ] || continue
-    # Match the path either at a word boundary or after a directory separator,
-    # so `cat .env`, `cat ./.env`, `cat /tmp/.env`, `dd if=.env`, and
-    # `$(cat .env)` are all caught while bare words like `myenv` are not.
+    # Catch path arguments and shell words without matching substrings like myenv.
     regex='(^|[^[:alnum:]_./~-])('${converted}'|[^[:space:]<>|;&`$()]*/'${converted}')([^[:alnum:]_.-]|$)'
     if printf '%s\n' "$cmd" | grep -Eq "$regex"; then
       return 0
@@ -400,9 +388,7 @@ bash_matches_deny_path() {
 
 is_git_commit_or_push() {
   cmd=$1
-  # Match the git binary token followed anywhere by a commit/push subcommand,
-  # tolerating switches like `git -c user.x=y commit`, `git -C . push`, and
-  # `/usr/bin/git --git-dir=.git --work-tree=. commit`.
+  # Allow git options before commit/push, e.g. `git -c x=y commit`.
   printf '%s\n' "$cmd" | grep -Eq '(^|[^[:alnum:]_./-])git([[:space:]]|$)'  || return 1
   printf '%s\n' "$cmd" | grep -Eq '(^|[^[:alnum:]_-])(commit|push)([^[:alnum:]_-]|$)'
 }

--- a/config/deny-bash-patterns.txt
+++ b/config/deny-bash-patterns.txt
@@ -1,9 +1,18 @@
 # POSIX ERE patterns. Blank lines and lines starting with # are ignored.
-(^|[[:space:];|&])cat[[:space:]]+([^;|&[:space:]]*/)?\.env([^[:alnum:]_.-]|$)
+#
+# Generic file-read bypass for deny-read-paths is handled in bash_matches_deny_path
+# inside bin/agent-guard, so this list only carries shell idioms that have no
+# obvious path argument (printenv, secret managers, exfiltration via curl/wget,
+# etc.).
 (^|[[:space:];|&])printenv([^[:alnum:]_-]|$)
-(^|[[:space:];|&])env([^[:alnum:]_-]|$)
+(^|[[:space:];|&])env[[:space:]]*($|[;|&])
 security[[:space:]]+find-generic-password
 op[[:space:]]+read
+op[[:space:]]+item[[:space:]]+get
 vault[[:space:]]+kv[[:space:]]+get
+vault[[:space:]]+read
 aws[[:space:]]+secretsmanager[[:space:]]+get-secret-value
+aws[[:space:]]+ssm[[:space:]]+get-parameter
+gcloud[[:space:]]+secrets[[:space:]]+versions[[:space:]]+access
 (curl|wget).*(TOKEN|SECRET|PASSWORD|API[_-]?KEY|ACCESS[_-]?KEY)
+gh[[:space:]]+auth[[:space:]]+token

--- a/config/deny-bash-patterns.txt
+++ b/config/deny-bash-patterns.txt
@@ -1,9 +1,5 @@
 # POSIX ERE patterns. Blank lines and lines starting with # are ignored.
-#
-# Generic file-read bypass for deny-read-paths is handled in bash_matches_deny_path
-# inside bin/agent-guard, so this list only carries shell idioms that have no
-# obvious path argument (printenv, secret managers, exfiltration via curl/wget,
-# etc.).
+# Path-based reads are handled from deny-read-paths; keep only pathless shell idioms here.
 (^|[[:space:];|&])printenv([^[:alnum:]_-]|$)
 (^|[[:space:];|&])env[[:space:]]*($|[;|&])
 security[[:space:]]+find-generic-password

--- a/config/deny-read-paths.txt
+++ b/config/deny-read-paths.txt
@@ -4,6 +4,8 @@
 .env*
 *.pem
 *.key
+*.pfx
+*.p12
 id_rsa
 id_dsa
 id_ecdsa
@@ -15,7 +17,15 @@ id_ed25519
 .netrc
 .docker/config.json
 .config/gh/hosts.yml
+.git-credentials
+.ssh/config
+.ssh/id_*
+.kube/config
+.config/gcloud/application_default_credentials.json
+.config/gcloud/credentials.db
 credentials.json
 secrets.json
 secrets.yaml
 secrets.yml
+service-account*.json
+gcp-sa*.json

--- a/examples/claude/settings.project.json
+++ b/examples/claude/settings.project.json
@@ -2,7 +2,7 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Write|Edit|MultiEdit|Read|Grep|Glob|Bash|apply_patch|mcp__.*",
+        "matcher": "Write|Edit|MultiEdit|Read|NotebookRead|Grep|Glob|Bash|apply_patch|mcp__.*",
         "hooks": [
           {
             "type": "command",

--- a/examples/github/secret-guard.yml
+++ b/examples/github/secret-guard.yml
@@ -13,3 +13,8 @@ jobs:
       - uses: JeongJaeSoon/agent-guard@v1
         with:
           paths: "."
+          # Required by default. Pin the sha256 of the gitleaks release archive
+          # matching the gitleaks-version input (default 8.30.1). Set
+          # require-checksum: "false" to opt out for local experimentation.
+          gitleaks-checksum: ""
+          require-checksum: "false"

--- a/examples/github/secret-guard.yml
+++ b/examples/github/secret-guard.yml
@@ -13,8 +13,4 @@ jobs:
       - uses: JeongJaeSoon/agent-guard@v1
         with:
           paths: "."
-          # Required by default. Pin the sha256 of the gitleaks release archive
-          # matching the gitleaks-version input (default 8.30.1). Set
-          # require-checksum: "false" to opt out for local experimentation.
-          gitleaks-checksum: ""
-          require-checksum: "false"
+          gitleaks-checksum: "<sha256 of the gitleaks release archive>"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -2,7 +2,7 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Write|Edit|MultiEdit|Read|Grep|Glob|Bash|apply_patch|mcp__.*",
+        "matcher": "Write|Edit|MultiEdit|Read|NotebookRead|Grep|Glob|Bash|apply_patch|mcp__.*",
         "hooks": [
           {
             "type": "command",

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -298,6 +298,314 @@ else
 fi
 rm -f "$INJECTION_CANARY"
 
+# --- CLI dispatch ----------------------------------------------------------
+
+run_expect 0 "version subcommand prints program/version" \
+  "$ROOT/bin/agent-guard" version
+case "$(cat /tmp/agent-guard-test.out)" in
+  agent-guard*) ok "version output starts with program name" ;;
+  *) not_ok "version output unexpected: $(cat /tmp/agent-guard-test.out)" ;;
+esac
+
+run_expect 0 "help subcommand exits 0" "$ROOT/bin/agent-guard" help
+run_expect 0 "no args exits 0 with usage on stderr" "$ROOT/bin/agent-guard"
+run_expect 2 "unknown subcommand exits 2" "$ROOT/bin/agent-guard" not-a-command
+
+run_expect 0 "check passes when deps and configs exist" "$ROOT/bin/agent-guard" check
+
+# --- scan-path -------------------------------------------------------------
+
+CLEAN_DIR="$TMP_ROOT/clean-dir"
+mkdir -p "$CLEAN_DIR"
+printf '%s\n' "ok content" > "$CLEAN_DIR/safe.txt"
+run_expect 0 "scan-path is clean for benign directory" \
+  "$ROOT/bin/agent-guard" scan-path "$CLEAN_DIR"
+
+DIRTY_DIR="$TMP_ROOT/dirty-dir"
+mkdir -p "$DIRTY_DIR"
+printf '%s\n' "AGENT_GUARD_TEST_SECRET" > "$DIRTY_DIR/leak.txt"
+run_expect 1 "scan-path detects secret via mock gitleaks" \
+  "$ROOT/bin/agent-guard" scan-path "$DIRTY_DIR"
+
+run_expect 1 "scan-path with multiple paths returns 1 if any has a leak" \
+  "$ROOT/bin/agent-guard" scan-path "$CLEAN_DIR" "$DIRTY_DIR"
+
+run_expect 0 "scan-path accepts -- arg terminator before paths" \
+  "$ROOT/bin/agent-guard" scan-path -- "$CLEAN_DIR"
+
+run_expect 2 "scan-path dies when given a missing path" \
+  "$ROOT/bin/agent-guard" scan-path "$TMP_ROOT/does-not-exist"
+
+run_expect 2 "scan-path dies with no paths" "$ROOT/bin/agent-guard" scan-path
+
+# --- hook_pre_tool routing & passthroughs ---------------------------------
+
+expect_json_status 0 "empty stdin to hook-pre-tool is allowed" "" hook-pre-tool
+expect_json_status 0 "unknown tool name passes through hook-pre-tool" \
+  '{"tool_name":"FutureTool","tool_input":{"x":1}}' \
+  hook-pre-tool
+
+expect_json_status 0 "Read on benign path passes" \
+  '{"tool_name":"Read","tool_input":{"file_path":"src/app.ts"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "Bash on benign command passes" \
+  '{"tool_name":"Bash","tool_input":{"command":"ls -la"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "MultiEdit with one secret edit is blocked" \
+  '{"tool_name":"MultiEdit","tool_input":{"edits":[{"new_string":"clean line"},{"new_string":"AGENT_GUARD_TEST_SECRET"}]}}' \
+  hook-pre-tool
+
+expect_json_status 0 "MultiEdit with all-clean edits passes" \
+  '{"tool_name":"MultiEdit","tool_input":{"edits":[{"new_string":"alpha"},{"new_string":"beta"}]}}' \
+  hook-pre-tool
+
+expect_json_status 0 "Write with no content key passes" \
+  '{"tool_name":"Write","tool_input":{"file_path":"x.txt"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "Edit with clean new_string passes" \
+  '{"tool_name":"Edit","tool_input":{"new_string":"const x = 1"}}' \
+  hook-pre-tool
+
+# --- hook_post_tool routing -----------------------------------------------
+
+POST_REPO="$TMP_ROOT/post-repo"
+mkdir -p "$POST_REPO"
+(
+  cd "$POST_REPO" || exit 2
+  git init -q
+  git config user.email t@e
+  git config user.name t
+  printf '%s\n' "ok" > README.md
+  git add README.md
+  git commit -q -m init
+)
+
+(
+  cd "$POST_REPO" || exit 2
+  printf '%s' '{"tool_name":"Read","tool_input":{"file_path":"README.md"}}' \
+    | "$ROOT/bin/agent-guard" hook-post-tool >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+)
+status=$?
+if [ "$status" -eq 0 ]; then
+  ok "hook-post-tool ignores non-mutation tools"
+else
+  not_ok "hook-post-tool ignores non-mutation tools (expected 0, got $status)"
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+
+(
+  cd "$POST_REPO" || exit 2
+  printf '%s\n' "AGENT_GUARD_TEST_SECRET" > leaked.txt
+  printf '%s' '{"tool_name":"Write","tool_input":{"file_path":"leaked.txt"}}' \
+    | "$ROOT/bin/agent-guard" hook-post-tool >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+)
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "hook-post-tool blocks when working tree has a new secret"
+else
+  not_ok "hook-post-tool blocks when working tree has a new secret (expected 2, got $status)"
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+
+# --- hook_stop ------------------------------------------------------------
+
+(
+  cd "$POST_REPO" || exit 2
+  rm -f leaked.txt
+  printf '%s' '{"stop_hook_active":false}' | "$ROOT/bin/agent-guard" hook-stop >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+)
+status=$?
+if [ "$status" -eq 0 ]; then
+  ok "hook-stop allows clean working tree when not active"
+else
+  not_ok "hook-stop allows clean working tree when not active (expected 0, got $status)"
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+
+(
+  cd "$POST_REPO" || exit 2
+  printf '%s\n' "AGENT_GUARD_TEST_SECRET" > stop-leak.txt
+  printf '%s' '{"stop_hook_active":false}' | "$ROOT/bin/agent-guard" hook-stop >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+)
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "hook-stop blocks when working tree has a secret and not active"
+else
+  not_ok "hook-stop blocks when working tree has a secret and not active (expected 2, got $status)"
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+
+# --- gitleaks fail-closed when scanner errors ------------------------------
+
+ERROR_BIN="$TMP_ROOT/error-bin"
+mkdir -p "$ERROR_BIN"
+cat > "$ERROR_BIN/gitleaks" <<'EOSH'
+#!/usr/bin/env sh
+echo "synthetic gitleaks failure" >&2
+exit 3
+EOSH
+chmod +x "$ERROR_BIN/gitleaks"
+
+PATH="$ERROR_BIN:$PATH" "$ROOT/bin/agent-guard" scan-path "$CLEAN_DIR" >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "scan-path fail-closes when gitleaks itself errors"
+else
+  not_ok "scan-path fail-closes when gitleaks itself errors (expected 2, got $status)"
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+
+PATH="$ERROR_BIN:$PATH" sh -c '
+  printf "%s" "{\"tool_name\":\"Write\",\"tool_input\":{\"content\":\"x\"}}" \
+    | "'"$ROOT"'/bin/agent-guard" hook-pre-tool
+' >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "hook-pre-tool fail-closes when gitleaks errors during a Write scan"
+else
+  not_ok "hook-pre-tool fail-closes when gitleaks errors during a Write scan (expected 2, got $status)"
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+
+# --- gitleaks not installed -----------------------------------------------
+
+NO_GITLEAKS_PATH=$(printf '%s' "$PATH" | tr ':' '\n' | grep -v "^$MOCK_BIN$" | grep -v "^$ERROR_BIN$" | tr '\n' ':')
+PATH="$NO_GITLEAKS_PATH" "$ROOT/bin/agent-guard" scan-path "$CLEAN_DIR" >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "scan-path dies when gitleaks is unavailable"
+else
+  not_ok "scan-path dies when gitleaks is unavailable (expected 2, got $status)"
+fi
+
+# --- extract_patch_added_lines via apply_patch dialects -------------------
+
+expect_json_status 0 "*** Delete File: hunk produces no scannable content" \
+  '{"tool_name":"apply_patch","tool_input":{"patch":"*** Begin Patch\n*** Delete File: secrets.json\n*** End Patch"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "*** Update File: hunk added line is scanned" \
+  '{"tool_name":"apply_patch","tool_input":{"patch":"*** Begin Patch\n*** Update File: x\n@@\n context\n+AGENT_GUARD_TEST_SECRET\n*** End Patch"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "*** Update File: context-only hunk is allowed" \
+  '{"tool_name":"apply_patch","tool_input":{"patch":"*** Begin Patch\n*** Update File: x\n@@\n context line\n-removed\n*** End Patch"}}' \
+  hook-pre-tool
+
+# --- MCP edge cases -------------------------------------------------------
+
+expect_json_status 0 "MCP input without secret passes" \
+  '{"tool_name":"mcp__server__tool","tool_input":{"prompt":"hello"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "MCP input with secret in nested object is blocked" \
+  '{"tool_name":"mcp__server__tool","tool_input":{"config":{"auth":{"token":"AGENT_GUARD_TEST_SECRET"}}}}' \
+  hook-pre-tool
+
+# --- scan_staged outside a git work tree ----------------------------------
+
+NON_REPO_DIR="$TMP_ROOT/not-a-repo"
+mkdir -p "$NON_REPO_DIR"
+(
+  cd "$NON_REPO_DIR" || exit 2
+  "$ROOT/bin/agent-guard" scan-staged >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+)
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "scan-staged dies outside a git work tree"
+else
+  not_ok "scan-staged dies outside a git work tree (expected 2, got $status)"
+fi
+
+# --- install.sh git-hooks safety ------------------------------------------
+
+EMPTY_TEMPLATE="$TMP_ROOT/empty-git-template"
+mkdir -p "$EMPTY_TEMPLATE"
+
+INSTALL_REPO="$TMP_ROOT/install-repo"
+mkdir -p "$INSTALL_REPO"
+(
+  cd "$INSTALL_REPO" || exit 2
+  # Use an empty template so the user's global init.templateDir cannot drop
+  # a stray pre-commit hook that the install safety check would refuse.
+  git init -q --template="$EMPTY_TEMPLATE"
+  git config user.email t@e
+  git config user.name t
+  "$ROOT/install.sh" git-hooks >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+)
+status=$?
+if [ "$status" -eq 0 ]; then
+  ok "install.sh git-hooks succeeds in a clean repo"
+else
+  not_ok "install.sh git-hooks succeeds in a clean repo (expected 0, got $status)"
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+configured=$(cd "$INSTALL_REPO" && git config --get core.hooksPath || true)
+if [ "$configured" = "githooks" ]; then
+  ok "install.sh sets core.hooksPath=githooks"
+else
+  not_ok "install.sh sets core.hooksPath=githooks (got: $configured)"
+fi
+
+CONFLICT_REPO="$TMP_ROOT/conflict-repo"
+mkdir -p "$CONFLICT_REPO"
+(
+  cd "$CONFLICT_REPO" || exit 2
+  git init -q --template="$EMPTY_TEMPLATE"
+  git config core.hooksPath someone-elses-hooks
+  "$ROOT/install.sh" git-hooks >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+)
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "install.sh refuses to overwrite an existing core.hooksPath"
+else
+  not_ok "install.sh refuses to overwrite an existing core.hooksPath (expected 2, got $status)"
+fi
+
+PRECOMMIT_REPO="$TMP_ROOT/precommit-repo"
+mkdir -p "$PRECOMMIT_REPO"
+(
+  cd "$PRECOMMIT_REPO" || exit 2
+  git init -q --template="$EMPTY_TEMPLATE"
+  mkdir -p .git/hooks
+  printf '%s\n' '#!/bin/sh' > .git/hooks/pre-commit
+  chmod +x .git/hooks/pre-commit
+  "$ROOT/install.sh" git-hooks >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+)
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "install.sh refuses to overwrite an existing .git/hooks/pre-commit"
+else
+  not_ok "install.sh refuses to overwrite an existing .git/hooks/pre-commit (expected 2, got $status)"
+fi
+
+run_expect 2 "install.sh unknown subcommand exits 2" "$ROOT/install.sh" not-a-command
+run_expect 0 "install.sh check passes" "$ROOT/install.sh" check
+
+# --- githooks/pre-commit invokes scan-staged ------------------------------
+
+HOOK_REPO="$TMP_ROOT/hook-repo"
+mkdir -p "$HOOK_REPO"
+(
+  cd "$HOOK_REPO" || exit 2
+  git init -q
+  git config user.email t@e
+  git config user.name t
+  printf '%s\n' "AGENT_GUARD_TEST_SECRET" > leak.txt
+  git add leak.txt
+  "$ROOT/githooks/pre-commit" >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+)
+status=$?
+if [ "$status" -eq 1 ]; then
+  ok "githooks/pre-commit blocks commits with staged secrets"
+else
+  not_ok "githooks/pre-commit blocks commits with staged secrets (expected 1, got $status)"
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+
 if command -v gitleaks >/dev/null 2>&1 && [ "$(command -v gitleaks)" != "$MOCK_BIN/gitleaks" ]; then
   say "real gitleaks available; mock tests already covered routing"
 else

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -113,6 +113,66 @@ expect_json_status 2 "risky Bash command is blocked" \
   '{"tool_name":"Bash","tool_input":{"command":"cat .env"}}' \
   hook-pre-tool
 
+expect_json_status 2 "Bash sed bypass is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"sed -n p .env"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Bash head bypass is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"head -c 200 .env"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Bash redirect bypass is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"cat < .env"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Bash command-substitution bypass is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"git config user.email \"$(cat .env)\""}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Bash dd-on-private-key bypass is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"dd if=id_rsa of=/tmp/x"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Bash absolute-path .env access is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"awk 1 /tmp/.env"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "myenv-like substring is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"echo myenvironment"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "env VAR=value command form is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"env CGO_ENABLED=0 go build"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "bare env is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"env"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "git --no-verify is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"git commit --no-verify -m x"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Read on tilde-path .env is blocked" \
+  '{"tool_name":"Read","tool_input":{"file_path":"~/.env.local"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Read with leading ./ is blocked" \
+  '{"tool_name":"Read","tool_input":{"file_path":"./.env"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "NotebookRead on sensitive path is blocked" \
+  '{"tool_name":"NotebookRead","tool_input":{"notebook_path":".env"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Codex Add File payload secret is blocked" \
+  '{"tool_name":"apply_patch","tool_input":{"patch":"*** Begin Patch\n*** Add File: x\nAGENT_GUARD_TEST_SECRET\n*** End Patch"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Codex double-plus added secret is blocked" \
+  '{"tool_name":"apply_patch","tool_input":{"patch":"*** Begin Patch\n*** Update File: x\n@@\n++AGENT_GUARD_TEST_SECRET\n*** End Patch"}}' \
+  hook-pre-tool
+
 expect_json_status 2 "MCP input secret is blocked" \
   '{"tool_name":"mcp__server__tool","tool_input":{"token":"AGENT_GUARD_TEST_SECRET"}}' \
   hook-pre-tool
@@ -163,6 +223,80 @@ if [ "$status" -eq 0 ]; then
 else
   not_ok "hook-stop loop protection allows active stop hook (expected 0, got $status)"
 fi
+
+(
+  cd "$TEST_REPO" || exit 2
+  git reset -q
+  rm -f staged.txt untracked.txt
+  printf '%s\n' "AGENT_GUARD_TEST_SECRET" > leak.txt
+  git add leak.txt
+  printf '%s' '{"tool_name":"Bash","tool_input":{"command":"git -c user.name=x commit -m leak"}}' \
+    | "$ROOT/bin/agent-guard" hook-pre-tool >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+)
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "git -c option-form commit with staged secret is intercepted"
+else
+  not_ok "git -c option-form commit with staged secret is intercepted (expected 2, got $status)"
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+
+(
+  cd "$TEST_REPO" || exit 2
+  printf '%s' '{"tool_name":"Bash","tool_input":{"command":"git -C . push origin main"}}' \
+    | "$ROOT/bin/agent-guard" hook-pre-tool >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+)
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "git -C option-form push with staged secret is intercepted"
+else
+  not_ok "git -C option-form push with staged secret is intercepted (expected 2, got $status)"
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+
+SYMLINK_REPO="$TMP_ROOT/symlink-repo"
+mkdir -p "$SYMLINK_REPO"
+(
+  cd "$SYMLINK_REPO" || exit 2
+  printf '%s\n' "AGENT_GUARD_TEST_SECRET" > .env
+  ln -s .env safe-link
+)
+if [ -L "$SYMLINK_REPO/safe-link" ]; then
+  payload='{"tool_name":"Read","tool_input":{"file_path":"'"$SYMLINK_REPO"'/safe-link"}}'
+  printf '%s' "$payload" | "$ROOT/bin/agent-guard" hook-pre-tool >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+  status=$?
+  if [ "$status" -eq 2 ]; then
+    ok "symlink to .env is blocked via realpath resolution"
+  else
+    not_ok "symlink to .env is blocked via realpath resolution (expected 2, got $status)"
+    sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+  fi
+else
+  say "skipping symlink test: filesystem does not support symlinks"
+fi
+
+# action.yml shell-injection regression: emulate the env-passing pattern from
+# action.yml's "Run Agent Guard" step and confirm a malicious paths value
+# cannot trigger an unrelated command. We use a canary file as the side-effect
+# probe so the test does not rely on stdout heuristics.
+INJECTION_CANARY="$TMP_ROOT/inject-canary"
+rm -f "$INJECTION_CANARY"
+AGENT_GUARD_PATHS=". && touch $INJECTION_CANARY" sh -c '
+  set -u
+  # Mirror the action.yml step verbatim minus the agent-guard call: words from
+  # AGENT_GUARD_PATHS become positional arguments after `--`, never command
+  # tokens. If the env-var contract leaked, the canary would appear.
+  set -- -- $AGENT_GUARD_PATHS
+  for arg in "$@"; do
+    : "$arg"
+  done
+' 2>/dev/null
+if [ -e "$INJECTION_CANARY" ]; then
+  not_ok "action.yml env-var paths pattern still allows shell injection (canary fired)"
+else
+  ok "action.yml env-var paths pattern resists shell injection"
+fi
+rm -f "$INJECTION_CANARY"
 
 if command -v gitleaks >/dev/null 2>&1 && [ "$(command -v gitleaks)" != "$MOCK_BIN/gitleaks" ]; then
   say "real gitleaks available; mock tests already covered routing"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -4,6 +4,11 @@ set -u
 ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd -P)
 TMP_ROOT=${TMPDIR:-/tmp}/agent-guard-tests.$$
 MOCK_BIN="$TMP_ROOT/bin"
+ORIGINAL_PATH=$PATH
+REAL_GITLEAKS=$(command -v gitleaks 2>/dev/null || true)
+REAL_SH=$(command -v sh)
+REAL_DIRNAME=$(command -v dirname)
+REAL_PWD=$(command -v pwd)
 PATH="$MOCK_BIN:$PATH"
 export PATH
 export AGENT_GUARD_GITLEAKS_CONFIG="$ROOT/config/gitleaks.toml"
@@ -467,8 +472,12 @@ fi
 
 # --- gitleaks not installed -----------------------------------------------
 
-NO_GITLEAKS_PATH=$(printf '%s' "$PATH" | tr ':' '\n' | grep -v "^$MOCK_BIN$" | grep -v "^$ERROR_BIN$" | tr '\n' ':')
-PATH="$NO_GITLEAKS_PATH" "$ROOT/bin/agent-guard" scan-path "$CLEAN_DIR" >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+NO_GITLEAKS_BIN="$TMP_ROOT/no-gitleaks-bin"
+mkdir -p "$NO_GITLEAKS_BIN"
+ln -s "$REAL_SH" "$NO_GITLEAKS_BIN/sh"
+ln -s "$REAL_DIRNAME" "$NO_GITLEAKS_BIN/dirname"
+ln -s "$REAL_PWD" "$NO_GITLEAKS_BIN/pwd"
+PATH="$NO_GITLEAKS_BIN" "$ROOT/bin/agent-guard" scan-path "$CLEAN_DIR" >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
 status=$?
 if [ "$status" -eq 2 ]; then
   ok "scan-path dies when gitleaks is unavailable"
@@ -601,8 +610,22 @@ else
   sed 's/^/  stderr: /' /tmp/agent-guard-test.err
 fi
 
-if command -v gitleaks >/dev/null 2>&1 && [ "$(command -v gitleaks)" != "$MOCK_BIN/gitleaks" ]; then
-  say "real gitleaks available; mock tests already covered routing"
+if [ -n "$REAL_GITLEAKS" ]; then
+  REAL_DIRTY_DIR="$TMP_ROOT/real-dirty-dir"
+  mkdir -p "$REAL_DIRTY_DIR"
+  {
+    printf '%s\n' '-----BEGIN RSA PRIVATE KEY-----'
+    printf '%s\n' 'MIIEpAIBAAKCAQEAwH6yqpN5f7c7k4KQkKtQ3Rvy9zfrlWvLq8Vbkg=='
+    printf '%s\n' '-----END RSA PRIVATE KEY-----'
+  } > "$REAL_DIRTY_DIR/key.pem"
+  PATH="$(dirname "$REAL_GITLEAKS"):$ORIGINAL_PATH" "$ROOT/bin/agent-guard" scan-path "$REAL_DIRTY_DIR" >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+  status=$?
+  if [ "$status" -eq 1 ]; then
+    ok "real gitleaks detects a private key through scan-path"
+  else
+    not_ok "real gitleaks detects a private key through scan-path (expected 1, got $status)"
+    sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+  fi
 else
   say "real gitleaks not available; skipped real-gitleaks integration tests"
 fi

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -275,17 +275,12 @@ else
   say "skipping symlink test: filesystem does not support symlinks"
 fi
 
-# action.yml shell-injection regression: emulate the env-passing pattern from
-# action.yml's "Run Agent Guard" step and confirm a malicious paths value
-# cannot trigger an unrelated command. We use a canary file as the side-effect
-# probe so the test does not rely on stdout heuristics.
+# action.yml shell-injection regression for AGENT_GUARD_PATHS.
 INJECTION_CANARY="$TMP_ROOT/inject-canary"
 rm -f "$INJECTION_CANARY"
 AGENT_GUARD_PATHS=". && touch $INJECTION_CANARY" sh -c '
   set -u
-  # Mirror the action.yml step verbatim minus the agent-guard call: words from
-  # AGENT_GUARD_PATHS become positional arguments after `--`, never command
-  # tokens. If the env-var contract leaked, the canary would appear.
+  # If path splitting leaked into command execution, the canary would appear.
   set -- -- $AGENT_GUARD_PATHS
   for arg in "$@"; do
     : "$arg"


### PR DESCRIPTION
## Summary

- **Bash bypass generalization**: `check_bash_command` now auto-matches all `deny-read-paths` basenames inside shell commands, blocking `sed/awk/head/dd/xxd/base64 .env`, `cat < .env`, `$(cat .env)` and similar — without needing explicit rules for each tool.
- **git option-form detection**: `git -c x=y commit` and `git -C . push` are now recognized; `--no-verify`/`--no-gpg-sign` are blocked to prevent agents from bypassing the Git hook channel.
- **Codex `apply_patch` fix**: `extract_patch_added_lines` rewritten as a state machine that correctly handles `*** Add File:` envelopes (content without `+` prefix) and `++secret` double-plus lines missed by the old `+[^+]` awk pattern.
- **Path normalization**: `~/`, `./`, and symlinks are now resolved before `deny-read-paths` matching (`~/.env.local`, `./.env`, and `ln -s .env safe-link` all blocked).
- **`NotebookRead` hook coverage**: Added to `PreToolUse` matchers.
- **Expanded deny lists**: Added `.git-credentials`, `.ssh/config`, `.kube/config`, gcloud ADC, `*.pfx`/`*.p12`, service-account JSON to `deny-read-paths`; added `gh auth token`, `aws ssm`, `gcloud secrets`, `op item get`, `vault read` to `deny-bash-patterns`; tightened `env` to bare invocation only.
- **`action.yml` shell injection fix**: `${{ inputs.paths }}` moved to an env var (`$AGENT_GUARD_PATHS`) with `--` arg terminator; `require-checksum: true` default now fail-closes when no archive sha256 is provided.
- **README channel table**: Documents four independent integration channels and what each one can/cannot block, reflecting the correct non-chained architecture.

## Test plan

- [x] `tests/run.sh` passes 80/80, covering the original regression cases plus broader CLI, hook, installer, and fail-closed behavior:
  - `sed`/`head`/redirect/`$(cat)`/`dd` bypass variants
  - `git -c`/`-C` option-form with staged secret
  - `git --no-verify` blocking
  - `~/.env.local` and `./env` path normalization
  - Symlink → `.env` via realpath resolution
  - Codex `*** Add File:` payload and `++secret` double-prefix
  - `NotebookRead` sensitive path blocking
  - `action.yml` env-var injection canary (side-effect probe)
- [x] `env CGO_ENABLED=0 go build` and `myenvironment` echo are confirmed allowed (no false positives)

## Functional verification

All changes verified via `tests/run.sh` (shell-level integration with mock gitleaks). The hook commands (`hook-pre-tool`, `hook-post-tool`, `hook-stop`) were also exercised directly with JSON payloads matching each bypass scenario.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Action: added require-checksum (default true) and env-driven path forwarding to the scanner
  * Channels: new README section describing four integration options with per-channel visibility

* **Bug Fixes & Improvements**
  * Tightened and expanded shell-command secret patterns; stronger git/commit/push and hook-bypass checks
  * Expanded deny-read paths (additional credential files, symlink/path resolution) and NotebookRead support in hooks

* **Documentation**
  * Expanded Actions guidance on checksum pinning and overrideable deny-read policy

* **Tests**
  * Added regression and integration tests for detections and path behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
