### PR TITLE
fix(release): bump VERSION constant in bin/agent-guard on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,10 @@ jobs:
           fi
           # Replace any pinned semver in README install snippets (no-op if none).
           sed -i -E "s|agent-guard@[0-9]+\.[0-9]+\.[0-9]+|agent-guard@${v}|g" README.md
+          # Bump the VERSION constant the CLI reports via 'agent-guard version'.
+          # Without this the binary ships a stale literal even after a tag bump
+          # (v1.1.1 shipped with VERSION=1.0.0 because this step was missing).
+          sed -i -E "s|^VERSION=[0-9]+\.[0-9]+\.[0-9]+$|VERSION=${v}|" bin/agent-guard
 
       - name: Build CHANGELOG entry
         run: |


### PR DESCRIPTION
## Summary

Add one `sed` line to the `Bump version in tracked files` step in `release.yml` so the `VERSION=` literal in `bin/agent-guard` is updated every release. Without it, `agent-guard version` always reported `1.0.0` regardless of which release was installed.

## Root cause

The existing step bumped:
- `.claude-plugin/plugin.json`
- `.codex-plugin/plugin.json`
- `.claude-plugin/marketplace.json`
- `README.md` (pinned `agent-guard@X.Y.Z` snippets)

But `bin/agent-guard:5` (`VERSION=1.0.0`) was never included. Discovered after v1.1.1 shipped: the binary reported `agent-guard 1.0.0` even though the tarball was built from the v1.1.1 tag.

## What changed

```diff
+          # Bump the VERSION constant the CLI reports via 'agent-guard version'.
+          # Without this the binary ships a stale literal even after a tag bump
+          # (v1.1.1 shipped with VERSION=1.0.0 because this step was missing).
+          sed -i -E "s|^VERSION=[0-9]+\.[0-9]+\.[0-9]+$|VERSION=${v}|" bin/agent-guard
```

The pattern anchors on `^` and `$` so it only matches the bare literal assignment, not a dynamic expression. If the assignment form ever changes, the sed is a silent no-op — the next `agent-guard version` output will make it obvious.

## Functional verification

- [x] Sed pattern simulated locally: `VERSION=1.0.0` → `VERSION=1.1.2` (diff shows only line 5 changed, nothing else)
- [x] YAML syntax validated: `ruby -ryaml` exits 0
- [x] Full test suite green: 102 passed / 0 failed
- [ ] End-to-end: dispatch `release.yml -f bump=patch` after merge → v1.1.2 → `agent-guard version` returns `agent-guard 1.1.2`