### PR TITLE
[codex] Add CI and clean public-readiness scan noise

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run tests
+        run: tests/run.sh

--- a/bin/agent-guard
+++ b/bin/agent-guard
@@ -104,10 +104,17 @@ scan_text_hook() {
   text=$2
   scan_text_direct "$label" "$text"
   status=$?
+  [ "$status" -eq 0 ] && return 0
+  return 2
+}
+
+block_on_scan_status() {
+  status=$1
+  message=$2
   case "$status" in
     0) return 0 ;;
-    1) return 2 ;;
-    *) return 2 ;;
+    1) info "$PROGRAM: $message"; exit 2 ;;
+    *) exit 2 ;;
   esac
 }
 
@@ -386,16 +393,103 @@ bash_matches_deny_path() {
   return 1
 }
 
+is_shell_command_separator() {
+  case "$1" in
+    ';'|'&&'|'||'|'|') return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+git_option_takes_value() {
+  case "$1" in
+    -c|-C|--git-dir|--work-tree|--namespace|--exec-path|--config-env) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+is_git_global_option() {
+  case "$1" in
+    --git-dir=*|--work-tree=*|--namespace=*|--exec-path=*|--config-env=*|-c*|-C*) return 0 ;;
+    --literal-pathspecs|--glob-pathspecs|--noglob-pathspecs|--icase-pathspecs) return 0 ;;
+    --no-pager|--no-replace-objects|-p|-P|--) return 0 ;;
+    -*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 is_git_commit_or_push() {
   cmd=$1
-  # Allow git options before commit/push, e.g. `git -c x=y commit`.
-  printf '%s\n' "$cmd" | grep -Eq '(^|[^[:alnum:]_./-])git([[:space:]]|$)'  || return 1
-  printf '%s\n' "$cmd" | grep -Eq '(^|[^[:alnum:]_-])(commit|push)([^[:alnum:]_-]|$)'
+  (
+    set -f
+    # shellcheck disable=SC2086
+    set -- $cmd
+
+    command_start=1
+    while [ "$#" -gt 0 ]; do
+      token=$1
+      shift
+
+      if [ "$command_start" -eq 1 ] && [ "$token" = "git" ]; then
+        while [ "$#" -gt 0 ]; do
+          token=$1
+          shift
+          if git_option_takes_value "$token"; then
+            [ "$#" -gt 0 ] && shift
+            continue
+          fi
+          is_git_global_option "$token" && continue
+
+          case "$token" in
+            commit|push)
+              return 0
+              ;;
+            *)
+              break
+              ;;
+          esac
+        done
+        command_start=0
+        continue
+      fi
+
+      if is_shell_command_separator "$token"; then
+        command_start=1
+      else
+        command_start=0
+      fi
+    done
+    return 1
+  )
 }
 
 is_git_hook_bypass() {
   cmd=$1
-  printf '%s\n' "$cmd" | grep -Eq '(--no-verify|--no-gpg-sign)([^[:alnum:]_-]|$)'
+  (
+    set -f
+    # shellcheck disable=SC2086
+    set -- $cmd
+
+    while [ "$#" -gt 0 ]; do
+      token=$1
+      shift
+      case "$token" in
+        --no-verify|--no-gpg-sign) return 0 ;;
+      esac
+    done
+    return 1
+  )
+}
+
+check_git_command() {
+  cmd=$1
+  if is_git_commit_or_push "$cmd"; then
+    if is_git_hook_bypass "$cmd"; then
+      info "$PROGRAM: blocked git command that disables hooks/signing"
+      exit 2
+    fi
+    scan_staged
+    block_on_scan_status "$?" "staged changes contain secret-like values; blocking git command"
+  fi
 }
 
 check_bash_command() {
@@ -420,19 +514,7 @@ check_bash_command() {
     exit 2
   fi
 
-  if is_git_commit_or_push "$cmd"; then
-    if is_git_hook_bypass "$cmd"; then
-      info "$PROGRAM: blocked git command that disables hooks/signing"
-      exit 2
-    fi
-    scan_staged
-    status=$?
-    case "$status" in
-      0) return 0 ;;
-      1) info "$PROGRAM: staged changes contain secret-like values; blocking git command"; exit 2 ;;
-      *) exit 2 ;;
-    esac
-  fi
+  check_git_command "$cmd"
 }
 
 scan_mcp_input() {
@@ -511,12 +593,7 @@ hook_post_tool() {
   is_mutation_tool "$tool" || return 0
 
   scan_working_tree
-  status=$?
-  case "$status" in
-    0) return 0 ;;
-    1) info "$PROGRAM: changed files contain secret-like values after tool execution"; exit 2 ;;
-    *) exit 2 ;;
-  esac
+  block_on_scan_status "$?" "changed files contain secret-like values after tool execution"
 }
 
 hook_stop() {
@@ -531,12 +608,7 @@ hook_stop() {
   fi
 
   scan_working_tree
-  status=$?
-  case "$status" in
-    0) return 0 ;;
-    1) info "$PROGRAM: changed files contain secret-like values before stop"; exit 2 ;;
-    *) exit 2 ;;
-  esac
+  block_on_scan_status "$?" "changed files contain secret-like values before stop"
 }
 
 cmd=${1:-}

