### PR TITLE
feat(install): publish bootstrap.sh for one-line curl | sh CLI install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,4 +177,5 @@ jobs:
             --generate-notes \
             "agent-guard-${v}.tar.gz" \
             "agent-guard-${v}.tar.gz.sha256" \
-            install.sh
+            install.sh \
+            bootstrap.sh

--- a/README.md
+++ b/README.md
@@ -41,17 +41,31 @@ The `gitleaks-checksum` is integrity metadata, not a credential — commit it di
 ### Direct CLI install (no clone)
 
 ```sh
+curl -fsSL https://github.com/JeongJaeSoon/agent-guard/releases/latest/download/bootstrap.sh | sh
+```
+
+The bootstrap script:
+
+- resolves the latest release version via the GitHub `releases/latest` redirect (override with `AGENT_GUARD_VERSION=1.2.3`),
+- downloads `agent-guard-X.Y.Z.tar.gz` and the published `.sha256`, verifies the checksum, and extracts to `~/.agent-guard` (override with `AGENT_GUARD_HOME`),
+- symlinks `~/.local/bin/agent-guard` (override with `AGENT_GUARD_BIN_DIR`),
+- runs `agent-guard setup` so you immediately see per-dependency status and any install hints.
+
+`agent-guard setup` is opt-in: it does *not* install anything by default. If `gitleaks` is missing, it prints the exact `--install` command (which requires `--gitleaks-checksum SHA` from the published gitleaks release). `jq` is left to your system package manager — `setup` prints the appropriate `brew`/`apt-get`/`dnf` command for your OS.
+
+<details>
+<summary>Manual equivalent (no <code>curl | sh</code>)</summary>
+
+```sh
 mkdir -p ~/.agent-guard && cd ~/.agent-guard
 gh release download --repo JeongJaeSoon/agent-guard --pattern '*.tar.gz' --pattern '*.sha256'
 shasum -a 256 -c agent-guard-*.tar.gz.sha256
 tar -xzf agent-guard-*.tar.gz
 ln -sf "$PWD/bin/agent-guard" ~/.local/bin/agent-guard
-agent-guard setup        # report dependency status; print install hints if any are missing
+agent-guard setup
 ```
 
