### PR TITLE
simplify: remove scan_text_hook, fix sub-shell exit, drop make doctor, optimize deny-pattern checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,17 @@
 # Agent Guard — discoverability layer for the existing scripts.
 # Each target is a thin pass-through to install.sh or bin/agent-guard.
 
-.PHONY: help check install test scan scan-staged doctor checksum
+.PHONY: help check install test scan scan-staged checksum
 
 help:
 	@printf 'Agent Guard — make targets\n'
 	@printf '\n'
 	@printf '  make help          Show this list (default).\n'
-	@printf '  make check         Verify dependencies and policy files.\n'
+	@printf '  make check         Verify deps and print installed gitleaks version.\n'
 	@printf '  make install       Configure the native git pre-commit hook.\n'
 	@printf '  make test          Run the test suite (uses a mock gitleaks).\n'
 	@printf '  make scan          Scan the working tree for secrets.\n'
 	@printf '  make scan-staged   Scan staged changes only.\n'
-	@printf '  make doctor        Check deps + print installed gitleaks version.\n'
 	@printf '  make checksum      How to pin a gitleaks-checksum for CI.\n'
 
 check:
@@ -29,8 +28,6 @@ scan:
 
 scan-staged:
 	@bin/agent-guard scan-staged
-
-doctor: check
 
 checksum:
 	@printf 'To pin gitleaks-checksum for the GitHub Action input:\n'

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Defense-in-depth is best, but a single channel still meaningfully reduces risk. 
 
 No Python, Node, npm hook manager, Docker, Go/Rust runtime, skills, prompts, or reporting layer is required.
 
-`make doctor` prints the installed `gitleaks` version alongside the dependency check.
+`make check` prints the installed `gitleaks` version alongside the dependency check.
 
 ## Commands
 
@@ -59,7 +59,6 @@ make install       # ./install.sh git-hooks
 make test          # tests/run.sh
 make scan          # bin/agent-guard scan-working-tree
 make scan-staged   # bin/agent-guard scan-staged
-make doctor        # check + installed gitleaks version
 make checksum      # how to pin a gitleaks-checksum for CI
 ```
 

--- a/bin/agent-guard
+++ b/bin/agent-guard
@@ -103,15 +103,6 @@ scan_text_direct() {
   printf '%s\n' "$text" | run_gitleaks_stdin "$label"
 }
 
-scan_text_hook() {
-  label=$1
-  text=$2
-  scan_text_direct "$label" "$text"
-  status=$?
-  [ "$status" -eq 0 ] && return 0
-  return 2
-}
-
 block_on_scan_status() {
   status=$1
   message=$2
@@ -362,30 +353,36 @@ check_sensitive_reads() {
   values=$(printf '%s' "$input" | jq -r '.tool_input // {} | .. | strings')
   [ -n "$values" ] || return 0
 
-  printf '%s\n' "$values" | while IFS= read -r value; do
+  # Drive the loop from a temp file so it runs in this shell, not a pipeline
+  # sub-shell — that keeps `exit 2` definitive even if a future edit appends
+  # work after the loop.
+  tmp=$(mktemp_file) || die "failed to create temp file"
+  printf '%s\n' "$values" >"$tmp"
+  while IFS= read -r value; do
     [ -n "$value" ] || continue
     if matches_deny_path "$value"; then
       info "$PROGRAM: blocked sensitive file access: $value"
+      rm -f "$tmp"
       exit 2
     fi
-  done
+  done <"$tmp"
+  rm -f "$tmp"
 }
 
 deny_path_basename_pattern() {
   # Convert the supported deny-read shell globs to POSIX ERE.
   pattern=$1
   py=
-  i=1
-  len=${#pattern}
-  while [ "$i" -le "$len" ]; do
-    ch=$(printf '%s' "$pattern" | cut -c"$i")
+  remaining=$pattern
+  while [ -n "$remaining" ]; do
+    ch=${remaining%"${remaining#?}"}
+    remaining=${remaining#?}
     case "$ch" in
       '*') py=${py}'[^[:space:]<>|;&`$()]*' ;;
       '.'|'^'|'$'|'+'|'?'|'('|')'|'['|']'|'{'|'}'|'|'|'\\') py=${py}'\'${ch} ;;
       '/') py=${py}'/' ;;
       *) py=${py}${ch} ;;
     esac
