### PR TITLE
feat(setup): add agent-guard setup subcommand for opt-in dependency bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,10 @@ gh release download --repo JeongJaeSoon/agent-guard --pattern '*.tar.gz' --patte
 shasum -a 256 -c agent-guard-*.tar.gz.sha256
 tar -xzf agent-guard-*.tar.gz
 ln -sf "$PWD/bin/agent-guard" ~/.local/bin/agent-guard
-agent-guard check
+agent-guard setup        # report dependency status; print install hints if any are missing
 ```
+
+`agent-guard setup` is opt-in: it does *not* install anything by default. If `gitleaks` is missing, it prints the exact `--install` command (which requires you to pass `--gitleaks-checksum SHA` from the published gitleaks release). `jq` is left to your system package manager — `setup` prints the appropriate `brew`/`apt-get`/`dnf` command for your OS.
 
 A future minor release will bundle a one-line `curl | sh` installer; the steps above are the manual equivalent that works today.
 
@@ -73,7 +75,7 @@ The right verification depends on the channel you used.
 | Claude Code | `/plugin list` should show `agent-guard`. To smoke-test the hook, ask the agent to read a deny-listed file (e.g. "read `.env`") — the agent should be blocked with `blocked sensitive file access: .env`. |
 | Codex | Same shape as Claude Code; the agent should be blocked when asked to read `.env`. |
 | GitHub Actions | The action runs on PR/push. A workflow run that reports either "no findings" (clean repo) or a deliberate finding (PR you crafted with a fake high-entropy secret) confirms the channel is wired. |
-| Direct CLI install | `agent-guard check` — works because `~/.local/bin/agent-guard` is on PATH after the symlink step. |
+| Direct CLI install | `agent-guard check` for a strict pass/fail; `agent-guard setup` for a per-dependency status report (and install hints if anything is missing). |
 | Cloned repo | `./install.sh check` or `make check` from the repo root. |
 
 Both `agent-guard check` and `./install.sh check` print the resolved `gitleaks` version alongside the dependency check.
@@ -217,8 +219,11 @@ bin/agent-guard scan-staged
 bin/agent-guard scan-working-tree
 bin/agent-guard scan-path PATH...
 bin/agent-guard check        # dependency / gitleaks version check
+bin/agent-guard setup        # report dependency status; --install opts in to gitleaks download
 bin/agent-guard version
 ```
+
+`setup` is the dependency bootstrap entry point. By default it only reports status and prints install hints. Pass `--install --gitleaks-checksum SHA [--gitleaks-version X.Y.Z]` to actually download `gitleaks` into `~/.agent-guard/bin/`. The checksum is required (no implicit fetch) and must match the value published in the gitleaks release's `gitleaks_X.Y.Z_checksums.txt`. `jq` is never auto-installed — `setup` prints the appropriate package-manager command for your OS instead, since `jq` belongs with the system package manager.
 
 ### Hook entry points
 

--- a/bin/agent-guard
+++ b/bin/agent-guard
@@ -26,6 +26,7 @@ Usage:
   agent-guard scan-working-tree
   agent-guard scan-path PATH...
   agent-guard check
+  agent-guard setup [--install --gitleaks-checksum SHA [--gitleaks-version X.Y.Z]]
   agent-guard version
 EOF
 }
