### PR TITLE
fix(release): build tarball outside the directory being archived

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,15 +168,18 @@ jobs:
           git push origin "v${v}"
           git push origin "${maj}" --force
 
-          # Exclude the output tarball + its sha256 sidecar so tar does not
-          # detect "file changed as we read it" when its own output grows
-          # in the directory it is enumerating. This was a latent race that
-          # surfaced once bootstrap.sh added enough input to cross the
-          # detection threshold (release run 25510030204).
+          # Build the tarball entirely outside the directory tar is enumerating.
+          # Excluding the output file alone is not enough: as the output grows
+          # it changes the enclosing '.' directory's mtime, and tar then reports
+          # "file changed as we read it" against '.' itself and exits 1. Run
+          # 25510030204 hit this for v1.1.0 (fixed once with --exclude in #16),
+          # and run 25511359582 hit it again for v1.1.1 -- proving --exclude
+          # only narrows the race rather than eliminating it. Writing to a
+          # temp dir and mv'ing the finished tarball back is bulletproof.
+          tarball_tmp=$(mktemp -d)/agent-guard-${v}.tar.gz
           tar --exclude='./.git' --exclude='./tests' \
-              --exclude="./agent-guard-${v}.tar.gz" \
-              --exclude="./agent-guard-${v}.tar.gz.sha256" \
-              -czf "agent-guard-${v}.tar.gz" .
+              -czf "$tarball_tmp" .
+          mv "$tarball_tmp" "agent-guard-${v}.tar.gz"
           sha256sum "agent-guard-${v}.tar.gz" > "agent-guard-${v}.tar.gz.sha256"
 
           gh release create "v${v}" \


### PR DESCRIPTION
## Summary
Build the release tarball in a temporary directory and `mv` it into place after `tar` finishes, eliminating the "file changed as we read it" race at the source. Sequel to #16.

## Why the previous fix wasn't enough
#16 added `--exclude="./agent-guard-${v}.tar.gz*"` so the output wouldn't be archived as content. That kept the *content* clean but did not solve the underlying problem: as `tar` writes the output file, the file grows inside the enclosing `.` directory, which changes `.`'s mtime, and `tar` reports `file changed as we read it` against `.` itself and exits 1.

This was probabilistic. The v1.1.0 dispatch ([run 25510475019](https://github.com/JeongJaeSoon/agent-guard/actions/runs/25510475019)) won the race. The v1.1.1 dispatch ([run 25511359582](https://github.com/JeongJaeSoon/agent-guard/actions/runs/25511359582)) on identical code lost it:

```
Updated tag 'v1' (was 9285f7f)
 * [new tag]         v1.1.1 -> v1.1.1
 + 9285f7f...68d4b87 v1 -> v1 (forced update)
tar: .: file changed as we read it
##[error]Process completed with exit code 1.
```

`--exclude` narrowed the window; it did not close it.

## Real fix
Build the tarball in `mktemp -d` and atomically `mv` it into the workspace once tar exits. tar then never writes to the directory it is enumerating, so the enclosing directory's mtime is stable for the whole archive operation.

```diff
-          tar --exclude='./.git' --exclude='./tests' \
-              --exclude="./agent-guard-${v}.tar.gz" \
-              --exclude="./agent-guard-${v}.tar.gz.sha256" \
-              -czf "agent-guard-${v}.tar.gz" .
+          tarball_tmp=$(mktemp -d)/agent-guard-${v}.tar.gz
+          tar --exclude='./.git' --exclude='./tests' \
+              -czf "$tarball_tmp" .
+          mv "$tarball_tmp" "agent-guard-${v}.tar.gz"
           sha256sum "agent-guard-${v}.tar.gz" > "agent-guard-${v}.tar.gz.sha256"
```

The two self-exclude entries are dropped — they are unnecessary once the output is no longer inside the input.

## Functional verification
- [x] YAML diff is structural-equivalent: same number of pipeline lines, same overall step shape.
- [x] `mv "$tarball_tmp" "agent-guard-${v}.tar.gz"` produces the same destination file the rest of the step expects (sha256sum + gh release create still reference the in-tree path).
- [x] `mktemp -d` is available on `ubuntu-latest` runners and produces a unique directory under `$TMPDIR` (tmpfs on Actions), so the move is also fast.
- [ ] **End-to-end verification deferred to v1.1.1 re-dispatch** — the half-released v1.1.1 needs to be rolled back and re-released on top of this fix. Plan in the next section.

## Plan after merge
1. Revert the v1.1.1 manifest bump commit (`68d4b87`) so manifests are back at 1.1.0 and the workflow's `Bump version in tracked files` step has something to do on re-dispatch — same recovery pattern used for v1.1.0 in #17.
2. Delete origin `v1.1.1` tag (orphaned identifier — destructive op, will request explicit user confirmation).
3. `gh workflow run release.yml -f bump=patch` to dispatch a fresh v1.1.1 release.
4. Smoke-test `curl -fsSL .../releases/latest/download/bootstrap.sh | sh` against an isolated `AGENT_GUARD_HOME` to verify both the redirect-follow fix from #19 and the tar-out-of-tree fix from this PR.

## Out-of-scope
The release workflow remains non-idempotent: a tag created before the publish step fails cannot be reused on retry, forcing the rollback dance. A follow-up should make the workflow idempotent (skip `git tag` if tag already at HEAD; reuse existing release object if present), but that is a larger change and not required for this hotfix.
