### PR TITLE
fix(release): exclude tarball self-reference from tar input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,7 +168,14 @@ jobs:
           git push origin "v${v}"
           git push origin "${maj}" --force
 
+          # Exclude the output tarball + its sha256 sidecar so tar does not
+          # detect "file changed as we read it" when its own output grows
+          # in the directory it is enumerating. This was a latent race that
+          # surfaced once bootstrap.sh added enough input to cross the
+          # detection threshold (release run 25510030204).
           tar --exclude='./.git' --exclude='./tests' \
+              --exclude="./agent-guard-${v}.tar.gz" \
+              --exclude="./agent-guard-${v}.tar.gz.sha256" \
               -czf "agent-guard-${v}.tar.gz" .
           sha256sum "agent-guard-${v}.tar.gz" > "agent-guard-${v}.tar.gz.sha256"
 


### PR DESCRIPTION
## Summary
Fix the `tar: .: file changed as we read it` race in `Tag and publish release` that broke v1.1.0 dispatch (run [25510030204](https://github.com/JeongJaeSoon/agent-guard/actions/runs/25510030204)).

## Root cause
`tar -czf "agent-guard-${v}.tar.gz" .` writes the output tarball into the same directory it is enumerating. tar opens the (empty) output file before walking the tree, includes that empty entry in its enumeration, and as the file grows during write, tar's per-file stat-check detects the size delta and exits 1.

This was latent in v1.0.0/v1.0.1/v1.0.2 dispatches — which got lucky on input volume vs. disk-flush timing — and surfaced once bootstrap.sh raised the input enough to push enumeration past the race threshold.

```
Updated tag 'v1' (was 0efb67d)
 * [new tag]         v1.1.0 -> v1.1.0
 + 0efb67d...c45e22f v1 -> v1 (forced update)
tar: .: file changed as we read it
##[error]Process completed with exit code 1.
```

## What changed
Add explicit `--exclude` entries for the tarball and its sidecar:

```yaml
tar --exclude='./.git' --exclude='./tests' \
    --exclude="./agent-guard-${v}.tar.gz" \
    --exclude="./agent-guard-${v}.tar.gz.sha256" \
    -czf "agent-guard-${v}.tar.gz" .
```

This removes them from the file enumeration entirely (they no longer participate in the in-progress write race), and is independently more correct — the tarball should not contain itself.

I considered writing the output to `/tmp` instead, but that's a bigger / more invasive change for the same effect.

## Functional verification
- [x] YAML diff is a 3-line addition with no structural changes (visually inspected, no quoting boundaries crossed).
- [ ] Real verification will be the next release dispatch on top of this commit. Plan after merge:
  1. `git push --delete origin v1.1.0` to clear the orphaned tag from the failed run.
  2. `gh workflow run release.yml -f bump=minor` to dispatch a fresh v1.1.0 release.
  3. `gh release view v1.1.0` to confirm the four assets are uploaded: `agent-guard-1.1.0.tar.gz`, `.sha256`, `install.sh`, `bootstrap.sh`.
  4. Smoke-test `curl -fsSL .../releases/latest/download/bootstrap.sh | sh` against a temp `AGENT_GUARD_HOME`.

## Out-of-scope
The release workflow currently fails non-idempotently if a tag already exists (`Guard against duplicate release` step). Making it idempotent (e.g., reuse the existing tag if it already points at the release branch's HEAD) is a follow-up worth tracking but not part of this hotfix — recovery from the failed v1.1.0 run is handled out-of-band via tag deletion as documented above.
