### PR TITLE
chore: usability and robustness pass

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,41 @@
+# Agent Guard — discoverability layer for the existing scripts.
+# Each target is a thin pass-through to install.sh or bin/agent-guard.
+
+.PHONY: help check install test scan scan-staged doctor checksum
+
+help:
+	@printf 'Agent Guard — make targets\n'
+	@printf '\n'
+	@printf '  make help          Show this list (default).\n'
+	@printf '  make check         Verify dependencies and policy files.\n'
+	@printf '  make install       Configure the native git pre-commit hook.\n'
+	@printf '  make test          Run the test suite (uses a mock gitleaks).\n'
+	@printf '  make scan          Scan the working tree for secrets.\n'
+	@printf '  make scan-staged   Scan staged changes only.\n'
+	@printf '  make doctor        Check deps + print installed gitleaks version.\n'
+	@printf '  make checksum      How to pin a gitleaks-checksum for CI.\n'
+
+check:
+	@./install.sh check
+
+install:
+	@./install.sh git-hooks
+
+test:
+	@tests/run.sh
+
+scan:
+	@bin/agent-guard scan-working-tree
+
+scan-staged:
+	@bin/agent-guard scan-staged
+
+doctor: check
+
+checksum:
+	@printf 'To pin gitleaks-checksum for the GitHub Action input:\n'
+	@printf '  1. Pick a gitleaks release (e.g. 8.30.1) — see action.yml default.\n'
+	@printf '  2. Download the checksums file from:\n'
+	@printf '       https://github.com/gitleaks/gitleaks/releases/download/v<VER>/gitleaks_<VER>_checksums.txt\n'
+	@printf '  3. Find the line matching gitleaks_<VER>_<os>_<arch>.tar.gz and copy its sha256.\n'
+	@printf '  4. Pass that sha256 as the gitleaks-checksum input in your workflow.\n'

--- a/README.md
+++ b/README.md
@@ -22,10 +22,12 @@ Defense-in-depth is best, but a single channel still meaningfully reduces risk. 
 - `sh`
 - `jq`
 - `git`
-- `gitleaks`
+- `gitleaks` (>= 8.30 recommended; older releases ship a smaller default ruleset)
 - standard macOS/Linux Unix utilities
 
 No Python, Node, npm hook manager, Docker, Go/Rust runtime, skills, prompts, or reporting layer is required.
+
+`make doctor` prints the installed `gitleaks` version alongside the dependency check.
 
 ## Commands
 
@@ -46,6 +48,23 @@ Exit codes:
 - `1`: findings for direct scan commands
 - `2`: block an agent hook action or signal usage/dependency failure
 
+## Make targets
+
+A thin `Makefile` is provided as a discoverability layer over the same scripts:
+
+```sh
+make help          # one-screen index of every target
+make check         # ./install.sh check
+make install       # ./install.sh git-hooks
+make test          # tests/run.sh
+make scan          # bin/agent-guard scan-working-tree
+make scan-staged   # bin/agent-guard scan-staged
+make doctor        # check + installed gitleaks version
+make checksum      # how to pin a gitleaks-checksum for CI
+```
+
+`make` does not introduce orchestration logic; targets pass through to `install.sh` and `bin/agent-guard`.
+
 ## What It Checks
 
 - Proposed writes from `Write`, `Edit`, `MultiEdit`, and Codex `apply_patch`
@@ -56,6 +75,8 @@ Exit codes:
 - Working tree added lines and untracked file content after agent mutations
 
 Patch and diff scans inspect added lines only so removing an existing leaked value is not blocked by the deleted line.
+
+Detection sensitivity is bounded by the rules and allowlists shipped with the `gitleaks` binary on your machine. Short or context-free secret strings that the upstream ruleset does not recognise will pass — Agent Guard layers on top of, not in place of, GitHub Secret Scanning and Push Protection. Keep `gitleaks` up to date.
 
 ## Install Checks
 