-    i=$((i + 1))
   done
   printf '%s' "$py"
 }
@@ -544,15 +541,28 @@ check_bash_command() {
   [ -n "$cmd" ] || return 0
 
   [ -f "$DENY_BASH_PATTERNS" ] || die "deny bash policy not found: $DENY_BASH_PATTERNS"
-  while IFS= read -r pattern || [ -n "$pattern" ]; do
-    case "$pattern" in
-      ''|\#*) continue ;;
+  patterns=$(mktemp_file) || die "failed to create temp file"
+  grep -Ev '^[[:space:]]*(#|$)' "$DENY_BASH_PATTERNS" >"$patterns"
+  if [ -s "$patterns" ]; then
+    printf '%s\n' "$cmd" | grep -E -q -f "$patterns"
+    grep_status=$?
+    rm -f "$patterns"
+    case "$grep_status" in
+      0)
+        info "$PROGRAM: blocked risky shell command by deny pattern"
+        exit 2
+        ;;
+      1) ;;
+      *)
+        # grep failed (e.g., invalid ERE in a custom deny file). Fail closed —
+        # silently allowing here would let the rest of the deny list be bypassed.
+        info "$PROGRAM: deny-bash-patterns scan failed; refusing to allow command"
+        exit 2
+        ;;
     esac
-    if printf '%s\n' "$cmd" | grep -Eq "$pattern"; then
-      info "$PROGRAM: blocked risky shell command by deny pattern"
-      exit 2
-    fi
-  done <"$DENY_BASH_PATTERNS"
+  else
+    rm -f "$patterns"
+  fi
 
   if bash_matches_deny_path "$cmd"; then
     info "$PROGRAM: blocked shell command referencing a deny-listed path"
@@ -566,7 +576,8 @@ scan_mcp_input() {
   input=$1
   need_jq
   text=$(printf '%s' "$input" | jq -c '.tool_input // {}')
-  scan_text_hook "MCP tool input" "$text"
+  scan_text_direct "MCP tool input" "$text"
+  block_on_scan_status "$?" "MCP tool input contains secret-like values"
 }
 
 scan_proposed_write() {
@@ -577,15 +588,18 @@ scan_proposed_write() {
   case "$tool" in
     Write)
       content=$(json_value '.tool_input.content // empty' "$input")
-      scan_text_hook "proposed Write content" "$content"
+      scan_text_direct "proposed Write content" "$content"
+      block_on_scan_status "$?" "proposed Write contains secret-like values"
       ;;
     Edit)
       content=$(json_value '.tool_input.new_string // empty' "$input")
-      scan_text_hook "proposed Edit content" "$content"
+      scan_text_direct "proposed Edit content" "$content"
+      block_on_scan_status "$?" "proposed Edit contains secret-like values"
       ;;
     MultiEdit)
       content=$(printf '%s' "$input" | jq -r '[.tool_input.edits[]?.new_string // empty] | join("\n")')
