### PR TITLE
feat(plugin): add /agent-guard:verify slash command

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,15 +86,15 @@ The right verification depends on the channel you used.
 
 | Channel | How to verify |
 |---|---|
-| Claude Code | `/plugin list` should show `agent-guard`. To smoke-test the hook, ask the agent to read a deny-listed file (e.g. "read `.env`") — the agent should be blocked with `blocked sensitive file access: .env`. |
-| Codex | Same shape as Claude Code; the agent should be blocked when asked to read `.env`. |
+| Claude Code | `/plugin list` should show `agent-guard`. Run `/agent-guard:verify` for a one-shot scan of the working tree, or smoke-test the hook by asking the agent to read a deny-listed file (e.g. "read `.env`") — the agent should be blocked with `blocked sensitive file access: .env`. |
+| Codex | Same shape as Claude Code; the agent should be blocked when asked to read `.env`. The `/agent-guard:verify` slash command is Claude Code-only at present; Codex users should fall back to running `agent-guard scan-working-tree` directly. |
 | GitHub Actions | The action runs on PR/push. A workflow run that reports either "no findings" (clean repo) or a deliberate finding (PR you crafted with a fake high-entropy secret) confirms the channel is wired. |
 | Direct CLI install | `agent-guard check` for a strict pass/fail; `agent-guard setup` for a per-dependency status report (and install hints if anything is missing). |
 | Cloned repo | `./install.sh check` or `make check` from the repo root. |
 
 Both `agent-guard check` and `./install.sh check` print the resolved `gitleaks` version alongside the dependency check.
 
-> The plugin channels currently rely on triggering the hook to verify. A future plugin-native slash command (`/agent-guard:verify`) will provide a one-step check directly inside Claude Code / Codex; tracked separately from this restructure.
+> Claude Code users can also run `/agent-guard:verify` for a one-step working-tree scan without crafting a hook trigger. See [Plugin slash commands](#plugin-slash-commands) under Reference for the full mapping.
 
 ## How it works
 
@@ -238,6 +238,16 @@ bin/agent-guard version
 ```
 
 `setup` is the dependency bootstrap entry point. By default it only reports status and prints install hints. Pass `--install --gitleaks-checksum SHA [--gitleaks-version X.Y.Z]` to actually download `gitleaks` into `~/.agent-guard/bin/`. The checksum is required (no implicit fetch) and must match the value published in the gitleaks release's `gitleaks_X.Y.Z_checksums.txt`. `jq` is never auto-installed — `setup` prints the appropriate package-manager command for your OS instead, since `jq` belongs with the system package manager.
+
+### Plugin slash commands
+
+Available inside Claude Code when `agent-guard` is installed as a plugin (auto-discovered from `commands/`).
+
+| Command | What it does |
+|---|---|
+| `/agent-guard:verify` | One-shot deterministic secret scan over the working tree (staged + unstaged + untracked), backed by the same gitleaks rules the hooks use. Reports clean tree silently; reports leaks with file paths and rule names if any are found. |
+
+Codex parity is **not implemented yet** — Codex's slash command convention differs from Claude Code's auto-discovered `commands/` layout, so the same source file does not light up there. Codex users running `agent-guard scan-working-tree` from a shell get the equivalent result.
 
 ### Hook entry points
 

--- a/commands/verify.md
+++ b/commands/verify.md
@@ -1,0 +1,21 @@
+---
+allowed-tools: Bash
+description: Run a deterministic one-shot secret scan over the current working tree (staged + unstaged + untracked). Use to confirm "is the current state safe to commit?" without going through hook triggers.
+---
+
+# /agent-guard:verify
+
+One-shot secret scan over everything currently on disk: staged changes, unstaged changes, and untracked files. Backed by the bundled gitleaks rule set the agent-guard hooks already use, so a clean verify here implies the same thing the hooks would say at commit time.
+
+## Run
+
+!`"${CLAUDE_PLUGIN_ROOT:-.}/bin/agent-guard" scan-working-tree`
+
+## Interpretation
+
+- **Exit 0, no output beyond the gitleaks summary** → no secrets detected. Tell the user the working tree is clean and stop.
+- **Non-zero exit with `agent-guard:` lines** → leaks were flagged. Report the exact file paths and rule names gitleaks emitted, verbatim. Do not propose fixes unless the user asks.
+- **`required command not found: gitleaks`** → suggest `agent-guard setup --install --gitleaks-checksum <SHA>` and stop.
+- **`gitleaks config not found`** → the plugin install is incomplete; suggest reinstalling via `curl -fsSL https://github.com/JeongJaeSoon/agent-guard/releases/latest/download/bootstrap.sh | sh`.
+
+Stay terse: the scan output is the answer. Avoid restating what gitleaks already printed.


### PR DESCRIPTION
## Summary

Add a Claude Code plugin-native slash command (`/agent-guard:verify`) that runs `scan-working-tree` in one shot. Closes the long-standing footnote in README ('future plugin-native slash command will provide a one-step check').

## Why

Until now, the only way to verify the current working tree from inside Claude Code was to craft a hook trigger (e.g. ask the agent to read `.env`) or drop to a shell and run `agent-guard scan-working-tree` manually. Neither is ergonomic. A slash command surfaces the same scan one keystroke away.

## What's new

### `commands/verify.md` (new file)

```yaml
---
allowed-tools: Bash
description: Run a deterministic one-shot secret scan over the current working tree...
---
```

Auto-discovered by Claude Code's plugin loader from the `commands/` directory next to `.claude-plugin/` — no `plugin.json` entry needed (matches the convention used by every plugin under `~/.claude/plugins/cache/`).

The body of the command shells out to:
```sh
"${CLAUDE_PLUGIN_ROOT:-.}/bin/agent-guard" scan-working-tree
```
the same code path `hook-stop` already uses for end-of-turn verification, so a clean verify here means exactly the same thing the hooks would say at commit time.

### README updates

- **Verify-your-install table**: Claude Code row now mentions `/agent-guard:verify` alongside the 'ask the agent to read .env' smoke test. Codex row notes parity is not yet available.
- **Footnote**: 'A future plugin-native slash command will...' replaced by a forward pointer to the new Reference subsection.
- **Reference / Plugin slash commands** (new subsection): documents the command and explicitly notes Codex is not yet supported (different slash command convention).

## Codex parity (deferred)

Codex's slash command discovery convention is not the same as Claude Code's auto-discovered `commands/` directory, so this single source file does not light up there. README explicitly tells Codex users to fall back to `agent-guard scan-working-tree` from a shell. Codex parity is tracked as a separate follow-up.

## Functional verification

- [x] Frontmatter YAML validates (`ruby -ryaml` parses the `---` block cleanly)
- [x] Test suite green: 102 / 0
- [x] No changes to bin/agent-guard, hooks, or tests — purely additive: 1 new file + 3 README hunks
- [ ] **End-to-end Claude Code invocation deferred** — verifying `/agent-guard:verify` actually fires inside Claude Code requires the plugin to be installed from a git ref that includes this commit. Will validate after the next release (v1.1.2 will be the first ref with the command included).