--- a/bin/agent-guard
+++ b/bin/agent-guard
@@ -400,6 +400,34 @@ is_shell_command_separator() {
   esac
 }
 
+shell_command_words() {
+  printf '%s\n' "$1" | awk '
+    {
+      out = ""
+      for (i = 1; i <= length($0); i++) {
+        c = substr($0, i, 1)
+        n = substr($0, i + 1, 1)
+        if (c == "&" && n == "&") {
+          out = out " && "
+          i++
+          continue
+        }
+        if (c == "|" && n == "|") {
+          out = out " || "
+          i++
+          continue
+        }
+        if (c == ";" || c == "|") {
+          out = out " " c " "
+          continue
+        }
+        out = out c
+      }
+      print out
+    }
+  '
+}
+
 git_option_takes_value() {
   case "$1" in
     -c|-C|--git-dir|--work-tree|--namespace|--exec-path|--config-env) return 0 ;;
@@ -421,8 +449,9 @@ is_git_commit_or_push() {
   cmd=$1
   (
     set -f
+    words=$(shell_command_words "$cmd")
     # shellcheck disable=SC2086
-    set -- $cmd
+    set -- $words
 
     command_start=1
     while [ "$#" -gt 0 ]; do
@@ -466,8 +495,9 @@ is_git_hook_bypass() {
   cmd=$1
   (
     set -f
+    words=$(shell_command_words "$cmd")
     # shellcheck disable=SC2086
-    set -- $cmd
+    set -- $words
 
     while [ "$#" -gt 0 ]; do
       token=$1

--- a/examples/codex/hooks.json
+++ b/examples/codex/hooks.json
@@ -2,7 +2,7 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Bash|apply_patch|Edit|Write|mcp__.*",
+        "matcher": "Write|Edit|MultiEdit|Read|NotebookRead|Grep|Glob|Bash|apply_patch|mcp__.*",
         "hooks": [
           {
             "type": "command",
@@ -14,7 +14,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Bash|apply_patch|Edit|Write|mcp__.*",
+        "matcher": "Write|Edit|MultiEdit|Bash|apply_patch|mcp__.*",
         "hooks": [
           {
             "type": "command",

--- a/tests/fixtures/mock-gitleaks
+++ b/tests/fixtures/mock-gitleaks
@@ -6,7 +6,7 @@ case "$mode" in
   stdin)
     input=$(cat)
     case "$input" in
-      *AGENT_GUARD_TEST_SECRET*|*AKIAIOSFODNN7EXAMPLE*)
+      *AGENT_GUARD_TEST_SECRET*)
         printf '%s\n' "Finding: REDACTED"
         exit 1
         ;;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -94,6 +94,20 @@ for file in \
   run_expect 0 "json syntax: $file" jq -e . "$file"
 done
 
+for event in PreToolUse PostToolUse; do
+  canonical=$(jq -r ".hooks.${event}[0].matcher" "$ROOT/hooks/hooks.json")
+  for file in \
+    "$ROOT/examples/claude/settings.project.json" \
+    "$ROOT/examples/codex/hooks.json"; do
+    actual=$(jq -r ".hooks.${event}[0].matcher" "$file")
+    if [ "$actual" = "$canonical" ]; then
+      ok "$event matcher in $file matches hooks/hooks.json"
+    else
+      not_ok "$event matcher in $file matches hooks/hooks.json (got: $actual)"
+    fi
+  done
+done
+
 expect_json_status 2 "Claude Write secret is blocked" \
   '{"tool_name":"Write","tool_input":{"file_path":"app.txt","content":"AGENT_GUARD_TEST_SECRET"}}' \
   hook-pre-tool
@@ -156,6 +170,10 @@ expect_json_status 2 "bare env is blocked" \
 
 expect_json_status 2 "git --no-verify is blocked" \
   '{"tool_name":"Bash","tool_input":{"command":"git commit --no-verify -m x"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "git word plus commit text is not treated as git commit" \
+  '{"tool_name":"Bash","tool_input":{"command":"git status && echo commit"}}' \
   hook-pre-tool
 
 expect_json_status 2 "Read on tilde-path .env is blocked" \
@@ -256,6 +274,19 @@ if [ "$status" -eq 2 ]; then
   ok "git -C option-form push with staged secret is intercepted"
 else
   not_ok "git -C option-form push with staged secret is intercepted (expected 2, got $status)"
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+
+(
+  cd "$TEST_REPO" || exit 2
+  printf '%s' '{"tool_name":"Bash","tool_input":{"command":"git status && git -C . push origin main"}}' \
+    | "$ROOT/bin/agent-guard" hook-pre-tool >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+)
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "chained git push after non-mutating git command is intercepted"
+else
+  not_ok "chained git push after non-mutating git command is intercepted (expected 2, got $status)"
   sed 's/^/  stderr: /' /tmp/agent-guard-test.err
 fi
 
@@ -614,9 +645,9 @@ if [ -n "$REAL_GITLEAKS" ]; then
   REAL_DIRTY_DIR="$TMP_ROOT/real-dirty-dir"
   mkdir -p "$REAL_DIRTY_DIR"
   {
-    printf '%s\n' '-----BEGIN RSA PRIVATE KEY-----'
+    printf '%s%s\n' '-----BEGIN RSA ' 'PRIVATE KEY-----'
     printf '%s\n' 'MIIEpAIBAAKCAQEAwH6yqpN5f7c7k4KQkKtQ3Rvy9zfrlWvLq8Vbkg=='
-    printf '%s\n' '-----END RSA PRIVATE KEY-----'
+    printf '%s%s\n' '-----END RSA ' 'PRIVATE KEY-----'
   } > "$REAL_DIRTY_DIR/key.pem"
   PATH="$(dirname "$REAL_GITLEAKS"):$ORIGINAL_PATH" "$ROOT/bin/agent-guard" scan-path "$REAL_DIRTY_DIR" >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
   status=$?

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -290,6 +290,23 @@ else
   sed 's/^/  stderr: /' /tmp/agent-guard-test.err
 fi
 
+(
+  cd "$TEST_REPO" || exit 2
+  printf '%s' '{"tool_name":"Bash","tool_input":{"command":"git status&&git -C . push origin main"}}' \
+    | "$ROOT/bin/agent-guard" hook-pre-tool >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+)
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "chained git push without separator spaces is intercepted"
+else
+  not_ok "chained git push without separator spaces is intercepted (expected 2, got $status)"
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+
+expect_json_status 2 "git hook bypass without separator spaces is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"git commit --no-verify&&echo done"}}' \
+  hook-pre-tool
+
 SYMLINK_REPO="$TMP_ROOT/symlink-repo"
 mkdir -p "$SYMLINK_REPO"
 (


### PR DESCRIPTION
## Summary

- Add a GitHub Actions CI workflow that runs `tests/run.sh` on pull requests and pushes to `main`.
- Keep Codex example hook matchers aligned with the canonical hook config.
- Reduce public-readiness secret-scan noise by removing an AWS example pattern from the mock scanner and constructing the real-gitleaks private-key fixture at runtime.
- Tighten git command parsing so chained `git push`/`git commit` commands are intercepted without treating unrelated words as git subcommands.

## Validation

- `tests/run.sh` passed: 87 passed, 0 failed.
- `bin/agent-guard scan-path .` passed on the current tree.
- `bin/agent-guard scan-staged` passed before commit.
- JSON config validation passed through the test suite.

## Public-readiness note

The current tree scans clean, but full git history scanning still reports the existing `main` commit `631740d` because it contains the previous test private-key literal. This PR fixes the file going forward; removing the historical finding before making the repository public would require a separate history rewrite of `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * More reliable interception of git commit/push in complex shell commands
  * Broadened tool types that trigger pre- and post-tool hooks
  * Stricter secret-scan result handling to enforce failures when leaks are detected

* **Tests**
  * Added validation ensuring hook matcher consistency across configs
  * Expanded git interception tests to cover chained commands and updated secret-fixture output

* **Chores**
  * Updated CI pipeline configuration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->