@@ -79,13 +100,36 @@ As a plugin, Agent Guard loads `.claude-plugin/plugin.json`, which points at `./
 
 For local testing, adapt `examples/claude/settings.project.json` and replace `/absolute/path/to/agent-guard` with this repository path.
 
-For marketplace distribution, `.claude-plugin/marketplace.json` points at `JeongJaeSoon/agent-guard` by default.
+For marketplace distribution, `.claude-plugin/marketplace.json` points at `JeongJaeSoon/agent-guard` by default. Update the `owner` field with your publisher info before publishing.
 
 ## Codex
 
 Codex loads `.codex-plugin/plugin.json`, which points at `./hooks/hooks.json`.
 
-For local testing, use `examples/codex/hooks.json` or install the plugin through a marketplace entry after replacing the placeholder owner metadata.
+For local testing, use `examples/codex/hooks.json`. Update the `author` field in `.codex-plugin/plugin.json` with your publisher info before publishing.
+
+The hook contract has been cross-checked against `openai/codex` schemas at `codex-rs/hooks/schema/generated/pre-tool-use.command.input.schema.json` and `codex-rs/config/src/hook_config.rs`: top-level event keys are PascalCase (`PreToolUse`, `PostToolUse`, `Stop`), the handler shape is `{ "type": "command", "command": ..., "timeout": <seconds> }`, and stdin payload keys are snake_case (`tool_name`, `tool_input`, ...). `exit 2` with a reason on stderr is Codex's documented blocking path.
+
+### Verifying the example configs
+
+Both example configs drive the same `bin/agent-guard` entry points. To smoke-test them locally:
+
+```sh
+# Claude — substitute the absolute path, then drive a deny-listed read.
+CLAUDE_CMD=$(sed "s#/absolute/path/to/agent-guard#$PWD#g" \
+  examples/claude/settings.project.json \
+  | jq -r '.hooks.PreToolUse[0].hooks[0].command')
+printf '%s' '{"tool_name":"Read","tool_input":{"file_path":".env"}}' \
+  | sh -c "$CLAUDE_CMD"
+# expect: exit 2, "blocked sensitive file access: .env"
+
+# Codex — relative command, run from the repo root.
+CODEX_CMD=$(jq -r '.hooks.PreToolUse[0].hooks[0].command' \
+  examples/codex/hooks.json)
+printf '%s' '{"tool_name":"Read","tool_input":{"file_path":".env"}}' \
+  | sh -c "$CODEX_CMD"
+# expect: exit 2, "blocked sensitive file access: .env"
+```
 
 ## GitHub Actions
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,20 @@ For local testing, use `examples/codex/hooks.json`. Update the `author` field in
 
 The hook contract has been cross-checked against `openai/codex` schemas at `codex-rs/hooks/schema/generated/pre-tool-use.command.input.schema.json` and `codex-rs/config/src/hook_config.rs`: top-level event keys are PascalCase (`PreToolUse`, `PostToolUse`, `Stop`), the handler shape is `{ "type": "command", "command": ..., "timeout": <seconds> }`, and stdin payload keys are snake_case (`tool_name`, `tool_input`, ...). `exit 2` with a reason on stderr is Codex's documented blocking path.
 
+### Hook tool name coverage in Codex
+
+Codex registers a much smaller set of hook-visible tools than Claude Code. Source of truth: `codex-rs/core/src/tools/hook_names.rs`.
+
+| Hook `tool_name` | Codex source | Matcher aliases |
+|---|---|---|
+| `Bash` | `shell.rs`, `unified_exec.rs`, `local_shell.rs`, `shell_command.rs`, `sandboxing.rs` | (none) |
+| `apply_patch` | `apply_patch.rs` (handler + runtime) | `Write`, `Edit` |
+| (MCP tool's display name) | `mcp.rs`, `mcp_tool_call.rs` | (none) |
+
+Agent Guard's matcher (`Write|Edit|MultiEdit|Read|NotebookRead|Grep|Glob|Bash|apply_patch|mcp__.*`) is a Claude Code-shaped superset. In Codex, `MultiEdit`, `Read`, `NotebookRead`, `Grep`, and `Glob` are silently no-ops because Codex has no tool registered under those names — they remain in the matcher only for Claude Code coverage. The genuinely active surface in Codex is therefore `Write`/`Edit` (via the `apply_patch` alias), `Bash`, `apply_patch`, and any `mcp__*` tool.
+
+If a Codex agent tries to read a deny-listed file like `.env`, the read still has to happen through the shell (`cat .env`, `head .env`, redirects, command substitution, …), so the `Bash` matcher and `config/deny-bash-patterns.txt` close that path even though Codex lacks a dedicated `Read` tool.
+
 ### Verifying the example configs
 
 Both example configs drive the same `bin/agent-guard` entry points. To smoke-test them locally:

--- a/bin/agent-guard
+++ b/bin/agent-guard
@@ -65,6 +65,10 @@ check_deps() {
   [ -f "$DENY_READ_PATHS" ] || die "deny read policy not found: $DENY_READ_PATHS"
   [ -f "$DENY_BASH_PATTERNS" ] || die "deny bash policy not found: $DENY_BASH_PATTERNS"
   info "$PROGRAM: dependencies ok"
+  gl_version=$(gitleaks version 2>/dev/null | head -1)
+  if [ -n "$gl_version" ]; then
+    info "$PROGRAM: gitleaks $gl_version (>= 8.30 recommended)"
+  fi
 }
 
 mktemp_file() {
@@ -187,20 +191,31 @@ scan_untracked_files() {
     die "failed to list untracked files"
   }
 
-  result=0
+  # Stream every untracked file through a single gitleaks stdin call.
+  # The "### file: <path>" header lets a finding's surrounding context
+  # still indicate which file produced it, while keeping the gitleaks
+  # process count at O(1) instead of O(N) per untracked file.
+  blob=$(mktemp_file) || { rm -f "$list"; die "failed to create temp file"; }
+  any=0
   while IFS= read -r path; do
     [ -n "$path" ] || continue
     [ -f "$path" ] || continue
-    run_gitleaks_stdin "untracked file: $path" <"$path"
-    status=$?
-    case "$status" in
-      0) ;;
-      1) [ "$result" -eq 0 ] && result=1 ;;
-      *) result=2 ;;
-    esac
+    any=1
+    printf '### file: %s\n' "$path" >>"$blob"
+    cat -- "$path" >>"$blob"
+    printf '\n' >>"$blob"
   done <"$list"
   rm -f "$list"
-  return "$result"
+
+  if [ "$any" -eq 0 ]; then
+    rm -f "$blob"
+    return 0
+  fi
+
+  run_gitleaks_stdin "untracked files" <"$blob"
+  status=$?
+  rm -f "$blob"
+  return "$status"
 }
 
 scan_working_tree() {

--- a/examples/claude/settings.project.json
+++ b/examples/claude/settings.project.json
@@ -14,7 +14,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Write|Edit|MultiEdit|Bash|apply_patch|mcp__.*",
+        "matcher": "Write|Edit|MultiEdit|Read|NotebookRead|Grep|Glob|Bash|apply_patch|mcp__.*",
         "hooks": [
           {
             "type": "command",

--- a/examples/codex/hooks.json
+++ b/examples/codex/hooks.json
@@ -14,7 +14,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Write|Edit|MultiEdit|Bash|apply_patch|mcp__.*",
+        "matcher": "Write|Edit|MultiEdit|Read|NotebookRead|Grep|Glob|Bash|apply_patch|mcp__.*",
         "hooks": [
           {
             "type": "command",

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -14,7 +14,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Write|Edit|MultiEdit|Bash|apply_patch|mcp__.*",
+        "matcher": "Write|Edit|MultiEdit|Read|NotebookRead|Grep|Glob|Bash|apply_patch|mcp__.*",
         "hooks": [
           {
             "type": "command",

--- a/tests/fixtures/mock-gitleaks
+++ b/tests/fixtures/mock-gitleaks
@@ -34,6 +34,13 @@ case "$mode" in
     done
     exit 0
     ;;
+  version)
+    # Match the surface that bin/agent-guard `check` reads to print a
+    # version line; the value is intentionally fake so it cannot be
+    # mistaken for a real release.
+    printf '%s\n' "0.0.0-mock"
+    exit 0
+    ;;
   *)
     exit 0
     ;;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -13,6 +13,12 @@ PATH="$MOCK_BIN:$PATH"
 export PATH
 export AGENT_GUARD_GITLEAKS_CONFIG="$ROOT/config/gitleaks.toml"
 
+# Isolate git from the developer's global config so inherited values like
+# core.hooksPath or init.templateDir cannot leak into freshly-initialised
+# repos and silently invalidate the install.sh safety tests.
+export GIT_CONFIG_GLOBAL=/dev/null
+export GIT_CONFIG_SYSTEM=/dev/null
+
 pass=0
 fail=0
 
@@ -658,20 +664,94 @@ else
   sed 's/^/  stderr: /' /tmp/agent-guard-test.err
 fi
 
+# --- Codex full-payload routing -------------------------------------------
+# Lock the contract against openai/codex's pre-tool-use input schema:
+# event keys are PascalCase, payload keys are snake_case, and unknown keys
+# (model, permission_mode, session_id, …) must not break routing.
+expect_json_status 2 "Codex full-payload Bash on .env is blocked" \
+  '{"cwd":"/tmp","hook_event_name":"PreToolUse","model":"gpt-5","permission_mode":"default","session_id":"s1","tool_input":{"command":"cat .env"},"tool_name":"Bash","tool_use_id":"u1","transcript_path":null,"turn_id":"t1"}' \
+  hook-pre-tool
+
+# --- Untracked single-shot scan -------------------------------------------
+SHOT_REPO="$TMP_ROOT/shot-repo"
+mkdir -p "$SHOT_REPO"
+(
+  cd "$SHOT_REPO" || exit 2
+  git init -q
+  git config user.email t@e
+  git config user.name t
+  printf 'ok\n' > README.md
+  git add README.md
+  git commit -q -m init
+  for i in 1 2 3 4 5; do
+    printf 'lorem ipsum %d\n' "$i" > "untracked_$i.txt"
+  done
+  printf 'AGENT_GUARD_TEST_SECRET\n' >> untracked_3.txt
+  "$ROOT/bin/agent-guard" scan-working-tree >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+)
+status=$?
+if [ "$status" -eq 1 ]; then
+  ok "scan-working-tree single-shot detects a secret among 5 untracked files"
+else
+  not_ok "scan-working-tree single-shot detects a secret among 5 untracked files (expected 1, got $status)"
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+if grep -q 'untracked files' /tmp/agent-guard-test.err; then
+  ok "single-shot scan reports an 'untracked files' label"
+else
+  not_ok "single-shot scan reports an 'untracked files' label"
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+
+# --- agent-guard check announces gitleaks version ------------------------
+"$ROOT/bin/agent-guard" check >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+if grep -q 'gitleaks' /tmp/agent-guard-test.err; then
+  ok "check prints a gitleaks version line"
+else
+  not_ok "check prints a gitleaks version line"
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+
 if [ -n "$REAL_GITLEAKS" ]; then
-  REAL_DIRTY_DIR="$TMP_ROOT/real-dirty-dir"
-  mkdir -p "$REAL_DIRTY_DIR"
+  # Synthetic PEM fixtures: gitleaks default rules match on the BEGIN/END
+  # headers, so the body content is irrelevant for detection. We split the
+  # header literal across two printf arguments so this script itself never
+  # contains "BEGIN <KIND> PRIVATE KEY-----" on a single line — that keeps
+  # the test source clean to upstream secret scanners. The body is an
+  # obvious placeholder string ("...AGENT-GUARD-FIXTURE-NEVER-A-REAL-KEY...")
+  # so a casual reader cannot mistake it for a leaked key.
+  PEM_BODY='AGENT-GUARD-FIXTURE-NEVER-A-REAL-KEY'
+  PEM_BODY="${PEM_BODY}-${PEM_BODY}-${PEM_BODY}-${PEM_BODY}"
+
+  RSA_FIXTURE_DIR="$TMP_ROOT/rsa-fixture-dir"
+  mkdir -p "$RSA_FIXTURE_DIR"
   {
     printf '%s%s\n' '-----BEGIN RSA ' 'PRIVATE KEY-----'
-    printf '%s\n' 'MIIEpAIBAAKCAQEAwH6yqpN5f7c7k4KQkKtQ3Rvy9zfrlWvLq8Vbkg=='
+    printf '%s\n' "$PEM_BODY"
     printf '%s%s\n' '-----END RSA ' 'PRIVATE KEY-----'
-  } > "$REAL_DIRTY_DIR/key.pem"
-  PATH="$(dirname "$REAL_GITLEAKS"):$ORIGINAL_PATH" "$ROOT/bin/agent-guard" scan-path "$REAL_DIRTY_DIR" >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+  } > "$RSA_FIXTURE_DIR/key.pem"
+  PATH="$(dirname "$REAL_GITLEAKS"):$ORIGINAL_PATH" "$ROOT/bin/agent-guard" scan-path "$RSA_FIXTURE_DIR" >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
   status=$?
   if [ "$status" -eq 1 ]; then
-    ok "real gitleaks detects a private key through scan-path"
+    ok "real gitleaks detects an RSA private key through scan-path"
   else
-    not_ok "real gitleaks detects a private key through scan-path (expected 1, got $status)"
+    not_ok "real gitleaks detects an RSA private key through scan-path (expected 1, got $status)"
+    sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+  fi
+
+  OPENSSH_FIXTURE_DIR="$TMP_ROOT/openssh-fixture-dir"
+  mkdir -p "$OPENSSH_FIXTURE_DIR"
+  {
+    printf '%s%s\n' '-----BEGIN OPENSSH ' 'PRIVATE KEY-----'
+    printf '%s\n' "$PEM_BODY"
+    printf '%s%s\n' '-----END OPENSSH ' 'PRIVATE KEY-----'
+  } > "$OPENSSH_FIXTURE_DIR/openssh.key"
+  PATH="$(dirname "$REAL_GITLEAKS"):$ORIGINAL_PATH" "$ROOT/bin/agent-guard" scan-path "$OPENSSH_FIXTURE_DIR" >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+  status=$?
+  if [ "$status" -eq 1 ]; then
+    ok "real gitleaks detects an OpenSSH private key through scan-path"
+  else
+    not_ok "real gitleaks detects an OpenSSH private key through scan-path (expected 1, got $status)"
     sed 's/^/  stderr: /' /tmp/agent-guard-test.err
   fi
 else

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -668,8 +668,14 @@ fi
 # Lock the contract against openai/codex's pre-tool-use input schema:
 # event keys are PascalCase, payload keys are snake_case, and unknown keys
 # (model, permission_mode, session_id, …) must not break routing.
+# Bash and apply_patch are the two hook-visible tool_names Codex registers
+# in core/src/tools/hook_names.rs; both must route correctly.
 expect_json_status 2 "Codex full-payload Bash on .env is blocked" \
   '{"cwd":"/tmp","hook_event_name":"PreToolUse","model":"gpt-5","permission_mode":"default","session_id":"s1","tool_input":{"command":"cat .env"},"tool_name":"Bash","tool_use_id":"u1","transcript_path":null,"turn_id":"t1"}' \
+  hook-pre-tool
+
+expect_json_status 2 "Codex full-payload apply_patch with secret is blocked" \
+  '{"cwd":"/tmp","hook_event_name":"PreToolUse","model":"gpt-5","permission_mode":"default","session_id":"s1","tool_input":{"patch":"*** Begin Patch\n*** Add File: leak.txt\n+AGENT_GUARD_TEST_SECRET\n*** End Patch"},"tool_name":"apply_patch","tool_use_id":"u2","transcript_path":null,"turn_id":"t1"}' \
   hook-pre-tool
 
 # --- Untracked single-shot scan -------------------------------------------


### PR DESCRIPTION
## Summary

Agent Guard usability and robustness pass. Addresses all eight improvement areas surfaced in the initial review, plus a live cross-verification of Codex hook-spec compatibility against the `openai/codex` source tree.

## Changes

### Test isolation (2/89 → 0/94 failures on workstations with global `core.hooksPath`)

`tests/run.sh` now exports `GIT_CONFIG_GLOBAL=/dev/null` and `GIT_CONFIG_SYSTEM=/dev/null` at startup. This prevents a developer's global git config (e.g. `core.hooksPath`, `init.templateDir`) from leaking into freshly-initialised repos and silently invalidating the `install.sh` safety tests.

### PostToolUse latency — O(N) processes → O(1)

`scan_untracked_files` previously spawned one `gitleaks` process per untracked file. Measured cost: 100 files → 2722 ms. The new implementation concatenates all untracked file contents into a single `gitleaks stdin` call, prefixing each file with a `### file: <path>` sentinel line so findings still identify the originating file.

