### PR TITLE
chore: revert v1.1.0 manifest bumps so a fresh v1.1.0 can be released

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
         "ref": "v1"
       },
       "description": "Deterministic secret-scanning guardrails for AI coding agents.",
-      "version": "1.1.0"
+      "version": "1.0.2"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-guard",
   "description": "Deterministic secret-scanning guardrails for AI coding agents, Git hooks, and GitHub Actions.",
-  "version": "1.1.0",
+  "version": "1.0.2",
   "hooks": "./hooks/hooks.json"
 }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-guard",
-  "version": "1.1.0",
+  "version": "1.0.2",
   "description": "Deterministic secret-scanning guardrails for AI coding agents, Git hooks, and GitHub Actions.",
   "author": {
     "name": "Agent Guard contributors"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,3 @@
-## v1.1.0 - 2026-05-07
-
-- feat(install): publish bootstrap.sh for one-line curl | sh CLI install (#14)
-- feat(setup): add agent-guard setup subcommand for opt-in dependency bootstrap (#13)
-- docs: restructure README into user-facing path and Reference/Development (#12)
-
 ## v1.0.2 - 2026-05-07
 
 - fix(release): pick latest semver tag, ignore moving major tag (#10)


### PR DESCRIPTION
## Summary
Reverts the v1.1.0 manifest bumps from #15 (commit `c45e22f`) so a fresh, complete v1.1.0 release can be produced on top of the tar self-reference fix from #16.

## Background
Release dispatch run [25510030204](https://github.com/JeongJaeSoon/agent-guard/actions/runs/25510030204) (bump=minor) failed at the **Tag and publish release** step due to the tar self-reference race fixed in #16. By the time it failed, it had already:

- merged the auto-generated release PR #15 (manifest bumps + CHANGELOG entry → main as `c45e22f`)
- pushed `v1.1.0` tag → `c45e22f`
- force-updated the moving `v1` tag → `c45e22f`

But it had NOT created the GitHub Release object or uploaded the assets — the release is half-published. End-users see v1.0.2 as the "Latest" release.

## Why revert instead of bump-to-v1.1.1?
We considered three recovery paths and picked the cleanest one (per the user's direction "버그 잇는 릴리즈는 제거하자"):

1. ❌ Skip ahead to v1.1.1 — leaves v1.1.0 as a phantom tag with no Release object visible on the GitHub Releases page; awkward narrative.
2. ❌ Make the workflow tag-idempotent — bigger change, deferred to a follow-up.
3. ✅ Roll back the manifest bumps + delete the orphan tag, then re-dispatch as v1.1.0.

Without this revert, a re-dispatch of `bump=minor` would compute next-version=1.1.0 but the manifests are already at 1.1.0 (from `c45e22f`), so the workflow's "Open release PR" step would fail with `no changes to commit - aborting`. Reverting puts manifests back at 1.0.2, restoring the workflow's invariant.

## What changed
This PR reverts these four files only:

```
.claude-plugin/marketplace.json  1.1.0 → 1.0.2
.claude-plugin/plugin.json       1.1.0 → 1.0.2
.codex-plugin/plugin.json        1.1.0 → 1.0.2
CHANGELOG.md                     drops the empty v1.1.0 entry
```

Crucially, this PR **does not** revert any feature commits — `bin/agent-guard setup` (#13), `bootstrap.sh` (#14), and the README restructure (#12) all remain on main. Only the version-tracking files are rolled back.

## Functional verification
- [x] `git show HEAD --stat` confirms only the four version-tracking files changed.
- [x] `jq -r '.version' .claude-plugin/plugin.json .codex-plugin/plugin.json` returns `1.0.2 / 1.0.2`.
- [x] `jq -r '.plugins[0].version' .claude-plugin/marketplace.json` returns `1.0.2`.
- [x] No code or doc files touched — features remain.

## Plan after merge
1. Delete origin `v1.1.0` tag (now-orphaned identifier; user authorized destructive op explicitly).
2. `gh workflow run release.yml -f bump=minor` to dispatch a fresh v1.1.0 release on top of the tar fix from #16. Expected outcome:
   - 4 release assets uploaded: `agent-guard-1.1.0.tar.gz`, `agent-guard-1.1.0.tar.gz.sha256`, `install.sh`, `bootstrap.sh`.
   - `v1` moving tag re-pointed to the new release commit.
3. Smoke-test `curl -fsSL .../releases/latest/download/bootstrap.sh | sh` against an isolated `AGENT_GUARD_HOME` to close the loop on the entire install-ergonomics series (#12 → #13 → #14 → #16 → this).
