### PR TITLE
fix(release): pick latest semver tag, ignore moving major tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,12 @@ jobs:
         id: ver
         run: |
           set -euo pipefail
-          cur=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo 0.0.0)
+          # Pick the latest semver tag (vX.Y.Z), ignoring moving tags like v1.
+          cur=$(git tag --sort=-version:refname --list 'v[0-9]*.[0-9]*.[0-9]*' \
+            | head -n1 | sed 's/^v//')
+          : "${cur:=0.0.0}"
           IFS=. read -r MA MI PA <<<"$cur"
+          : "${MA:=0}"; : "${MI:=0}"; : "${PA:=0}"
           case "${{ inputs.bump }}" in
             major) MA=$((MA+1)); MI=0; PA=0 ;;
             minor) MI=$((MI+1)); PA=0 ;;


### PR DESCRIPTION
## Summary
The v1.0.2 dispatch failed at `Open release PR` with `fatal: 'release/v1..1' is not a valid branch name`. Root cause: `git describe --tags --abbrev=0` returned the moving `v1` tag (which points at the same commit as `v1.0.1`), and stripping the leading `v` produced `cur=1`, which split into `MA=1, MI=, PA=`. The patch bump then yielded the broken version string `1..1`.

## Fix
Replace `git describe` with a deterministic semver-only filter:

```sh
cur=$(git tag --sort=-version:refname --list 'v[0-9]*.[0-9]*.[0-9]*' \
  | head -n1 | sed 's/^v//')
: "${cur:=0.0.0}"
```

Also defensively defaults `MA/MI/PA` to `0` after the IFS split so any future malformed tag cannot break version math.

## Why this matters
The bug was latent: it only manifested after the moving `v1` tag started colliding with a semver tag on the same commit. It would have triggered on every subsequent dispatch.

## Verification
- [x] YAML parses.
- [x] Tag-selection logic simulated locally with `sort -V -r | grep`: returns `v1.0.1` from {`v1`, `v1.0.0`, `v1.0.1`} and `v1.0.2` from the post-release set.
- [ ] Will be exercised by the next `bump=patch` dispatch (expected: v1.0.2).