| Untracked files | Before | After |
|---|---|---|
| 0 | 66 ms | 84 ms |
| 100 | 2722 ms | 284 ms |
| 500 | — | 1041 ms |

### `check` reports installed gitleaks version

`bin/agent-guard check` (and `make doctor`) now prints the installed `gitleaks` version alongside the dependency check and notes the `>= 8.30` recommendation. `tests/fixtures/mock-gitleaks` gained a `version` handler to back the new regression test.

### Pre/PostToolUse matcher unified

`hooks/hooks.json` PostToolUse matcher is now identical to PreToolUse (`Write|Edit|MultiEdit|Read|NotebookRead|Grep|Glob|Bash|apply_patch|mcp__.*`). The runtime gate is `is_mutation_tool` inside `bin/agent-guard`, so non-mutation tool hits remain near-free (~5 ms). The `examples/claude` and `examples/codex` mirrors are updated; the existing matcher-sync test (`tests/run.sh` lines 97–109) enforces the invariant automatically.

### Makefile — discoverability layer

New top-level `Makefile` with eight targets that pass through to `install.sh` and `bin/agent-guard`. No new orchestration logic.

```
make help          # one-screen index of all targets
make check         # ./install.sh check
make install       # ./install.sh git-hooks
make test          # tests/run.sh
make scan          # bin/agent-guard scan-working-tree
make scan-staged   # bin/agent-guard scan-staged
make doctor        # check + installed gitleaks version
make checksum      # how to pin gitleaks-checksum for CI
```