@@ -69,6 +70,166 @@ check_deps() {
   if [ -n "$gl_version" ]; then
     info "$PROGRAM: gitleaks $gl_version (>= 8.30 recommended)"
   fi
+}
+
+GITLEAKS_DEFAULT_VERSION=8.30.1
+SETUP_INSTALL_DIR=${AGENT_GUARD_BIN_DIR:-$HOME/.agent-guard/bin}
+
+setup_status_line() {
+  name=$1
+  if command -v "$name" >/dev/null 2>&1; then
+    ver=$($name --version 2>/dev/null | head -1)
+    if [ -z "$ver" ]; then
+      ver=$($name version 2>/dev/null | head -1)
+    fi
+    info "$PROGRAM: $name  ok  (${ver:-installed})"
+    return 0
+  fi
+  info "$PROGRAM: $name  missing"
+  return 1
+}
+
+setup_suggest_jq_install() {
+  if command -v brew >/dev/null 2>&1; then
+    info "  brew install jq"
+  elif command -v apt-get >/dev/null 2>&1; then
+    info "  sudo apt-get install -y jq"
+  elif command -v dnf >/dev/null 2>&1; then
+    info "  sudo dnf install -y jq"
+  else
+    info "  https://stedolan.github.io/jq/download/"
+  fi
+}
+
+setup_install_gitleaks() {
+  version=$1
+  checksum=$2
+  if [ -z "$checksum" ]; then
+    die "setup: --gitleaks-checksum is required when using --install. Get the published value from https://github.com/gitleaks/gitleaks/releases/download/v${version}/gitleaks_${version}_checksums.txt"
+  fi
+
+  os=$(uname -s | tr '[:upper:]' '[:lower:]')
+  arch=$(uname -m)
+  case "$arch" in
+    x86_64|amd64) arch=x64 ;;
+    arm64|aarch64) arch=arm64 ;;
+    *) die "setup: unsupported architecture: $arch" ;;
+  esac
+  case "$os" in
+    darwin|linux) ;;
+    *) die "setup: unsupported os: $os" ;;
+  esac
+
+  need_cmd curl
+  need_cmd shasum
+  need_cmd tar
+
+  archive="gitleaks_${version}_${os}_${arch}.tar.gz"
+  url="https://github.com/gitleaks/gitleaks/releases/download/v${version}/${archive}"
+
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/agent-guard-setup.XXXXXX") || die "setup: failed to create temp dir"
+  # POSIX trap chain so caller's traps still run.
+  trap 'rm -rf "$tmp"' EXIT
+
+  info "$PROGRAM: downloading $archive"
+  curl -fsSL "$url" -o "$tmp/$archive" || die "setup: download failed: $url"
+
+  info "$PROGRAM: verifying sha256"
+  printf '%s  %s\n' "$checksum" "$tmp/$archive" | shasum -a 256 -c - >&2 \
+    || die "setup: checksum verification failed for $archive"
+
+  info "$PROGRAM: extracting"
+  tar -xzf "$tmp/$archive" -C "$tmp" || die "setup: extraction failed"
+
+  mkdir -p "$SETUP_INSTALL_DIR" || die "setup: cannot create install dir: $SETUP_INSTALL_DIR"
+  mv "$tmp/gitleaks" "$SETUP_INSTALL_DIR/gitleaks" || die "setup: failed to install gitleaks binary"
+  chmod +x "$SETUP_INSTALL_DIR/gitleaks"
+
+  info "$PROGRAM: installed gitleaks v${version} at $SETUP_INSTALL_DIR/gitleaks"
+  case ":$PATH:" in
+    *":$SETUP_INSTALL_DIR:"*) ;;
+    *)
+      info "$PROGRAM: $SETUP_INSTALL_DIR is not on PATH; add to your shell rc:"
+      info "  export PATH=\"$SETUP_INSTALL_DIR:\$PATH\""
+      ;;
+  esac
+}
+
+do_setup() {
+  install=0
+  version=$GITLEAKS_DEFAULT_VERSION
+  checksum=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --install) install=1 ;;
+      --gitleaks-version)
+        shift
+        [ $# -gt 0 ] || die "setup: --gitleaks-version requires a value"
+        version=$1
+        ;;
+      --gitleaks-version=*) version=${1#--gitleaks-version=} ;;
+      --gitleaks-checksum)
+        shift
+        [ $# -gt 0 ] || die "setup: --gitleaks-checksum requires a value"
+        checksum=$1
+        ;;
+      --gitleaks-checksum=*) checksum=${1#--gitleaks-checksum=} ;;
+      -h|--help)
+        cat >&2 <<'EOF'
+Usage:
+  agent-guard setup
+  agent-guard setup --install --gitleaks-checksum SHA [--gitleaks-version X.Y.Z]
+
+Default behavior is opt-in: setup only reports the dependency status.
+Pass --install to download gitleaks. The checksum is required and must
+match the published value at:
+  https://github.com/gitleaks/gitleaks/releases/download/vX.Y.Z/gitleaks_X.Y.Z_checksums.txt
+EOF
+        return 0
+        ;;
+      *) die "setup: unknown argument: $1" ;;
+    esac
+    shift
+  done
+
+  jq_ok=1; gitleaks_ok=1
+  setup_status_line jq       || jq_ok=0
+  setup_status_line git      || :
+  setup_status_line gitleaks || gitleaks_ok=0
+
+  if [ "$install" -eq 1 ]; then
+    if [ "$gitleaks_ok" -eq 1 ]; then
+      info "$PROGRAM: gitleaks already on PATH; skipping --install"
+    else
+      setup_install_gitleaks "$version" "$checksum"
+    fi
+    if [ "$jq_ok" -eq 0 ]; then
+      info "$PROGRAM: jq is not auto-installed; use your system package manager:"
+      setup_suggest_jq_install
+    fi
+    return 0
+  fi
+
+  if [ "$jq_ok" -eq 0 ] || [ "$gitleaks_ok" -eq 0 ]; then
+    info ""
+    if [ "$jq_ok" -eq 0 ]; then
+      info "$PROGRAM: install jq with your package manager:"
+      setup_suggest_jq_install
+    fi
+    if [ "$gitleaks_ok" -eq 0 ]; then
+      info "$PROGRAM: install gitleaks (rerun with --install to opt in):"
+      info "  agent-guard setup --install \\"
+      info "    --gitleaks-version $GITLEAKS_DEFAULT_VERSION \\"
+      info "    --gitleaks-checksum <sha256-from-published-checksums.txt>"
+      info ""
+      info "$PROGRAM: get the checksum from"
+      info "  https://github.com/gitleaks/gitleaks/releases/download/v$GITLEAKS_DEFAULT_VERSION/gitleaks_${GITLEAKS_DEFAULT_VERSION}_checksums.txt"
+    fi
+    return 1
+  fi
+
+  info "$PROGRAM: setup ok"
+  return 0
 }
 
 mktemp_file() {
@@ -680,6 +841,7 @@ case "$cmd" in
   scan-working-tree) shift; scan_working_tree "$@" ;;
   scan-path) shift; scan_path "$@" ;;
   check) check_deps ;;
