### PR TITLE
chore: revert v1.1.1 manifest bumps to enable fresh re-release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
         "ref": "v1"
       },
       "description": "Deterministic secret-scanning guardrails for AI coding agents.",
-      "version": "1.1.1"
+      "version": "1.1.0"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-guard",
   "description": "Deterministic secret-scanning guardrails for AI coding agents, Git hooks, and GitHub Actions.",
-  "version": "1.1.1",
+  "version": "1.1.0",
   "hooks": "./hooks/hooks.json"
 }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-guard",
-  "version": "1.1.1",
+  "version": "1.1.0",
   "description": "Deterministic secret-scanning guardrails for AI coding agents, Git hooks, and GitHub Actions.",
   "author": {
     "name": "Agent Guard contributors"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-## v1.1.1 - 2026-05-07
-
-- fix(bootstrap): follow redirects when resolving latest version (#19)
-
 ## v1.1.0 - 2026-05-07
 
 - Revert "chore(release): v1.1.0 (#15)" (#17)


### PR DESCRIPTION
Same recovery pattern as #17 (v1.1.0 rollback). The v1.1.1 dispatch failed at 'Tag and publish release' due to the tar race fixed in #21, leaving manifests bumped to 1.1.1 on main and an orphan v1.1.1 tag with no GitHub Release object. Reverting the manifest bump restores the workflow's invariant so a re-dispatch (after deleting the orphan tag) can produce a real v1.1.1 release with assets.