-`agent-guard setup` is opt-in: it does *not* install anything by default. If `gitleaks` is missing, it prints the exact `--install` command (which requires you to pass `--gitleaks-checksum SHA` from the published gitleaks release). `jq` is left to your system package manager — `setup` prints the appropriate `brew`/`apt-get`/`dnf` command for your OS.
-
-A future minor release will bundle a one-line `curl | sh` installer; the steps above are the manual equivalent that works today.
+</details>
 
 ### Native Git hook
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env sh
+# Agent Guard bootstrap installer.
+#
+# Usage:
+#   curl -fsSL https://github.com/JeongJaeSoon/agent-guard/releases/latest/download/bootstrap.sh | sh
+#
+# Environment overrides:
+#   AGENT_GUARD_VERSION   pin a specific version (e.g. 1.2.0). Defaults to the
+#                         latest release resolved via the GitHub redirect.
+#   AGENT_GUARD_HOME      install destination (default: $HOME/.agent-guard).
+#   AGENT_GUARD_BIN_DIR   directory the agent-guard symlink lives in (default:
+#                         $HOME/.local/bin).
+#   AGENT_GUARD_REPO      override the source repo (default: JeongJaeSoon/agent-guard).
+
+set -eu
+
+REPO=${AGENT_GUARD_REPO:-JeongJaeSoon/agent-guard}
+HOME_DIR=${AGENT_GUARD_HOME:-$HOME/.agent-guard}
+BIN_DIR=${AGENT_GUARD_BIN_DIR:-$HOME/.local/bin}
+VERSION=${AGENT_GUARD_VERSION:-}
+
+prog=agent-guard-bootstrap
+
+info() { printf '%s\n' "$*" >&2; }
+die()  { info "$prog: $*"; exit 2; }
+
+require() {
+  command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+resolve_latest_version() {
+  # GitHub redirects releases/latest -> releases/tag/vX.Y.Z. We follow the
+  # redirect and read the effective URL rather than parsing release notes.
+  url=$(curl -fsS -o /dev/null -w '%{url_effective}' \
+    "https://github.com/${REPO}/releases/latest") \
+    || die "could not query latest release"
+  v=$(printf '%s' "$url" | sed -n -E 's|.*/tag/v([0-9]+\.[0-9]+\.[0-9]+)$|\1|p')
+  [ -n "$v" ] || die "could not parse version from $url"
+  printf '%s' "$v"
+}
+
+main() {
+  require curl
+  require shasum
+  require tar
+  require ln
+
+  if [ -z "$VERSION" ]; then
+    VERSION=$(resolve_latest_version)
+  fi
+  info "$prog: target version v$VERSION"
+
+  archive="agent-guard-${VERSION}.tar.gz"
+  base="https://github.com/${REPO}/releases/download/v${VERSION}"
+
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/agent-guard-bootstrap.XXXXXX") \
+    || die "mktemp failed"
+  # shellcheck disable=SC2064
+  trap "rm -rf '$tmp'" EXIT INT TERM
+
+  info "$prog: downloading $archive"
+  curl -fsSL "$base/$archive"        -o "$tmp/$archive" \
+    || die "download failed: $base/$archive"
+  curl -fsSL "$base/$archive.sha256" -o "$tmp/$archive.sha256" \
+    || die "download failed: $base/$archive.sha256"
+
+  info "$prog: verifying sha256"
+  ( cd "$tmp" && shasum -a 256 -c "$archive.sha256" ) >&2 \
+    || die "checksum verification failed for $archive"
+
+  info "$prog: extracting to $HOME_DIR"
+  mkdir -p "$HOME_DIR"
+  tar -xzf "$tmp/$archive" -C "$HOME_DIR"
+
+  bin_path="$HOME_DIR/bin/agent-guard"
+  [ -x "$bin_path" ] || die "expected executable not found after extraction: $bin_path"
+
+  mkdir -p "$BIN_DIR"
+  ln -sf "$bin_path" "$BIN_DIR/agent-guard"
+  info "$prog: linked $BIN_DIR/agent-guard -> $bin_path"
+
+  case ":$PATH:" in
+    *":$BIN_DIR:"*) ;;
+    *)
+      info ""
+      info "$prog: $BIN_DIR is not on PATH. Add this to your shell rc:"
+      info "  export PATH=\"$BIN_DIR:\$PATH\""
+      info ""
+      ;;
+  esac
+
+  info "$prog: running 'agent-guard setup' to report dependency status"
+  info ""
+  # 'setup' may exit 1 if deps are missing; that's expected and not a bootstrap
+  # failure -- the user just gets the install hints.
+  "$bin_path" setup || true
+  info ""
+  info "$prog: done. v${VERSION} installed at $HOME_DIR."
+}
+
+main "$@"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -84,6 +84,7 @@ chmod +x "$MOCK_BIN/gitleaks"
 for file in \
   "$ROOT/bin/agent-guard" \
   "$ROOT/install.sh" \
+  "$ROOT/bootstrap.sh" \
   "$ROOT/githooks/pre-commit" \
   "$ROOT/tests/run.sh"; do
   run_expect 0 "shell syntax: $file" sh -n "$file"


### PR DESCRIPTION
## Summary
Adds a published `bootstrap.sh` so direct CLI install becomes a true one-liner:

```sh
curl -fsSL https://github.com/JeongJaeSoon/agent-guard/releases/latest/download/bootstrap.sh | sh
```

This is the third (final) PR in the install-ergonomics series:
1. ✅ #12 — README reorganization.
2. ✅ #13 — `agent-guard setup` for opt-in dependency bootstrap.
3. **#14 (this PR)** — `bootstrap.sh` for `curl | sh` install (delegates dep handling to `agent-guard setup`).

## Why
The previous "Direct CLI install (no clone)" was 6 manual steps: `mkdir`, `gh release download`, `shasum -c`, `tar -xzf`, `ln -sf`, `agent-guard setup`. That's a lot of friction for users who just want to *try* agent-guard. Plugin install paths (Claude Code, Codex, GitHub Actions) are all single-line; direct CLI was the lone exception.

`bootstrap.sh` brings direct CLI install to parity.

## What changed

### `bootstrap.sh` (new file)
A POSIX-`sh` script published as a release asset. Behavior:

