### PR TITLE
fix(bootstrap): follow redirects when resolving latest version

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -30,8 +30,11 @@ require() {
 
 resolve_latest_version() {
   # GitHub redirects releases/latest -> releases/tag/vX.Y.Z. We follow the
-  # redirect and read the effective URL rather than parsing release notes.
-  url=$(curl -fsS -o /dev/null -w '%{url_effective}' \
+  # redirect (-L) and read the effective URL rather than parsing release
+  # notes. Without -L curl stops at the 302 and url_effective stays at the
+  # input URL, so the sed match fails and we die with "could not parse
+  # version" -- previously broke v1.1.0 installs.
+  url=$(curl -fsSL -o /dev/null -w '%{url_effective}' \
     "https://github.com/${REPO}/releases/latest") \
     || die "could not query latest release"
   v=$(printf '%s' "$url" | sed -n -E 's|.*/tag/v([0-9]+\.[0-9]+\.[0-9]+)$|\1|p')


### PR DESCRIPTION
## Summary
One-character fix: `curl -fsS` → `curl -fsSL` in `bootstrap.sh::resolve_latest_version()`. Adding `-L` makes curl follow GitHub's 302 redirect from `/releases/latest` to `/releases/tag/vX.Y.Z`, so the sed pattern that extracts the version actually has the right URL to match against.

## Root cause
Without `-L`, curl stops at the 302 and `%{url_effective}` reports the input URL unchanged. The sed pattern in `resolve_latest_version()` requires the `.../tag/vX.Y.Z` suffix to extract a version, so it produced an empty string and the script died with:

```
agent-guard-bootstrap: could not parse version from \
  https://github.com/JeongJaeSoon/agent-guard/releases/latest
```

This blocked every `curl | sh` install of v1.1.0 once the repository was made public. The bug was masked while the repo was private — anonymous curl got a 404 long before it reached the redirect-parsing line — but became the load-bearing failure as soon as the repo flipped public.

The other two curl calls in `bootstrap.sh` (the tarball download and the sha256 download) were already using `-fsSL`. Only `resolve_latest_version` was missing the `-L`. Plain typo-class regression.

## Why our tests didn't catch it
`tests/run.sh` uses `sh -n` to syntax-check `bootstrap.sh` and stops there. The script is intentionally runtime-only (it hits real GitHub release URLs), so the existing suite cannot reach `resolve_latest_version`'s actual network behavior. Adding a network test to the unit suite would be the wrong tradeoff — it would couple unit-test runs to GitHub availability and rate limits.

A better follow-up would be a `make smoke-bootstrap` target (or a separate workflow job) that spins up a temporary install dir and runs `curl | sh` end-to-end against the latest release, gated to run on demand. That's tracked separately from this hotfix.

## What changed
```diff
-  url=$(curl -fsS -o /dev/null -w '%{url_effective}' \
+  url=$(curl -fsSL -o /dev/null -w '%{url_effective}' \
     "https://github.com/${REPO}/releases/latest") \
```

Plus a comment explaining why `-L` is load-bearing here, naming the v1.1.0 incident so the next reader doesn't repeat the regression.

## Functional verification
- [x] `sh -n bootstrap.sh` clean.
- [x] Full `tests/run.sh` 102/0.
- [x] Diff is exactly `-fsS` → `-fsSL` plus a 5-line comment block.
- [ ] **End-to-end verification deferred to v1.1.1 release** — the published v1.1.0 bootstrap.sh asset still has the bug, so the verification path is: merge this → dispatch `release.yml -f bump=patch` → v1.1.1 publishes a corrected bootstrap.sh → smoke-test `curl -fsSL .../releases/latest/download/bootstrap.sh | sh`.

## Plan after merge
1. `gh workflow run release.yml -f bump=patch` to dispatch v1.1.1.
2. Watch run; expect green tag + publish (the tar self-reference fix from #16 is already in place).
3. `gh release view v1.1.1` confirms the new `bootstrap.sh` asset matches the corrected source.
4. End-user smoke test: `curl -fsSL .../releases/latest/download/bootstrap.sh | sh` — expect `target version v1.1.1`, then download/extract/symlink/setup output (no "could not parse version" abort).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the bootstrap installation script's version resolution when fetching the latest release from GitHub. The script now properly handles URL redirects, preventing installation failures for recent versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->