### PR TITLE
chore(release): bump marketplace.json plugin version on release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
         "ref": "v1"
       },
       "description": "Deterministic secret-scanning guardrails for AI coding agents.",
-      "version": "1.0.0"
+      "version": "1.0.1"
     }
   ]
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,12 @@ jobs:
           for f in .claude-plugin/plugin.json .codex-plugin/plugin.json; do
             jq --arg v "$v" '.version=$v' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
           done
+          # Marketplace catalog: bump the agent-guard plugin entry's version field.
+          mp=.claude-plugin/marketplace.json
+          if [ -f "$mp" ]; then
+            jq --arg v "$v" '(.plugins[] | select(.name=="agent-guard") | .version) = $v' \
+              "$mp" > "$mp.tmp" && mv "$mp.tmp" "$mp"
+          fi
           # Replace any pinned semver in README install snippets (no-op if none).
           sed -i -E "s|agent-guard@[0-9]+\.[0-9]+\.[0-9]+|agent-guard@${v}|g" README.md
 


### PR DESCRIPTION
## Summary
Two small fixes discovered during v1.0.1 verification.

## Why
`.claude-plugin/marketplace.json` carries a separate `version` field on its plugin entry (it is the marketplace catalog, distinct from `plugin.json`). The original `release.yml` only bumped `plugin.json` and `codex-plugin/plugin.json`, so the marketplace catalog drifted to a stale value (still `1.0.0` after the v1.0.1 release).

## What changed
- `.github/workflows/release.yml`: add a guarded `jq` step that updates `.plugins[] | select(.name=="agent-guard") | .version` in `.claude-plugin/marketplace.json`. Skipped if the file is absent.
- `.claude-plugin/marketplace.json`: one-time backfill from `1.0.0` → `1.0.1` to align with the current release before the next dispatch overwrites it.

## Functional verification
- [x] YAML still parses (`ruby -ryaml`).
- [x] `jq` selector verified against the actual file structure.
- [ ] Will be exercised by the next release dispatch (v1.0.2). Expected post-release state: marketplace.json plugin version = 1.0.2 alongside both plugin.json files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released agent-guard plugin version 1.0.1.
  * Enhanced release workflow to automatically synchronize version information across plugin configuration files during the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->