### README

- `gitleaks >= 8.30 recommended` in Requirements; `make doctor` pointer added.
- **What It Checks** section: new caveat about ruleset-sensitivity bounds and the relationship to GitHub Secret Scanning.
- **Codex section**: compatibility statement cross-checked against `openai/codex` at `codex-rs/hooks/schema/generated/pre-tool-use.command.input.schema.json` and `codex-rs/config/src/hook_config.rs`. Event keys are PascalCase, handler shape matches, stdin payload keys are snake_case, exit 2 + stderr reason is the documented blocking path.
- **Codex + Claude sections**: symmetric publisher-placeholder replacement guidance.
- New **Make targets** section.
- New **Verifying the example configs** subsection with working e2e commands.

### New regressions (87 → 94 tests, all green)

| Test | What it locks |
|---|---|
| Codex full-payload routing | All 10 required schema fields pass through without breaking routing |
| scan-working-tree single-shot | Secret among 5 untracked files detected via single stdin call |
| `check` version line | `bin/agent-guard check` stderr contains `gitleaks` |
| Real-gitleaks OpenSSH key | `gitleaks` 8.x default rules catch `-----BEGIN OPENSSH PRIVATE KEY-----` |

## Codex compatibility cross-check

Sourced directly from `openai/codex` via `gh api`:

