### PR TITLE
docs: add Quickstart section with plugin install paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,56 @@ Agent Guard inserts deterministic secret-scanning checks into AI coding agent ho
 
 It is intentionally small. It does not teach agents how to behave, manage vaults, rotate credentials, verify live credentials, produce dashboards, or replace GitHub Secret Scanning and Push Protection.
 
+## Quickstart
+
+Pick the channel matching your environment. All commands resolve to the same released version.
+
+### Claude Code
+
+```text
+/plugin marketplace add JeongJaeSoon/agent-guard
+/plugin install agent-guard@latest
+```
+
+### Codex
+
+```text
+/plugin install JeongJaeSoon/agent-guard@latest
+```
+
+### GitHub Actions
+
+```yaml
+- uses: JeongJaeSoon/agent-guard@v1
+  with:
+    paths: "."
+    gitleaks-checksum: "<sha256 of the gitleaks release archive>"
+```
+
+`@v1` tracks the latest 1.x release. Pin to a full commit SHA for high-security environments.
+
+### Direct CLI install (no clone)
+
+```sh
+mkdir -p ~/.agent-guard && cd ~/.agent-guard
+gh release download --repo JeongJaeSoon/agent-guard --pattern '*.tar.gz' --pattern '*.sha256'
+shasum -a 256 -c agent-guard-*.tar.gz.sha256
+tar -xzf agent-guard-*.tar.gz
+ln -sf "$PWD/bin/agent-guard" ~/.local/bin/agent-guard
+agent-guard check
+```
+
+A future minor release will bundle a one-line `curl | sh` installer; the steps above are the manual equivalent that works today.
+
+### Native Git hook (after one of the above)
+
+```sh
+cd <your-project>
+~/.agent-guard/install.sh git-hooks
+```
+
+See **Advanced setup** below for the full per-channel configuration, including how to wire local `examples/claude/settings.project.json` into a project, the Codex hook contract, and the `gitleaks-checksum` pinning policy for CI.
+
 ## Channels
 
 Agent Guard offers four independent integration points. Pick whichever match your workflow — they do **not** chain. Each row lists what that channel alone can and cannot block.


### PR DESCRIPTION
## Summary
Adds a top-of-README Quickstart section that surfaces the official plugin install paths (Claude Code marketplace, Codex), the GitHub Action snippet, a manual CLI install via released tarball + sha256, and the native Git hook step.

The existing detailed sections remain untouched and now serve as **Advanced setup**.

## Why
- Closes the gap surfaced in the v1.0.1 verification: until now, the only way to install was `git clone` + `sed`-based path substitution. The Quickstart points first-time users at the supported, version-pinned channels.
- Each command resolves to the same git tag, since `release.yml` keeps `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, `v1` moving tag, and the GitHub Release tarball in sync.

## What changed
- README.md: insert a `## Quickstart` section between the intro and `## Channels`. No existing section was deleted or rewritten.

## Functional verification
- [x] v1.0.1 release has `agent-guard-1.0.1.tar.gz`, matching `.sha256`, and `install.sh` attached. Downloaded via `gh release download` and SHA verified locally.
- [x] `v1` moving tag points at the same SHA as `v1.0.1` and main HEAD.
- [x] `action.yml` is present at the `v1` ref (3.5 KB), so `uses: JeongJaeSoon/agent-guard@v1` resolves.
- [x] Both plugin manifests at `v1` report `version: 1.0.1`.
- [ ] Plugin install (`/plugin install agent-guard@latest`) hands-on smoke test in a real Claude/Codex session — to be performed by maintainer; the marketplace/manifest data has been verified statically.

## Follow-ups (separate PRs)
- `marketplace.json` plugin entry has `version: 1.0.0` (stale). Will be added to the workflow's jq bump loop in a small follow-up PR.
- A future `install.sh` enhancement to support `curl | sh` (and `agent-guard install claude/codex/git-hooks`) is mentioned but not blocking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Quickstart section with channel-specific installation instructions for Claude Code, Codex, and GitHub Actions
  * Included step-by-step CLI installation process with checksum verification
  * Added guidance for native Git hook setup
  * Referenced upcoming simplified installer in future release
  * Linked to Advanced setup section for detailed configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->