-      scan_text_hook "proposed MultiEdit content" "$content"
+      scan_text_direct "proposed MultiEdit content" "$content"
+      block_on_scan_status "$?" "proposed MultiEdit contains secret-like values"
       ;;
     apply_patch)
       patch=$(printf '%s' "$input" | jq -r '
@@ -593,7 +607,8 @@ scan_proposed_write() {
         | if type == "string" then . else tojson end
       ')
       added=$(printf '%s\n' "$patch" | extract_patch_added_lines)
-      scan_text_hook "proposed apply_patch added lines" "$added"
+      scan_text_direct "proposed apply_patch added lines" "$added"
+      block_on_scan_status "$?" "proposed apply_patch contains secret-like values"
       ;;
   esac
 }

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -524,6 +524,23 @@ else
   sed 's/^/  stderr: /' /tmp/agent-guard-test.err
 fi
 
+# --- deny-bash-patterns fail-closed on invalid ERE -------------------------
+# Regression guard: an invalid line in a custom deny file must NOT silently
+# disable the rest of the policy. The combined `grep -f` exits with status 2,
+# which we translate to a hard block instead of treating it as "no match".
+BAD_PATTERNS_FILE="$TMP_ROOT/bad-deny-bash.txt"
+printf '%s\n' '[unterminated-bracket' >"$BAD_PATTERNS_FILE"
+printf '%s' '{"tool_name":"Bash","tool_input":{"command":"echo hi"}}' \
+  | AGENT_GUARD_DENY_BASH_PATTERNS="$BAD_PATTERNS_FILE" \
+    "$ROOT/bin/agent-guard" hook-pre-tool >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "deny-bash-patterns invalid ERE fails closed"
+else
+  not_ok "deny-bash-patterns invalid ERE fails closed (expected 2, got $status)"
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+
 # --- gitleaks not installed -----------------------------------------------
 
 NO_GITLEAKS_BIN="$TMP_ROOT/no-gitleaks-bin"


### PR DESCRIPTION
## Summary

Post-review simplify pass across the full implementation. Three review agents (reuse / quality / efficiency) plus an independent **Codex review** were run against the diff; only changes with no semantic regression were applied. The Codex review caught one fail-open regression in the initial grep consolidation, which was corrected before this PR.

## Changes

### 1. Remove `scan_text_hook` wrapper (bin/agent-guard)
`scan_text_hook` was a shim that called `scan_text_direct` and translated its result 1→2. Every caller site was in a mutation-tool path where that translation was redundant with `block_on_scan_status`. Dropping the wrapper:
- Removes one layer of indirection
- Gives callers an explicit, informative block message (e.g. `proposed Write contains secret-like values`)
- Unifies the findings→block path with the git-command and post-tool paths

### 2. Fix `check_sensitive_reads` sub-shell exit fragility (bin/agent-guard)
`printf … | while … exit 2 … done` runs the loop in a pipeline sub-shell, making `exit 2` affect only that sub-shell. The function's exit code was correct **only** because the pipeline was the last statement. A future edit appending code after the loop would silently fail-open. Replaced with a temp-file-driven loop that runs in the parent shell, making the `exit 2` unambiguous.

### 3. Drop `make doctor` alias (Makefile, README.md)
`doctor: check` was a 100% pass-through to `make check` with no additional behavior. Removed the target and its help line; README updated to reference `make check` for the gitleaks version output.

### 4. Replace per-char `cut -c""` with POSIX parameter expansion (bin/agent-guard)
`deny_path_basename_pattern` advanced through a string by spawning one `cut` subprocess per character. Replaced with `ch=${remaining%"${remaining#?}"}` / `remaining=${remaining#?}`, eliminating O(chars × patterns) subprocess spawns per Bash hook. Codex independently verified byte-identical output on dash, bash, and zsh.

### 5. Collapse deny-bash-pattern loop to `grep -E -f` (bin/agent-guard)
Reduced ~12 sequential `grep -Eq` invocations per Bash hook to one `grep -E -f`. Critically, **grep exit 2 (invalid ERE in a custom policy file) is now treated as a hard block** rather than no-match, preserving fail-closed semantics. A regression test covering this exact scenario was added.

## Functional Verification

```
tests/run.sh
passed: 96
failed: 0
```

Tests run with both the bundled mock gitleaks and real gitleaks (v8.26.0). The Codex review verified the parameter-expansion rewrite on three POSIX shells (dash, bash, zsh) and flagged the initial grep fail-open path before it could land.

All changes are on POSIX `sh`; no new dependencies introduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed `make doctor` command; added `make checksum` to available build targets
  * Updated build configuration documentation

* **Bug Fixes**
  * Enhanced security scanning to fail closed when pattern matching encounters errors

* **Documentation**
  * Updated README requirements section with current build command information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->