+  setup) shift; do_setup "$@" ;;
   version) printf '%s %s\n' "$PROGRAM" "$VERSION" ;;
   ''|-h|--help|help) usage; exit 0 ;;
   *) usage; exit 2 ;;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -367,6 +367,12 @@ run_expect 2 "unknown subcommand exits 2" "$ROOT/bin/agent-guard" not-a-command
 
 run_expect 0 "check passes when deps and configs exist" "$ROOT/bin/agent-guard" check
 
+# --- setup -----------------------------------------------------------------
+
+run_expect 0 "setup --help exits 0" "$ROOT/bin/agent-guard" setup --help
+run_expect 2 "setup unknown flag exits 2" "$ROOT/bin/agent-guard" setup --bogus
+run_expect 0 "setup with all deps present exits 0" "$ROOT/bin/agent-guard" setup
+
 # --- scan-path -------------------------------------------------------------
 
 CLEAN_DIR="$TMP_ROOT/clean-dir"
@@ -554,6 +560,31 @@ if [ "$status" -eq 2 ]; then
   ok "scan-path dies when gitleaks is unavailable"
 else
   not_ok "scan-path dies when gitleaks is unavailable (expected 2, got $status)"
+fi
+
+# Reuse NO_GITLEAKS_BIN: jq must remain reachable so setup can report jq ok
+# while gitleaks is missing.
+ln -sf "$(command -v jq)" "$NO_GITLEAKS_BIN/jq"
+ln -sf "$(command -v git)" "$NO_GITLEAKS_BIN/git"
+ln -sf "$(command -v command)" "$NO_GITLEAKS_BIN/command" 2>/dev/null || true
+ln -sf "$(command -v uname)" "$NO_GITLEAKS_BIN/uname" 2>/dev/null || true
+
+PATH="$NO_GITLEAKS_BIN" "$ROOT/bin/agent-guard" setup >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+status=$?
+if [ "$status" -eq 1 ]; then
+  ok "setup exits 1 when gitleaks missing"
+else
+  not_ok "setup exits 1 when gitleaks missing (expected 1, got $status)"
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+
+PATH="$NO_GITLEAKS_BIN" "$ROOT/bin/agent-guard" setup --install >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "setup --install without --gitleaks-checksum exits 2"
+else
+  not_ok "setup --install without --gitleaks-checksum exits 2 (expected 2, got $status)"
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
 fi
 
 # --- extract_patch_added_lines via apply_patch dialects -------------------


### PR DESCRIPTION
## Summary
Adds `agent-guard setup` — a single dependency-bootstrap entry point so direct CLI users have a defined path to install / verify `gitleaks` without manual download + checksum + extract + chmod steps.