1. Resolves target version: env `AGENT_GUARD_VERSION` if set, else parses the `releases/latest` redirect (`curl -w '%{url_effective}'`).
2. Downloads `agent-guard-X.Y.Z.tar.gz` and `agent-guard-X.Y.Z.tar.gz.sha256` from the same release URL.
3. `shasum -a 256 -c` to verify integrity.
4. Extracts to `$AGENT_GUARD_HOME` (default `~/.agent-guard`).
5. Symlinks `$AGENT_GUARD_BIN_DIR/agent-guard` (default `~/.local/bin/agent-guard`).
6. Prints PATH advisory if `$AGENT_GUARD_BIN_DIR` is not on PATH.
7. Delegates to `agent-guard setup` (no `--install`) so the user immediately sees per-dependency status and install hints. Setup's exit 1 (deps missing) is swallowed — bootstrap's job is to install agent-guard itself, not to install gitleaks.

Configurable via env (no flags, since `curl | sh` doesn't take stdin args cleanly):

| Env | Default | Purpose |
|---|---|---|
| `AGENT_GUARD_VERSION` | latest (resolved at runtime) | pin a specific version |
| `AGENT_GUARD_HOME` | `~/.agent-guard` | extract destination |
| `AGENT_GUARD_BIN_DIR` | `~/.local/bin` | symlink target dir |
| `AGENT_GUARD_REPO` | `JeongJaeSoon/agent-guard` | source repo (for forks/mirrors) |

### `release.yml`
One-line change: add `bootstrap.sh` to the `gh release create` asset list, alongside the existing `agent-guard-X.Y.Z.tar.gz`, its `.sha256`, and `install.sh`. The release URL `releases/latest/download/bootstrap.sh` becomes stable.

### `README.md`
Quickstart / Direct CLI install now leads with the one-liner. The previous 6-step manual flow is preserved inside a `<details>` fold for users who refuse to pipe curl into sh, or for offline / audit review.

### `tests/run.sh`
`bootstrap.sh` added to the existing shell-syntax check loop. No network test here — the script hits real GitHub URLs which is exercised end-to-end on the next release dispatch.

## Design decisions

| Decision | Rationale |
|---|---|
| Version resolved via runtime redirect parsing, not release-time `sed` substitution | The same `bootstrap.sh` works from a clone, from any URL, and from a release asset. Zero coupling between `bootstrap.sh` and `release.yml`. One extra HTTP HEAD on install — negligible. |
| Trust model for the agent-guard tarball checksum is the same release URL | This is *our own* artifact. A release-URL compromise would also tamper with the checksum, but that's the same trust boundary as `releases/latest/download/bootstrap.sh` itself — there's no out-of-band verification path that would help here without adding GPG signing infrastructure. (Compare to gitleaks, which is third-party — there we *do* require OOB checksum.) |
| Bootstrap does not duplicate gitleaks-install logic | Bootstrap stops at extract + symlink. Dep handling (gitleaks install, `jq` policy, OS/arch detection, etc.) stays in `agent-guard setup` from #13. One maintenance point. Bootstrap calls setup at the end so the user's first interaction is the same rich dep report. |
| `curl \| sh` takes config via env vars, not flags | Stdin is consumed by curl; `curl ... \| sh -s -- --flag` works but is fragile. Env vars are POSIX-portable and obvious. |
| Bootstrap is POSIX `sh` (not bash) | Same as `bin/agent-guard` and `install.sh`. Runs anywhere `/bin/sh` exists, which is broader than bash. |

## Functional verification
- [x] `sh -n bootstrap.sh` — passes (added to the existing `tests/run.sh` syntax-check loop).
- [x] `tests/run.sh` — 102/0 passing (101 prior + 1 syntax test for bootstrap.sh).
- [x] Manual code review against `bin/agent-guard` for style consistency (`info`/`die` helpers, POSIX-only constructs, `set -eu` for one-shot scripts, trap-based tmp cleanup, parameter expansion conventions).
- [ ] **End-to-end install test deferred to next release dispatch** — the script hits real GitHub URLs that don't exist for this branch yet. The first post-merge release (e.g., `gh workflow run release.yml -f bump=minor`) will produce v1.1.0 (or v1.0.3) with `bootstrap.sh` attached, and a real `curl | sh` test against that asset will close the loop.

## Out-of-scope (tracked elsewhere)
- Plugin-native `/agent-guard:verify` slash command (mentioned in the README footnote from #12).
- Homebrew tap — deferred until adoption signals warrant the maintenance overhead of a separate tap repo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added one-line bootstrap installer for simplified setup with automatic latest-release resolution, checksum verification, and dependency checks.
  * Release workflow now includes bootstrap script as a published artifact.

* **Documentation**
  * Updated installation guide with new quick-install method; manual steps moved to collapsible section.

* **Tests**
  * Added bootstrap script validation to test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->