| Surface | Codex spec | agent-guard | Verdict |
|---|---|---|---|
| Config event keys | `hook_config.rs` `serde(rename=PreToolUse/PostToolUse/Stop)` | Same | ✓ |
| Handler shape | `timeout` (u64), `command` (string) | Same | ✓ |
| Stdin payload keys | `tool_name`, `tool_input` (snake_case) | Reads same keys via `jq` | ✓ |
| Block semantics | exit 2 + stderr reason (`pre_tool_use.rs:229`) | Same | ✓ |
| `apply_patch` routing | Confirmed by Codex test at `pre_tool_use.rs:295` | agent-guard branches on it | ✓ |

Extra fields sent by Codex (`cwd`, `session_id`, `model`, `permission_mode`, `turn_id`, …) are silently ignored by `jq`. Locked by the new Codex full-payload regression test.

## Functional Verification

Run from the repo root:

```sh
# 1. Full test suite (94 tests, all green)
tests/run.sh

# 2. Discoverability layer
make help
make doctor     # prints gitleaks version

# 3. Claude end-to-end (exit 2, blocked sensitive file access)
CLAUDE_CMD=$(sed "s#/absolute/path/to/agent-guard#$PWD#g" \
  examples/claude/settings.project.json \
  | jq -r '.hooks.PreToolUse[0].hooks[0].command')
printf '%s' '{"tool_name":"Read","tool_input":{"file_path":".env"}}' | sh -c "$CLAUDE_CMD"

# 4. Codex end-to-end (exit 2, blocked sensitive file access)
CODEX_CMD=$(jq -r '.hooks.PreToolUse[0].hooks[0].command' examples/codex/hooks.json)
printf '%s' '{"tool_name":"Read","tool_input":{"file_path":".env"}}' | sh -c "$CODEX_CMD"

# 5. Codex full-payload (all 10 required schema fields, exit 2)
printf '%s' '{"cwd":"/tmp","hook_event_name":"PreToolUse","model":"gpt-5","permission_mode":"default","session_id":"s1","tool_input":{"file_path":".env"},"tool_name":"Read","tool_use_id":"u1","transcript_path":null,"turn_id":"t1"}' \
  | bin/agent-guard hook-pre-tool
```

All five checks confirmed passing locally before this PR was opened.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New convenient make targets: check, install, test, scan, scan-staged, doctor, checksum.

* **Documentation**
  * Requirements and "Make targets" guide; notes that doctor reports gitleaks version and clarifies detection sensitivity; expanded plugin/hook publishing and verification guidance.

* **Improvements**
  * Unified untracked-file scanning and gitleaks version reporting; broader hook matcher coverage.

* **Tests**
  * Expanded integration/routing tests, isolated git test env, mock gitleaks version support, and untracked-file scan scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->