This is the second of three sequential PRs improving install ergonomics:
1. ✅ #12 — README reorganization.
2. **#13 (this PR)** — `agent-guard setup` subcommand for opt-in dependency bootstrap.
3. **next** — `bootstrap.sh` published to releases for `curl | sh` install (will reuse `setup`'s install logic).

## Why
Three problems before this PR:

- **No defined path for "I just installed via `gh release download`, what now?"** The Quickstart said `agent-guard check` after symlinking, but `check` is a strict pass/fail — when something *is* missing, the user has to read failure output, recognise it, and know the right install incantation themselves.
- **Inconsistent gitleaks-install posture between channels**: `action.yml` has a robust gitleaks-installer (with required checksum, OS/arch detection, etc.). The CLI side had nothing equivalent — direct CLI users were left to install gitleaks via brew or by hand.
- **No story for `jq` missing**: `check` would fail with `required command not found: jq`, no guidance.

`setup` fixes all three by reporting per-dependency status, printing the exact next command(s) to run, and providing an opt-in install path that mirrors the action's checksum policy.

## What changed

### New subcommand: `agent-guard setup`

Default (`agent-guard setup`):
- Probes `jq`, `git`, `gitleaks` independently.
- Prints one line per dependency: `<name>  ok  (<version>)` or `<name>  missing`.
- Exits `0` if all present, `1` if anything is missing.
- When missing, prints the *exact* command(s) to run, including the URL of gitleaks's published `gitleaks_X.Y.Z_checksums.txt` so the user can copy a trusted SHA-256.

Opt-in install (`agent-guard setup --install --gitleaks-checksum SHA [--gitleaks-version X.Y.Z]`):
- Detects OS (`darwin`/`linux`) and arch (`x64`/`arm64`).
- Downloads `gitleaks_X.Y.Z_<os>_<arch>.tar.gz` from the official gitleaks GitHub release.
- Verifies SHA-256 against the value passed via `--gitleaks-checksum`.
- Extracts the binary into `$AGENT_GUARD_BIN_DIR` (default `~/.agent-guard/bin`).
- Aborts cleanly if the checksum is empty or verification fails.

`jq` policy:
- `setup` *never* auto-installs `jq`. It prints the OS-appropriate package-manager command (`brew`/`apt-get`/`dnf`) and lets the user run it. `jq` is a standard system tool and belongs with the system package manager — pulling it down as an opaque binary would blur the responsibility boundary.

## Design decisions

| Decision | Rationale |
|---|---|
| Opt-in via `--install` flag (no [Y/n] prompt) | The flag is the explicit consent signal. CI and interactive use take the same arguments — no `--no-prompt` mode needed, no behavior divergence. |
| `--gitleaks-checksum` is required (not optional) | Matches `action.yml`'s `require-checksum: "true"` default. Refusing to fall back to HTTPS-only integrity is consistent with agent-guard's deterministic, conservative posture: a compromised release URL cannot inject a bad binary. |
| Don't auto-fetch the checksum from gitleaks's release | A release-URL compromise can also tamper with the checksum file. Forcing the user to obtain the checksum *out-of-band* (the URL is printed in the missing-dep message) at least requires two compromise points instead of one. |
| Install dir overridable via `AGENT_GUARD_BIN_DIR` | Sandboxed CI and per-user multi-installs need a non-`$HOME` install location. Default stays `~/.agent-guard/bin` so it's discoverable. |
| POSIX `sh`, no bashisms | Matches the rest of `bin/agent-guard`. |

## Functional verification
- [x] `agent-guard setup --help` prints usage, exits 0.
- [x] `agent-guard setup` with all deps present exits 0 with `setup ok` line.
- [x] `agent-guard setup` with `gitleaks` missing (stripped PATH) exits 1 with explicit install hint.
- [x] `agent-guard setup --install` without `--gitleaks-checksum` exits 2 with checksum URL pointer.
- [x] `agent-guard setup --bogus` exits 2 with `unknown argument`.
- [x] `tests/run.sh` passes 101/0 (96 prior + 5 new setup tests).
- [x] `sh -n bin/agent-guard` clean (POSIX-syntax check via existing `shell syntax` test).
- [x] gitleaks pre-commit scan: clean.

## Out of scope (next PR)
- `bootstrap.sh` for `curl | sh` install — will be a thin wrapper that downloads agent-guard, then internally calls `agent-guard setup --install ...` so the dependency-install logic stays in one place.
- Plugin-native `/agent-guard:verify` slash command (referenced in the README footnote).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `agent-guard setup` subcommand to check and report the status of required dependencies, with optional installation mode for downloading and verifying gitleaks automatically.

* **Documentation**
  * Updated README to document the new `setup` subcommand, including usage guidance and dependency installation instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->