### PR TITLE
docs: restructure README around user task flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ help:
 	@printf '  make test          Run the test suite (uses a mock gitleaks).\n'
 	@printf '  make scan          Scan the working tree for secrets.\n'
 	@printf '  make scan-staged   Scan staged changes only.\n'
-	@printf '  make checksum [VERSION=X.Y.Z]   Fetch the gitleaks-checksum to pin in CI.\n'
+	@printf '  make checksum [VERSION=X.Y.Z]   Fetch gitleaks-checksum for every supported OS/arch (CI typically picks linux/x64).\n'
 
 check:
 	@./install.sh check

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Agent Guard inserts deterministic secret-scanning checks into AI coding agent hooks, native Git hooks, and GitHub Actions.
 
-It is intentionally small. It does not teach agents how to behave, manage vaults, rotate credentials, verify live credentials, produce dashboards, or replace GitHub Secret Scanning and Push Protection.
+It is a thin layer — not a vault, not a credential rotator, not a replacement for GitHub Secret Scanning and Push Protection.
 
 ## Quickstart
 
@@ -10,7 +10,7 @@ Pick the channel matching your environment. All commands resolve to the same rel
 
 ### Prerequisites
 
-`sh`, `git`, `jq`, and [`gitleaks`](https://github.com/gitleaks/gitleaks) (>= 8.30 recommended) on macOS or Linux. No Python, Node, npm hook manager, Docker, or other runtime is required. If `gitleaks` is missing, the first hook invocation will fail with a clear error.
+`sh`, `git`, `jq`, and [`gitleaks`](https://github.com/gitleaks/gitleaks) (>= 8.30 recommended) on macOS or Linux.
 
 ### Claude Code
 
@@ -34,9 +34,7 @@ Pick the channel matching your environment. All commands resolve to the same rel
     gitleaks-checksum: "<sha256 of the gitleaks release archive>"
 ```
 
-`@v1` is a moving major tag — patch and minor releases are picked up automatically with no workflow edit. To upgrade across a major (`v1` → `v2`), bump the tag explicitly. Pin to a full commit SHA for high-security environments.
-
-The `gitleaks-checksum` is integrity metadata, not a credential — commit it directly to your workflow file. Storing it as a GitHub Secret would hide the audit trail without adding security: the value is the public SHA-256 of a public release archive, and the whole point of pinning is that reviewers can see *what* you are pinning to.
+`@v1` is a moving major tag — patch and minor releases are picked up automatically. The `gitleaks-checksum` input is required by default; pin a known-good sha256 from `gitleaks_${version}_checksums.txt`. Set `require-checksum: "false"` for local experimentation only. For high-security CI, also pin Agent Guard to a full commit SHA.
 
 ### Direct CLI install (no clone)
 
@@ -44,28 +42,9 @@ The `gitleaks-checksum` is integrity metadata, not a credential — commit it di
 curl -fsSL https://github.com/JeongJaeSoon/agent-guard/releases/latest/download/bootstrap.sh | sh
 ```
 
-The bootstrap script:
+The bootstrap script downloads the latest release, verifies its sha256, extracts to `~/.agent-guard`, symlinks `~/.local/bin/agent-guard`, and runs `agent-guard setup` to report dependency status. Override with `AGENT_GUARD_VERSION`, `AGENT_GUARD_HOME`, or `AGENT_GUARD_BIN_DIR`.
 
-- resolves the latest release version via the GitHub `releases/latest` redirect (override with `AGENT_GUARD_VERSION=1.2.3`),
-- downloads `agent-guard-X.Y.Z.tar.gz` and the published `.sha256`, verifies the checksum, and extracts to `~/.agent-guard` (override with `AGENT_GUARD_HOME`),
-- symlinks `~/.local/bin/agent-guard` (override with `AGENT_GUARD_BIN_DIR`),
-- runs `agent-guard setup` so you immediately see per-dependency status and any install hints.
-
-`agent-guard setup` is opt-in: it does *not* install anything by default. If `gitleaks` is missing, it prints the exact `--install` command (which requires `--gitleaks-checksum SHA` from the published gitleaks release). `jq` is left to your system package manager — `setup` prints the appropriate `brew`/`apt-get`/`dnf` command for your OS.
-
-<details>
-<summary>Manual equivalent (no <code>curl | sh</code>)</summary>
-
-```sh
-mkdir -p ~/.agent-guard && cd ~/.agent-guard
-gh release download --repo JeongJaeSoon/agent-guard --pattern '*.tar.gz' --pattern '*.sha256'
-shasum -a 256 -c agent-guard-*.tar.gz.sha256
-tar -xzf agent-guard-*.tar.gz
-ln -sf "$PWD/bin/agent-guard" ~/.local/bin/agent-guard
-agent-guard setup
-```
-
-</details>
+`agent-guard setup` is opt-in: it never installs anything by default. If `gitleaks` is missing it prints the exact `--install` command (which requires `--gitleaks-checksum SHA`). `jq` is left to your system package manager — `setup` prints the appropriate `brew`/`apt-get`/`dnf` command for your OS.
 
 ### Native Git hook
 
@@ -78,7 +57,7 @@ cd <your-project>
 ./install.sh git-hooks
 ```
 
-See [Native Git hook](#native-git-hook) under Advanced setup for behavior around existing `core.hooksPath` setups.
+The installer sets `core.hooksPath=githooks` only when it will not overwrite an existing hook setup. Agent Guard does not require Husky, npm, or another hook manager.
 
 ### Verify your install
 
@@ -86,21 +65,17 @@ The right verification depends on the channel you used.
 
 | Channel | How to verify |
 |---|---|
-| Claude Code | `/plugin list` should show `agent-guard`. Run `/agent-guard:verify` for a one-shot scan of the working tree, or smoke-test the hook by asking the agent to read a deny-listed file (e.g. "read `.env`") — the agent should be blocked with `blocked sensitive file access: .env`. |
-| Codex | Same shape as Claude Code; the agent should be blocked when asked to read `.env`. The `/agent-guard:verify` slash command is Claude Code-only at present; Codex users should fall back to running `agent-guard scan-working-tree` directly. |
-| GitHub Actions | The action runs on PR/push. A workflow run that reports either "no findings" (clean repo) or a deliberate finding (PR you crafted with a fake high-entropy secret) confirms the channel is wired. |
-| Direct CLI install | `agent-guard check` for a strict pass/fail; `agent-guard setup` for a per-dependency status report (and install hints if anything is missing). |
-| Cloned repo | `./install.sh check` or `make check` from the repo root. |
-
-Both `agent-guard check` and `./install.sh check` print the resolved `gitleaks` version alongside the dependency check.
-
-> Claude Code users can also run `/agent-guard:verify` for a one-step working-tree scan without crafting a hook trigger. See [Plugin slash commands](#plugin-slash-commands) under Reference for the full mapping.
+| Claude Code | `/plugin list` should show `agent-guard`. Run `/agent-guard:verify` for a one-shot working-tree scan, or smoke-test the hook by asking the agent to read a deny-listed file (e.g. "read `.env`") — it should be blocked with `blocked sensitive file access: .env`. |
+| Codex | Smoke-test by asking the agent to read `.env`; it should be blocked. (`/agent-guard:verify` is Claude Code only — fall back to `agent-guard scan-working-tree` directly.) |
+| GitHub Actions | The action runs on PR/push. A run that reports either "no findings" or a deliberate finding (PR you crafted with a fake high-entropy secret) confirms the channel is wired. |
+| Direct CLI install | `agent-guard check` for a strict pass/fail; `agent-guard setup` for a per-dependency status report. |
+| Cloned repo | `./install.sh check` or `make check`. |
 
 ## How it works
 
 ### Channels
 
-Agent Guard offers four independent integration points. Pick whichever match your workflow — they do **not** chain. Each row lists what that channel alone can and cannot block.
+Agent Guard offers four independent integration points. Pick whichever matches your workflow — they do **not** chain. Each row lists what that channel alone can and cannot block.
 
 | Channel | What it blocks | What it cannot see |
 |---|---|---|
@@ -109,124 +84,32 @@ Agent Guard offers four independent integration points. Pick whichever match you
 | GitHub Action | Secrets in any tracked file on a PR/push. | Anything that already merged before the workflow ran. |
 | Direct CLI (`bin/agent-guard scan-*`) | Whatever you point it at, on demand. | Anything outside the invocation. |
 
-Defense-in-depth is best, but a single channel still meaningfully reduces risk. The agent-hook channel is the only one that can stop a leak **before** the secret leaves the host.
-
 ### What it checks
 
 - Proposed writes from `Write`, `Edit`, `MultiEdit`, and Codex `apply_patch`
 - Sensitive read/search paths such as `.env*`, private keys, `.aws/credentials`, `.npmrc`, `.pypirc`
-- Obvious risky shell commands such as `cat .env`, `printenv`, `op read`, `vault kv get`, `aws secretsmanager get-secret-value`
+- Risky shell commands such as `cat .env`, `printenv`, `op read`, `vault kv get`, `aws secretsmanager get-secret-value`
 - MCP tool input JSON
 - Staged added lines for `pre-commit`
 - Working tree added lines and untracked file content after agent mutations
 
-Patch and diff scans inspect added lines only so removing an existing leaked value is not blocked by the deleted line.
+Patch and diff scans inspect added lines only — removing an existing leaked value is not blocked by the deleted line.
 
-Detection sensitivity is bounded by the rules and allowlists shipped with the `gitleaks` binary on your machine. Short or context-free secret strings that the upstream ruleset does not recognise will pass — Agent Guard layers on top of, not in place of, GitHub Secret Scanning and Push Protection. Keep `gitleaks` up to date.
+Detection is bounded by the rules in your `gitleaks` binary, so keep it up to date. Agent Guard layers on top of, not in place of, GitHub Secret Scanning and Push Protection.
 
-## Advanced setup
+## Configuration
 
-### Claude Code
+Override the bundled policies via environment variables:
 
-As a plugin, Agent Guard loads `.claude-plugin/plugin.json`, which points at `./hooks/hooks.json`.
-
-For local testing, adapt `examples/claude/settings.project.json` and replace `/absolute/path/to/agent-guard` with this repository path.
-
-For marketplace distribution, `.claude-plugin/marketplace.json` points at `JeongJaeSoon/agent-guard` by default. Update the `owner` field with your publisher info before publishing.
-
-### Codex
-
-Codex loads `.codex-plugin/plugin.json`, which points at `./hooks/hooks.json`.
-
-For local testing, use `examples/codex/hooks.json`. Update the `author` field in `.codex-plugin/plugin.json` with your publisher info before publishing.
-
-The hook contract has been cross-checked against `openai/codex` schemas at `codex-rs/hooks/schema/generated/pre-tool-use.command.input.schema.json` and `codex-rs/config/src/hook_config.rs`: top-level event keys are PascalCase (`PreToolUse`, `PostToolUse`, `Stop`), the handler shape is `{ "type": "command", "command": ..., "timeout": <seconds> }`, and stdin payload keys are snake_case (`tool_name`, `tool_input`, ...). `exit 2` with a reason on stderr is Codex's documented blocking path.
-
-#### Hook tool name coverage in Codex
-
-Codex registers a much smaller set of hook-visible tools than Claude Code. Source of truth: `codex-rs/core/src/tools/hook_names.rs`.
-
-| Hook `tool_name` | Codex source | Matcher aliases |
-|---|---|---|
-| `Bash` | `shell.rs`, `unified_exec.rs`, `local_shell.rs`, `shell_command.rs`, `sandboxing.rs` | (none) |
-| `apply_patch` | `apply_patch.rs` (handler + runtime) | `Write`, `Edit` |
-| (MCP tool's display name) | `mcp.rs`, `mcp_tool_call.rs` | (none) |
-
-Agent Guard's matcher (`Write|Edit|MultiEdit|Read|NotebookRead|Grep|Glob|Bash|apply_patch|mcp__.*`) is a Claude Code-shaped superset. In Codex, `MultiEdit`, `Read`, `NotebookRead`, `Grep`, and `Glob` are silently no-ops because Codex has no tool registered under those names — they remain in the matcher only for Claude Code coverage. The genuinely active surface in Codex is therefore `Write`/`Edit` (via the `apply_patch` alias), `Bash`, `apply_patch`, and any `mcp__*` tool.
-
-If a Codex agent tries to read a deny-listed file like `.env`, the read still has to happen through the shell (`cat .env`, `head .env`, redirects, command substitution, …), so the `Bash` matcher and `config/deny-bash-patterns.txt` close that path even though Codex lacks a dedicated `Read` tool.
-
-#### Verifying the example configs
-
-Both example configs drive the same `bin/agent-guard` entry points. To smoke-test them locally:
-
-```sh
-# Claude — substitute the absolute path, then drive a deny-listed read.
-CLAUDE_CMD=$(sed "s#/absolute/path/to/agent-guard#$PWD#g" \
-  examples/claude/settings.project.json \
-  | jq -r '.hooks.PreToolUse[0].hooks[0].command')
-printf '%s' '{"tool_name":"Read","tool_input":{"file_path":".env"}}' \
-  | sh -c "$CLAUDE_CMD"
-# expect: exit 2, "blocked sensitive file access: .env"
-
-# Codex — relative command, run from the repo root.
-CODEX_CMD=$(jq -r '.hooks.PreToolUse[0].hooks[0].command' \
-  examples/codex/hooks.json)
-printf '%s' '{"tool_name":"Read","tool_input":{"file_path":".env"}}' \
-  | sh -c "$CODEX_CMD"
-# expect: exit 2, "blocked sensitive file access: .env"
-```
-
-### GitHub Actions
-
-The root `action.yml` lets consumers use the repository directly:
-
-```yaml
-- uses: JeongJaeSoon/agent-guard@v1
-  with:
-    paths: "."
-    gitleaks-checksum: "<sha256 of the gitleaks release archive>"
-```
-
-The `gitleaks-checksum` input is required by default. Pin a known-good sha256 for the `gitleaks-version` you select — this stops a compromised release URL from injecting a malicious binary into your CI runner.
-
-To opt out (local experimentation only) set `require-checksum: "false"`. Do not do this in production CI.
-
-For high-security environments, also pin Agent Guard to a full commit SHA instead of the moving `@v1` tag.
-
-### Native Git hook
-
-Agent Guard uses native Git hooks. It does not require Husky, npm, or another hook manager.
-
-```sh
-./install.sh git-hooks
-```
-
-The installer sets `core.hooksPath=githooks` only when it will not overwrite an existing hook setup.
-
-### Configuration
-
-Agent Guard always passes the bundled `config/gitleaks.toml` unless you explicitly override it:
-
-```sh
-AGENT_GUARD_GITLEAKS_CONFIG=/path/to/gitleaks.toml bin/agent-guard scan-path .
-```
-
-Policy files:
-
-- `config/gitleaks.toml`
-- `config/deny-read-paths.txt`
-- `config/deny-bash-patterns.txt`
-
-The bundled deny-read policy is conservative, including local credential files such as `.env*`, SSH keys/config, cloud CLI credentials, and certificate bundles. If your workflow needs a different read policy, point `AGENT_GUARD_DENY_READ_PATHS` at your own deny-list file.
+- `AGENT_GUARD_GITLEAKS_CONFIG` — gitleaks rules (default: `config/gitleaks.toml`)
+- `AGENT_GUARD_DENY_READ_PATHS` — deny-list for `Read`/`NotebookRead`/`Grep`/`Glob` (default: `config/deny-read-paths.txt`)
+- `AGENT_GUARD_DENY_BASH_PATTERNS` — deny-list for `Bash` (default: `config/deny-bash-patterns.txt`)
 
 Project-local `.gitleaks.toml` files are not automatically trusted.
 
 ## Reference
 
 ### CLI subcommands
-
-User-callable commands, used by Git hooks, GitHub Actions, and manual checks:
 
 ```sh
 bin/agent-guard scan-staged
@@ -237,17 +120,13 @@ bin/agent-guard setup        # report dependency status; --install opts in to gi
 bin/agent-guard version
 ```
 
-`setup` is the dependency bootstrap entry point. By default it only reports status and prints install hints. Pass `--install --gitleaks-checksum SHA [--gitleaks-version X.Y.Z]` to actually download `gitleaks` into `~/.agent-guard/bin/`. The checksum is required (no implicit fetch) and must match the value published in the gitleaks release's `gitleaks_X.Y.Z_checksums.txt`. `jq` is never auto-installed — `setup` prints the appropriate package-manager command for your OS instead, since `jq` belongs with the system package manager.
+`setup` is the dependency bootstrap entry point. By default it only reports status. Pass `--install --gitleaks-checksum SHA [--gitleaks-version X.Y.Z]` to download `gitleaks` into `~/.agent-guard/bin/`; the checksum must match the value published at `https://github.com/gitleaks/gitleaks/releases/download/vX.Y.Z/gitleaks_X.Y.Z_checksums.txt`. `jq` is never auto-installed.
 
 ### Plugin slash commands
 
-Available inside Claude Code when `agent-guard` is installed as a plugin (auto-discovered from `commands/`).
-
 | Command | What it does |
 |---|---|
-| `/agent-guard:verify` | One-shot deterministic secret scan over the working tree (staged + unstaged + untracked), backed by the same gitleaks rules the hooks use. Reports clean tree silently; reports leaks with file paths and rule names if any are found. |
-
-Codex parity is **not implemented yet** — Codex's slash command convention differs from Claude Code's auto-discovered `commands/` layout, so the same source file does not light up there. Codex users running `agent-guard scan-working-tree` from a shell get the equivalent result.
+| `/agent-guard:verify` | One-shot deterministic secret scan over the working tree (staged + unstaged + untracked). Claude Code only. |
 
 ### Hook entry points
 
@@ -267,10 +146,6 @@ bin/agent-guard hook-stop
 
 ## Development
 
-### Make targets
-
-A thin `Makefile` is provided as a discoverability layer over the same scripts:
-
 ```sh
 make help          # one-screen index of every target
 make check         # ./install.sh check
@@ -281,12 +156,4 @@ make scan-staged   # bin/agent-guard scan-staged
 make checksum      # how to pin a gitleaks-checksum for CI
 ```
 
-`make` does not introduce orchestration logic; targets pass through to `install.sh` and `bin/agent-guard`.
-
-### Tests
-
-```sh
-tests/run.sh
-```
-
-The default test suite uses a mock `gitleaks` to validate routing and policy behavior without downloading dependencies. If real `gitleaks` is installed, direct manual scans can be run with `bin/agent-guard scan-path .`.
+Run `tests/run.sh` for the test suite — it uses a mock `gitleaks` to validate routing without downloading dependencies. With real `gitleaks` installed, `bin/agent-guard scan-path .` does a full scan.

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Equivalent surfaces — pick whichever matches your channel:
 | Codex plugin | Ask Codex to run `${CODEX_PLUGIN_ROOT}/bin/agent-guard checksum [VERSION]` (no automatic slash command) |
 | Direct CLI install / Native hook (binary on PATH) | `agent-guard checksum [VERSION]` |
 | Clone of this repo | `make checksum [VERSION=X.Y.Z]` or `scripts/gitleaks-checksum.sh [VERSION]` |
-| Nothing installed yet (e.g. preparing a GitHub Actions workflow) | `curl -fsSL https://raw.githubusercontent.com/JeongJaeSoon/agent-guard/v1/scripts/gitleaks-checksum.sh \| sh` (pin to `v1.1.2` or a full SHA for stricter reproducibility) |
+| Nothing installed yet (e.g. preparing a GitHub Actions workflow) | `curl -fsSL https://raw.githubusercontent.com/JeongJaeSoon/agent-guard/v1/scripts/gitleaks-checksum.sh \| sh` (`v1` is the moving major tag — substitute a full commit SHA or a specific minor-version tag for stricter reproducibility) |
 
 ### Without `agent-guard` on disk (Claude Code / Codex plugin only)
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Pick one or more — they don't chain. Each row lists what that channel alone ca
 /plugin install agent-guard@latest
 ```
 
-Restart your Claude Code session (or run `/plugin reload` if available) so the hooks load.
+Run `/reload-plugins` (or restart your Claude Code session) so the hooks load.
 
 ### Codex
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It is a thin layer — not a vault, not a credential rotator, not a replacement 
 - [Channels](#channels) — pick which integration(s) to use
 - [Quick start (Claude Code)](#quick-start-claude-code) — 3 commands, ~1 minute
 - [Install other channels](#install-other-channels) — Codex, GitHub Actions, Direct CLI, Native Git hook
-- [Dependencies & setup](#dependencies--setup) — check `jq` / `gitleaks`, auto-install, troubleshoot
+- [Dependencies & setup](#dependencies--setup) — check `jq` / `gitleaks`, auto-install, fetch a `gitleaks-checksum`
 - [Verify the install](#verify-the-install)
 - [What it catches](#what-it-catches)
 - [Configuration](#configuration)
@@ -80,7 +80,12 @@ Restart Codex so the hooks load.
     gitleaks-checksum: "<sha256 of the gitleaks release archive>"
 ```
 
-`@v1` follows minor and patch releases automatically. Pin `gitleaks-checksum` from the published `gitleaks_${version}_checksums.txt`. Use `require-checksum: "false"` only for local experimentation. For high-security CI, also pin Agent Guard to a full commit SHA.
+**Pinning options for `@v1`:**
+- `@v1` — moving major tag, picks up minor / patch releases automatically (recommended default)
+- `@v1.1.2` — pin to a specific release for fully reproducible CI
+- `@<full-commit-sha>` — pin to a commit for the strictest security posture
+
+**Filling in `gitleaks-checksum`:** run [`agent-guard checksum [VERSION]`](#fetching-a-gitleaks-checksum) (or [`/agent-guard:checksum`](#slash-commands) inside Claude Code) — it prints the value pre-formatted for paste. Use `require-checksum: "false"` only for local experimentation; never in production CI.
 
 ### Direct CLI install (no clone)
 
@@ -122,7 +127,37 @@ agent-guard setup --install \
   [--gitleaks-version 8.30.1]
 ```
 
-The checksum is required — fetch it from `https://github.com/gitleaks/gitleaks/releases/download/v${version}/gitleaks_${version}_checksums.txt`. `jq` is never auto-installed; `setup` prints the right `brew` / `apt-get` / `dnf` command for your OS.
+The checksum is required. The fastest way to get it: run [`agent-guard checksum [VERSION]`](#fetching-a-gitleaks-checksum) — it auto-detects your OS / arch and prints the right value, formatted for both `--gitleaks-checksum` (CLI) and `gitleaks-checksum:` (GitHub Actions YAML).
+
+`jq` is never auto-installed; `setup` prints the right `brew` / `apt-get` / `dnf` command for your OS.
+
+### Fetching a `gitleaks-checksum`
+
+Looking up the right sha256 by hand is the most common chore around dependency setup. The bundled helper does it for you:
+
+```sh
+agent-guard checksum             # uses the version pinned in action.yml (8.30.1)
+agent-guard checksum 8.30.0      # specific version
+```
+
+Output (paste-ready):
+
+```
+gitleaks v8.30.1 — darwin/arm64
+
+sha256: <hex>
+
+GitHub Actions workflow:
+  gitleaks-checksum: "<hex>"
+
+agent-guard setup CLI:
+  agent-guard setup --install --gitleaks-checksum <hex> --gitleaks-version 8.30.1
+```
+
+Equivalent surfaces:
+- `/agent-guard:checksum [VERSION]` — Claude Code slash command (calls the same script under the plugin path)
+- `make checksum [VERSION=X.Y.Z]` — from a clone
+- `scripts/gitleaks-checksum.sh [VERSION]` — direct script invocation
 
 ### Without `agent-guard` on disk (Claude Code / Codex plugin only)
 
@@ -134,7 +169,7 @@ The plugin install does not place a binary on the filesystem — install depende
 | Debian / Ubuntu | `sudo apt-get install -y jq` &nbsp;+ download `gitleaks` from its [releases page](https://github.com/gitleaks/gitleaks/releases) |
 | Fedora | `sudo dnf install -y jq` &nbsp;+ download `gitleaks` from its [releases page](https://github.com/gitleaks/gitleaks/releases) |
 
-After dependencies are in place, run `/reload-plugins` in Claude Code (or restart Codex) and re-run the smoke test.
+After dependencies are in place, run `/reload-plugins` in Claude Code (or restart Codex) and re-run the smoke test. Plugin users can still reach the [`/agent-guard:checksum`](#fetching-a-gitleaks-checksum) helper from inside their session — no PATH binary required.
 
 ## Verify the install
 
@@ -175,8 +210,9 @@ Project-local `.gitleaks.toml` files are not automatically trusted.
 bin/agent-guard scan-staged
 bin/agent-guard scan-working-tree
 bin/agent-guard scan-path PATH...
-bin/agent-guard check        # dependency / gitleaks version check
-bin/agent-guard setup        # report dependency status; --install opts in to gitleaks download
+bin/agent-guard check              # dependency / gitleaks version check
+bin/agent-guard setup              # report dependency status; --install opts in to gitleaks download
+bin/agent-guard checksum [VERSION] # fetch the gitleaks-checksum for your OS/arch
 bin/agent-guard version
 ```
 
@@ -185,6 +221,7 @@ bin/agent-guard version
 | Command | What it does |
 |---|---|
 | `/agent-guard:verify` | One-shot deterministic secret scan over the working tree (staged + unstaged + untracked). Claude Code only. |
+| `/agent-guard:checksum [VERSION]` | Fetch the gitleaks release sha256 for your OS / arch and emit paste-ready snippets for both GitHub Actions YAML and `agent-guard setup --install`. Claude Code only. |
 
 ### Exit codes
 
@@ -203,7 +240,7 @@ make install       # ./install.sh git-hooks
 make test          # tests/run.sh
 make scan          # bin/agent-guard scan-working-tree
 make scan-staged   # bin/agent-guard scan-staged
-make checksum      # how to pin a gitleaks-checksum for CI
+make checksum      # fetch the gitleaks-checksum for your OS/arch (override with VERSION=X.Y.Z)
 ```
 
 `tests/run.sh` uses a mock `gitleaks` to validate routing without downloading dependencies. With real `gitleaks` installed, `bin/agent-guard scan-path .` does a full scan.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ That's it. From here, every `Read`, `Write`, `Edit`, `Bash`, and MCP tool call g
 /plugin install JeongJaeSoon/agent-guard@latest
 ```
 
-Restart Codex so the hooks load.
+Restart Codex so the hooks load. Codex does not auto-discover the `commands/` directory, so `/agent-guard:checksum` and `/agent-guard:verify` are not available — ask Codex to run `${CODEX_PLUGIN_ROOT}/bin/agent-guard checksum` (or `scan-working-tree`) directly when you need them.
 
 ### GitHub Actions
 
@@ -85,7 +85,20 @@ Restart Codex so the hooks load.
 - `@v1.1.2` — pin to a specific release for fully reproducible CI
 - `@<full-commit-sha>` — pin to a commit for the strictest security posture
 
-**Filling in `gitleaks-checksum`:** run [`agent-guard checksum [VERSION]`](#fetching-a-gitleaks-checksum) (or [`/agent-guard:checksum`](#slash-commands) inside Claude Code) — it prints the value pre-formatted for paste. Use `require-checksum: "false"` only for local experimentation; never in production CI.
+**Filling in `gitleaks-checksum`:** the helper prints the linux/x64 value pre-formatted for paste. Pick the path that matches what you have on hand:
+
+```sh
+# (a) inside Claude Code (after plugin install)
+/agent-guard:checksum
+
+# (b) with agent-guard on disk (Direct CLI install or clone)
+agent-guard checksum
+
+# (c) no install — one-liner suitable for adoption-time:
+curl -fsSL https://raw.githubusercontent.com/JeongJaeSoon/agent-guard/v1/scripts/gitleaks-checksum.sh | sh
+```
+
+Use `require-checksum: "false"` only for local experimentation; never in production CI.
 
 ### Direct CLI install (no clone)
 
@@ -127,13 +140,13 @@ agent-guard setup --install \
   [--gitleaks-version 8.30.1]
 ```
 
-The checksum is required. The fastest way to get it: run [`agent-guard checksum [VERSION]`](#fetching-a-gitleaks-checksum) — it auto-detects your OS / arch and prints the right value, formatted for both `--gitleaks-checksum` (CLI) and `gitleaks-checksum:` (GitHub Actions YAML).
+The checksum is required. The fastest way to get it: run [`agent-guard checksum [VERSION]`](#fetching-a-gitleaks-checksum) — it prints every supported OS / arch with paste-ready snippets for both `--gitleaks-checksum` (CLI) and `gitleaks-checksum:` (GitHub Actions YAML).
 
 `jq` is never auto-installed; `setup` prints the right `brew` / `apt-get` / `dnf` command for your OS.
 
 ### Fetching a `gitleaks-checksum`
 
-Looking up the right sha256 by hand is the most common chore around dependency setup. The bundled helper does it for you:
+Looking up the right sha256 by hand is the most common chore around dependency setup. The bundled helper does it for you and prints every supported platform — so the value is correct regardless of where you run it from (e.g. on macOS for a Linux CI runner).
 
 ```sh
 agent-guard checksum             # uses the version pinned in action.yml (8.30.1)
@@ -143,21 +156,29 @@ agent-guard checksum 8.30.0      # specific version
 Output (paste-ready):
 
 ```
-gitleaks v8.30.1 — darwin/arm64
+gitleaks v8.30.1 — sha256 by OS/arch
 
-sha256: <hex>
+  darwin/arm64: <hex-a>   <- this machine
+  darwin/x64:   <hex-b>
+  linux/arm64:  <hex-c>
+  linux/x64:    <hex-d>
 
-GitHub Actions workflow:
-  gitleaks-checksum: "<hex>"
+GitHub Actions workflow (CI runners are typically linux/x64):
+  gitleaks-checksum: "<hex-d>"
 
-agent-guard setup CLI:
-  agent-guard setup --install --gitleaks-checksum <hex> --gitleaks-version 8.30.1
+agent-guard setup CLI (this machine: darwin/arm64):
+  agent-guard setup --install --gitleaks-checksum <hex-a> --gitleaks-version 8.30.1
 ```
 
-Equivalent surfaces:
-- `/agent-guard:checksum [VERSION]` — Claude Code slash command (calls the same script under the plugin path)
-- `make checksum [VERSION=X.Y.Z]` — from a clone
-- `scripts/gitleaks-checksum.sh [VERSION]` — direct script invocation
+Equivalent surfaces — pick whichever matches your channel:
+
+| You have | How to invoke |
+|---|---|
+| Claude Code plugin | `/agent-guard:checksum [VERSION]` (slash command, calls the same script under the plugin path) |
+| Codex plugin | Ask Codex to run `${CODEX_PLUGIN_ROOT}/bin/agent-guard checksum [VERSION]` (no automatic slash command) |
+| Direct CLI install / Native hook (binary on PATH) | `agent-guard checksum [VERSION]` |
+| Clone of this repo | `make checksum [VERSION=X.Y.Z]` or `scripts/gitleaks-checksum.sh [VERSION]` |
+| Nothing installed yet (e.g. preparing a GitHub Actions workflow) | `curl -fsSL https://raw.githubusercontent.com/JeongJaeSoon/agent-guard/v1/scripts/gitleaks-checksum.sh \| sh` (pin to `v1.1.2` or a full SHA for stricter reproducibility) |
 
 ### Without `agent-guard` on disk (Claude Code / Codex plugin only)
 
@@ -169,7 +190,7 @@ The plugin install does not place a binary on the filesystem — install depende
 | Debian / Ubuntu | `sudo apt-get install -y jq` &nbsp;+ download `gitleaks` from its [releases page](https://github.com/gitleaks/gitleaks/releases) |
 | Fedora | `sudo dnf install -y jq` &nbsp;+ download `gitleaks` from its [releases page](https://github.com/gitleaks/gitleaks/releases) |
 
-After dependencies are in place, run `/reload-plugins` in Claude Code (or restart Codex) and re-run the smoke test. Plugin users can still reach the [`/agent-guard:checksum`](#fetching-a-gitleaks-checksum) helper from inside their session — no PATH binary required.
+After dependencies are in place, run `/reload-plugins` in Claude Code (or restart Codex) and re-run the smoke test. Plugin users can still reach the [`gitleaks-checksum` helper](#fetching-a-gitleaks-checksum) from inside their session — no PATH binary required (Claude Code: `/agent-guard:checksum`; Codex: ask the agent to run `${CODEX_PLUGIN_ROOT}/bin/agent-guard checksum`).
 
 ## Verify the install
 
@@ -212,7 +233,7 @@ bin/agent-guard scan-working-tree
 bin/agent-guard scan-path PATH...
 bin/agent-guard check              # dependency / gitleaks version check
 bin/agent-guard setup              # report dependency status; --install opts in to gitleaks download
-bin/agent-guard checksum [VERSION] # fetch the gitleaks-checksum for your OS/arch
+bin/agent-guard checksum [VERSION] # fetch the gitleaks-checksum for every supported OS/arch
 bin/agent-guard version
 ```
 
@@ -221,7 +242,7 @@ bin/agent-guard version
 | Command | What it does |
 |---|---|
 | `/agent-guard:verify` | One-shot deterministic secret scan over the working tree (staged + unstaged + untracked). Claude Code only. |
-| `/agent-guard:checksum [VERSION]` | Fetch the gitleaks release sha256 for your OS / arch and emit paste-ready snippets for both GitHub Actions YAML and `agent-guard setup --install`. Claude Code only. |
+| `/agent-guard:checksum [VERSION]` | Fetch the gitleaks release sha256 for every supported OS / arch and emit paste-ready snippets for both GitHub Actions YAML and `agent-guard setup --install`. Claude Code only — Codex / GitHub Action / no-install paths are listed in [Fetching a gitleaks-checksum](#fetching-a-gitleaks-checksum). |
 
 ### Exit codes
 
@@ -240,7 +261,7 @@ make install       # ./install.sh git-hooks
 make test          # tests/run.sh
 make scan          # bin/agent-guard scan-working-tree
 make scan-staged   # bin/agent-guard scan-staged
-make checksum      # fetch the gitleaks-checksum for your OS/arch (override with VERSION=X.Y.Z)
+make checksum      # fetch the gitleaks-checksum for every supported OS/arch (override with VERSION=X.Y.Z)
 ```
 
 `tests/run.sh` uses a mock `gitleaks` to validate routing without downloading dependencies. With real `gitleaks` installed, `bin/agent-guard scan-path .` does a full scan.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,31 @@
 # Agent Guard
 
-Agent Guard inserts deterministic secret-scanning checks into AI coding agent hooks, native Git hooks, and GitHub Actions.
+[![Release](https://img.shields.io/github/v/release/JeongJaeSoon/agent-guard)](https://github.com/JeongJaeSoon/agent-guard/releases)
+[![CI](https://github.com/JeongJaeSoon/agent-guard/actions/workflows/ci.yml/badge.svg)](https://github.com/JeongJaeSoon/agent-guard/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
+> Deterministic secret-scanning guardrails for AI coding agents, native Git hooks, and GitHub Actions.
+
+Agent Guard intercepts AI coding agents (Claude Code, Codex) before they read sensitive files, propose writes containing secrets, or run risky shell commands — and re-scans the working tree after every change. Backed by [gitleaks](https://github.com/gitleaks/gitleaks); no Python, Node, Docker, or vault account required.
+
+```text
+> Please read .env to set up the project
+
+agent-guard: blocked sensitive file access: .env
+```
 
 It is a thin layer — not a vault, not a credential rotator, not a replacement for GitHub Secret Scanning and Push Protection.
 
 ## Contents
 
-- [Channels](#channels) — pick which one(s) to use
-- [Install](#install) — Claude Code, Codex, GitHub Actions, Direct CLI, Native Git hook
-- [Verify](#verify-your-install)
+- [Channels](#channels) — pick which integration(s) to use
+- [Quick start (Claude Code)](#quick-start-claude-code) — 3 commands, ~1 minute
+- [Install other channels](#install-other-channels) — Codex, GitHub Actions, Direct CLI, Native Git hook
+- [Dependencies & setup](#dependencies--setup) — check `jq` / `gitleaks`, auto-install, troubleshoot
+- [Verify the install](#verify-the-install)
 - [What it catches](#what-it-catches)
 - [Configuration](#configuration)
-- [Reference](#reference) — CLI subcommands, slash commands, exit codes
+- [Reference](#reference)
 - [Development](#development)
 
 ## Channels
@@ -25,18 +39,29 @@ Pick one or more — they don't chain. Each row lists what that channel alone ca
 | GitHub Action | Secrets in any tracked file on a PR/push. | Anything that already merged before the workflow ran. |
 | Direct CLI (`bin/agent-guard scan-*`) | Whatever you point it at, on demand. | Anything outside the invocation. |
 
-## Install
+## Quick start (Claude Code)
 
-**Prerequisites**: `sh`, `git`, `jq`, [`gitleaks`](https://github.com/gitleaks/gitleaks) (>= 8.30 recommended) on macOS or Linux.
+**Prerequisites**: `git`, `jq`, `gitleaks` (>= 8.30 recommended) on macOS or Linux. Missing something? Jump to [Dependencies & setup](#dependencies--setup) — `agent-guard setup` will tell you exactly what to install.
 
-### Claude Code
+1. **Install the plugin and reload**:
 
-```text
-/plugin marketplace add JeongJaeSoon/agent-guard
-/plugin install agent-guard@latest
-```
+   ```text
+   /plugin marketplace add JeongJaeSoon/agent-guard
+   /plugin install agent-guard@latest
+   /reload-plugins
+   ```
 
-Run `/reload-plugins` (or restart your Claude Code session) so the hooks load.
+2. **Smoke-test** by asking the agent to read `.env`. The hook should block it:
+
+   ```text
+   agent-guard: blocked sensitive file access: .env
+   ```
+
+   If the read goes through silently, see [Dependencies & setup](#dependencies--setup) — `gitleaks` is most likely missing.
+
+That's it. From here, every `Read`, `Write`, `Edit`, `Bash`, and MCP tool call goes through the guard.
+
+## Install other channels
 
 ### Codex
 
@@ -65,8 +90,6 @@ curl -fsSL https://github.com/JeongJaeSoon/agent-guard/releases/latest/download/
 
 The script downloads the latest release, verifies its sha256, extracts to `~/.agent-guard`, symlinks `~/.local/bin/agent-guard`, and runs `agent-guard setup` to report dependency status. Override with `AGENT_GUARD_VERSION`, `AGENT_GUARD_HOME`, or `AGENT_GUARD_BIN_DIR`.
 
-`agent-guard setup` is opt-in: nothing is installed by default. If `gitleaks` is missing it prints the exact `--install` command (which requires `--gitleaks-checksum SHA`). `jq` is left to your system package manager.
-
 ### Native Git hook
 
 Requires `agent-guard` on disk. The Claude Code / Codex plugin install does **not** place a binary on the filesystem, so use Direct CLI install or a clone first:
@@ -80,14 +103,47 @@ cd <your-project>
 
 Sets `core.hooksPath=githooks` only when it will not overwrite an existing setup. No Husky / npm hook manager required.
 
-## Verify your install
+## Dependencies & setup
+
+Agent Guard requires `sh`, `git`, `jq`, and `gitleaks` (>= 8.30 recommended) on macOS or Linux. The right setup path depends on whether you have the `agent-guard` binary on disk.
+
+### With `agent-guard` on disk (Direct CLI install or clone)
+
+```sh
+agent-guard check       # strict pass/fail (exit 2 if anything is missing)
+agent-guard setup       # per-dependency status with install hints
+```
+
+`agent-guard setup` is opt-in: by default it only reports status, never installs. To download `gitleaks` automatically with checksum verification:
+
+```sh
+agent-guard setup --install \
+  --gitleaks-checksum <sha256-from-published-checksums.txt> \
+  [--gitleaks-version 8.30.1]
+```
+
+The checksum is required — fetch it from `https://github.com/gitleaks/gitleaks/releases/download/v${version}/gitleaks_${version}_checksums.txt`. `jq` is never auto-installed; `setup` prints the right `brew` / `apt-get` / `dnf` command for your OS.
+
+### Without `agent-guard` on disk (Claude Code / Codex plugin only)
+
+The plugin install does not place a binary on the filesystem — install dependencies with your package manager:
+
+| OS | Command |
+|---|---|
+| macOS | `brew install jq gitleaks` |
+| Debian / Ubuntu | `sudo apt-get install -y jq` &nbsp;+ download `gitleaks` from its [releases page](https://github.com/gitleaks/gitleaks/releases) |
+| Fedora | `sudo dnf install -y jq` &nbsp;+ download `gitleaks` from its [releases page](https://github.com/gitleaks/gitleaks/releases) |
+
+After dependencies are in place, run `/reload-plugins` in Claude Code (or restart Codex) and re-run the smoke test.
+
+## Verify the install
 
 | Channel | How to verify |
 |---|---|
-| Claude Code | `/plugin list` should show `agent-guard`. Run `/agent-guard:verify` for a one-shot working-tree scan, or smoke-test the hook by asking the agent to read a deny-listed file (e.g. "read `.env`") — it should be blocked with `blocked sensitive file access: .env`. |
+| Claude Code | `/plugin list` should show `agent-guard`. Run `/agent-guard:verify` for a one-shot working-tree scan, or smoke-test the hook by asking the agent to read `.env` (should be blocked with `blocked sensitive file access: .env`). |
 | Codex | Smoke-test by asking the agent to read `.env`; it should be blocked. (`/agent-guard:verify` is Claude Code only — fall back to `agent-guard scan-working-tree` directly.) |
-| GitHub Actions | A workflow run reporting either "no findings" or a deliberate finding (PR you crafted with a fake high-entropy secret) confirms the channel is wired. |
-| Direct CLI install | `agent-guard check` for a strict pass/fail; `agent-guard setup` for a per-dependency status report. |
+| GitHub Actions | A workflow run reporting either "no findings" or a deliberate finding (PR you crafted with a fake high-entropy secret) confirms it. |
+| Direct CLI install | `agent-guard check` for a strict pass/fail. |
 | Cloned repo | `./install.sh check` or `make check`. |
 
 ## What it catches
@@ -106,7 +162,7 @@ Patch and diff scans inspect added lines only — removing an existing leaked va
 Override the bundled policies via environment variables:
 
 - `AGENT_GUARD_GITLEAKS_CONFIG` — gitleaks rules (default: `config/gitleaks.toml`)
-- `AGENT_GUARD_DENY_READ_PATHS` — deny-list for `Read`/`NotebookRead`/`Grep`/`Glob` (default: `config/deny-read-paths.txt`)
+- `AGENT_GUARD_DENY_READ_PATHS` — deny-list for `Read` / `NotebookRead` / `Grep` / `Glob` (default: `config/deny-read-paths.txt`)
 - `AGENT_GUARD_DENY_BASH_PATTERNS` — deny-list for `Bash` (default: `config/deny-bash-patterns.txt`)
 
 Project-local `.gitleaks.toml` files are not automatically trusted.
@@ -124,8 +180,6 @@ bin/agent-guard setup        # report dependency status; --install opts in to gi
 bin/agent-guard version
 ```
 
-`setup --install --gitleaks-checksum SHA [--gitleaks-version X.Y.Z]` downloads `gitleaks` to `~/.agent-guard/bin/`. The checksum must match the published value at `https://github.com/gitleaks/gitleaks/releases/download/vX.Y.Z/gitleaks_X.Y.Z_checksums.txt`. `jq` is never auto-installed.
-
 ### Slash commands
 
 | Command | What it does |
@@ -134,9 +188,9 @@ bin/agent-guard version
 
 ### Exit codes
 
-- `0`: clean / allow
-- `1`: findings (direct scan commands)
-- `2`: block agent hook action or signal usage / dependency failure
+- `0` — clean / allow
+- `1` — findings (direct scan commands)
+- `2` — block agent hook action or signal usage / dependency failure
 
 (Hook entry points `hook-pre-tool`, `hook-post-tool`, and `hook-stop` are invoked by Claude Code, Codex, or Git via `hooks/hooks.json` — not by users directly.)
 
@@ -152,4 +206,4 @@ make scan-staged   # bin/agent-guard scan-staged
 make checksum      # how to pin a gitleaks-checksum for CI
 ```
 
-Run `tests/run.sh` for the test suite — it uses a mock `gitleaks` to validate routing without downloading dependencies. With real `gitleaks` installed, `bin/agent-guard scan-path .` does a full scan.
+`tests/run.sh` uses a mock `gitleaks` to validate routing without downloading dependencies. With real `gitleaks` installed, `bin/agent-guard scan-path .` does a full scan.

--- a/README.md
+++ b/README.md
@@ -80,10 +80,7 @@ Restart Codex so the hooks load. Codex does not auto-discover the `commands/` di
     gitleaks-checksum: "<sha256 of the gitleaks release archive>"
 ```
 
-**Pinning options for `@v1`:**
-- `@v1` — moving major tag, picks up minor / patch releases automatically (recommended default)
-- `@v1.1.2` — pin to a specific release for fully reproducible CI
-- `@<full-commit-sha>` — pin to a commit for the strictest security posture
+> Use `@v1` for auto-updates, or pin to a tag (`@v1.2.3`) or commit SHA for reproducibility.
 
 **Filling in `gitleaks-checksum`:** the helper prints the linux/x64 value pre-formatted for paste. Pick the path that matches what you have on hand:
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ agent-guard checksum 8.30.0      # specific version
 
 Output (paste-ready):
 
-```
+```text
 gitleaks v8.30.1 — sha256 by OS/arch
 
   darwin/arm64: <hex-a>   <- this machine

--- a/README.md
+++ b/README.md
@@ -82,20 +82,7 @@ Restart Codex so the hooks load. Codex does not auto-discover the `commands/` di
 
 > Use `@v1` for auto-updates, or pin to a tag (`@v1.2.3`) or commit SHA for reproducibility.
 
-**Filling in `gitleaks-checksum`:** the helper prints the linux/x64 value pre-formatted for paste. Pick the path that matches what you have on hand:
-
-```sh
-# (a) inside Claude Code (after plugin install)
-/agent-guard:checksum
-
-# (b) with agent-guard on disk (Direct CLI install or clone)
-agent-guard checksum
-
-# (c) no install — one-liner suitable for adoption-time:
-curl -fsSL https://raw.githubusercontent.com/JeongJaeSoon/agent-guard/v1/scripts/gitleaks-checksum.sh | sh
-```
-
-Use `require-checksum: "false"` only for local experimentation; never in production CI.
+Run [`agent-guard checksum`](#fetching-a-gitleaks-checksum) to fill in `gitleaks-checksum`. Use `require-checksum: "false"` only for local experimentation; never in production CI.
 
 ### Direct CLI install (no clone)
 
@@ -175,7 +162,7 @@ Equivalent surfaces — pick whichever matches your channel:
 | Codex plugin | Ask Codex to run `${CODEX_PLUGIN_ROOT}/bin/agent-guard checksum [VERSION]` (no automatic slash command) |
 | Direct CLI install / Native hook (binary on PATH) | `agent-guard checksum [VERSION]` |
 | Clone of this repo | `make checksum [VERSION=X.Y.Z]` or `scripts/gitleaks-checksum.sh [VERSION]` |
-| Nothing installed yet (e.g. preparing a GitHub Actions workflow) | `curl -fsSL https://raw.githubusercontent.com/JeongJaeSoon/agent-guard/v1/scripts/gitleaks-checksum.sh \| sh` (`v1` is the moving major tag — substitute a full commit SHA or a specific minor-version tag for stricter reproducibility) |
+| Nothing installed yet (e.g. preparing a GitHub Actions workflow) | `curl -fsSL https://raw.githubusercontent.com/JeongJaeSoon/agent-guard/v1/scripts/gitleaks-checksum.sh \| sh` |
 
 ### Without `agent-guard` on disk (Claude Code / Codex plugin only)
 
@@ -187,7 +174,7 @@ The plugin install does not place a binary on the filesystem — install depende
 | Debian / Ubuntu | `sudo apt-get install -y jq` &nbsp;+ download `gitleaks` from its [releases page](https://github.com/gitleaks/gitleaks/releases) |
 | Fedora | `sudo dnf install -y jq` &nbsp;+ download `gitleaks` from its [releases page](https://github.com/gitleaks/gitleaks/releases) |
 
-After dependencies are in place, run `/reload-plugins` in Claude Code (or restart Codex) and re-run the smoke test. Plugin users can still reach the [`gitleaks-checksum` helper](#fetching-a-gitleaks-checksum) from inside their session — no PATH binary required (Claude Code: `/agent-guard:checksum`; Codex: ask the agent to run `${CODEX_PLUGIN_ROOT}/bin/agent-guard checksum`).
+After installing dependencies, reload the plugin (Claude Code: `/reload-plugins`; Codex: restart) and re-run the smoke test.
 
 ## Verify the install
 
@@ -240,14 +227,6 @@ bin/agent-guard version
 |---|---|
 | `/agent-guard:verify` | One-shot deterministic secret scan over the working tree (staged + unstaged + untracked). Claude Code only. |
 | `/agent-guard:checksum [VERSION]` | Fetch the gitleaks release sha256 for every supported OS / arch and emit paste-ready snippets for both GitHub Actions YAML and `agent-guard setup --install`. Claude Code only — Codex / GitHub Action / no-install paths are listed in [Fetching a gitleaks-checksum](#fetching-a-gitleaks-checksum). |
-
-### Exit codes
-
-- `0` — clean / allow
-- `1` — findings (direct scan commands)
-- `2` — block agent hook action or signal usage / dependency failure
-
-(Hook entry points `hook-pre-tool`, `hook-post-tool`, and `hook-stop` are invoked by Claude Code, Codex, or Git via `hooks/hooks.json` — not by users directly.)
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,30 @@ Agent Guard inserts deterministic secret-scanning checks into AI coding agent ho
 
 It is a thin layer — not a vault, not a credential rotator, not a replacement for GitHub Secret Scanning and Push Protection.
 
-## Quickstart
+## Contents
 
-Pick the channel matching your environment. All commands resolve to the same released version.
+- [Channels](#channels) — pick which one(s) to use
+- [Install](#install) — Claude Code, Codex, GitHub Actions, Direct CLI, Native Git hook
+- [Verify](#verify-your-install)
+- [What it catches](#what-it-catches)
+- [Configuration](#configuration)
+- [Reference](#reference) — CLI subcommands, slash commands, exit codes
+- [Development](#development)
 
-### Prerequisites
+## Channels
 
-`sh`, `git`, `jq`, and [`gitleaks`](https://github.com/gitleaks/gitleaks) (>= 8.30 recommended) on macOS or Linux.
+Pick one or more — they don't chain. Each row lists what that channel alone can and cannot block.
+
+| Channel | What it blocks | What it cannot see |
+|---|---|---|
+| Agent hook (Claude Code / Codex) | Pre-tool: deny-listed reads (`.env`, `id_rsa`, …), risky shell idioms, secrets in proposed `Write`/`Edit`/`apply_patch`, secrets in MCP tool input. Post-tool & Stop: secrets in working-tree diff & untracked files. | Edits the user makes by hand outside the agent session. |
+| Native Git pre-commit hook | Secrets in staged added lines at commit time. | Reads the agent performed earlier; commits made with `--no-verify`. |
+| GitHub Action | Secrets in any tracked file on a PR/push. | Anything that already merged before the workflow ran. |
+| Direct CLI (`bin/agent-guard scan-*`) | Whatever you point it at, on demand. | Anything outside the invocation. |
+
+## Install
+
+**Prerequisites**: `sh`, `git`, `jq`, [`gitleaks`](https://github.com/gitleaks/gitleaks) (>= 8.30 recommended) on macOS or Linux.
 
 ### Claude Code
 
@@ -19,11 +36,15 @@ Pick the channel matching your environment. All commands resolve to the same rel
 /plugin install agent-guard@latest
 ```
 
+Restart your Claude Code session (or run `/plugin reload` if available) so the hooks load.
+
 ### Codex
 
 ```text
 /plugin install JeongJaeSoon/agent-guard@latest
 ```
+
+Restart Codex so the hooks load.
 
 ### GitHub Actions
 
@@ -34,7 +55,7 @@ Pick the channel matching your environment. All commands resolve to the same rel
     gitleaks-checksum: "<sha256 of the gitleaks release archive>"
 ```
 
-`@v1` is a moving major tag — patch and minor releases are picked up automatically. The `gitleaks-checksum` input is required by default; pin a known-good sha256 from `gitleaks_${version}_checksums.txt`. Set `require-checksum: "false"` for local experimentation only. For high-security CI, also pin Agent Guard to a full commit SHA.
+`@v1` follows minor and patch releases automatically. Pin `gitleaks-checksum` from the published `gitleaks_${version}_checksums.txt`. Use `require-checksum: "false"` only for local experimentation. For high-security CI, also pin Agent Guard to a full commit SHA.
 
 ### Direct CLI install (no clone)
 
@@ -42,13 +63,13 @@ Pick the channel matching your environment. All commands resolve to the same rel
 curl -fsSL https://github.com/JeongJaeSoon/agent-guard/releases/latest/download/bootstrap.sh | sh
 ```
 
-The bootstrap script downloads the latest release, verifies its sha256, extracts to `~/.agent-guard`, symlinks `~/.local/bin/agent-guard`, and runs `agent-guard setup` to report dependency status. Override with `AGENT_GUARD_VERSION`, `AGENT_GUARD_HOME`, or `AGENT_GUARD_BIN_DIR`.
+The script downloads the latest release, verifies its sha256, extracts to `~/.agent-guard`, symlinks `~/.local/bin/agent-guard`, and runs `agent-guard setup` to report dependency status. Override with `AGENT_GUARD_VERSION`, `AGENT_GUARD_HOME`, or `AGENT_GUARD_BIN_DIR`.
 
-`agent-guard setup` is opt-in: it never installs anything by default. If `gitleaks` is missing it prints the exact `--install` command (which requires `--gitleaks-checksum SHA`). `jq` is left to your system package manager — `setup` prints the appropriate `brew`/`apt-get`/`dnf` command for your OS.
+`agent-guard setup` is opt-in: nothing is installed by default. If `gitleaks` is missing it prints the exact `--install` command (which requires `--gitleaks-checksum SHA`). `jq` is left to your system package manager.
 
 ### Native Git hook
 
-Adding the native Git hook channel requires `agent-guard` on disk. The Claude Code / Codex plugin install does **not** place a binary on the filesystem, so use Direct CLI install or a clone first:
+Requires `agent-guard` on disk. The Claude Code / Codex plugin install does **not** place a binary on the filesystem, so use Direct CLI install or a clone first:
 
 ```sh
 cd <your-project>
@@ -57,45 +78,28 @@ cd <your-project>
 ./install.sh git-hooks
 ```
 
-The installer sets `core.hooksPath=githooks` only when it will not overwrite an existing hook setup. Agent Guard does not require Husky, npm, or another hook manager.
+Sets `core.hooksPath=githooks` only when it will not overwrite an existing setup. No Husky / npm hook manager required.
 
-### Verify your install
-
-The right verification depends on the channel you used.
+## Verify your install
 
 | Channel | How to verify |
 |---|---|
 | Claude Code | `/plugin list` should show `agent-guard`. Run `/agent-guard:verify` for a one-shot working-tree scan, or smoke-test the hook by asking the agent to read a deny-listed file (e.g. "read `.env`") — it should be blocked with `blocked sensitive file access: .env`. |
 | Codex | Smoke-test by asking the agent to read `.env`; it should be blocked. (`/agent-guard:verify` is Claude Code only — fall back to `agent-guard scan-working-tree` directly.) |
-| GitHub Actions | The action runs on PR/push. A run that reports either "no findings" or a deliberate finding (PR you crafted with a fake high-entropy secret) confirms the channel is wired. |
+| GitHub Actions | A workflow run reporting either "no findings" or a deliberate finding (PR you crafted with a fake high-entropy secret) confirms the channel is wired. |
 | Direct CLI install | `agent-guard check` for a strict pass/fail; `agent-guard setup` for a per-dependency status report. |
 | Cloned repo | `./install.sh check` or `make check`. |
 
-## How it works
-
-### Channels
-
-Agent Guard offers four independent integration points. Pick whichever matches your workflow — they do **not** chain. Each row lists what that channel alone can and cannot block.
-
-| Channel | What it blocks | What it cannot see |
-|---|---|---|
-| Agent hook (Claude Code / Codex) | Pre-tool: deny-listed reads (`.env`, `id_rsa`, …), risky shell idioms, secrets in proposed `Write`/`Edit`/`apply_patch`, secrets in MCP tool input. Post-tool & Stop: secrets in working-tree diff & untracked files. | Edits the user makes by hand outside the agent session. |
-| Native Git pre-commit hook | Secrets in staged added lines at commit time. | Reads the agent performed earlier; commits made with `--no-verify`. |
-| GitHub Action | Secrets in any tracked file on a PR/push. | Anything that already merged before the workflow ran. |
-| Direct CLI (`bin/agent-guard scan-*`) | Whatever you point it at, on demand. | Anything outside the invocation. |
-
-### What it checks
+## What it catches
 
 - Proposed writes from `Write`, `Edit`, `MultiEdit`, and Codex `apply_patch`
-- Sensitive read/search paths such as `.env*`, private keys, `.aws/credentials`, `.npmrc`, `.pypirc`
-- Risky shell commands such as `cat .env`, `printenv`, `op read`, `vault kv get`, `aws secretsmanager get-secret-value`
+- Sensitive read/search paths: `.env*`, private keys, `.aws/credentials`, `.npmrc`, `.pypirc`
+- Risky shell commands: `printenv`, `op read`, `vault kv get`, `aws secretsmanager get-secret-value` (path-referencing forms like `cat .env` are blocked via the deny-read paths)
 - MCP tool input JSON
 - Staged added lines for `pre-commit`
 - Working tree added lines and untracked file content after agent mutations
 
-Patch and diff scans inspect added lines only — removing an existing leaked value is not blocked by the deleted line.
-
-Detection is bounded by the rules in your `gitleaks` binary, so keep it up to date. Agent Guard layers on top of, not in place of, GitHub Secret Scanning and Push Protection.
+Patch and diff scans inspect added lines only — removing an existing leaked value is not blocked. Detection is bounded by the rules in your `gitleaks` binary; keep it up to date. Agent Guard layers on top of, not in place of, GitHub Secret Scanning and Push Protection.
 
 ## Configuration
 
@@ -120,29 +124,21 @@ bin/agent-guard setup        # report dependency status; --install opts in to gi
 bin/agent-guard version
 ```
 
-`setup` is the dependency bootstrap entry point. By default it only reports status. Pass `--install --gitleaks-checksum SHA [--gitleaks-version X.Y.Z]` to download `gitleaks` into `~/.agent-guard/bin/`; the checksum must match the value published at `https://github.com/gitleaks/gitleaks/releases/download/vX.Y.Z/gitleaks_X.Y.Z_checksums.txt`. `jq` is never auto-installed.
+`setup --install --gitleaks-checksum SHA [--gitleaks-version X.Y.Z]` downloads `gitleaks` to `~/.agent-guard/bin/`. The checksum must match the published value at `https://github.com/gitleaks/gitleaks/releases/download/vX.Y.Z/gitleaks_X.Y.Z_checksums.txt`. `jq` is never auto-installed.
 
-### Plugin slash commands
+### Slash commands
 
 | Command | What it does |
 |---|---|
 | `/agent-guard:verify` | One-shot deterministic secret scan over the working tree (staged + unstaged + untracked). Claude Code only. |
 
-### Hook entry points
-
-Called by Claude Code, Codex, or Git — not by users directly. Each reads hook JSON from stdin:
-
-```sh
-bin/agent-guard hook-pre-tool
-bin/agent-guard hook-post-tool
-bin/agent-guard hook-stop
-```
-
 ### Exit codes
 
 - `0`: clean / allow
-- `1`: findings for direct scan commands
-- `2`: block an agent hook action or signal usage/dependency failure
+- `1`: findings (direct scan commands)
+- `2`: block agent hook action or signal usage / dependency failure
+
+(Hook entry points `hook-pre-tool`, `hook-post-tool`, and `hook-stop` are invoked by Claude Code, Codex, or Git via `hooks/hooks.json` — not by users directly.)
 
 ## Development
 


### PR DESCRIPTION
## Summary

Started as a README trim (cut bloat accreted through v1.1.2) and grew into a broader restructure around user task flow plus end-to-end integration of the new `gitleaks-checksum` helper (#31). No code changes, no behavior changes.

> Note: This PR replaces #29, which GitHub auto-closed when its base branch (`feature/gitleaks-checksum-helper`) was deleted on #31's squash-merge. Same head branch (`docs/readme-trim`), rebased onto `main`.

## What changed

**Restructure around user task flow (popular OSS pattern)**

- Top-level flow: Install → Verify → How it works → Configuration → Reference → Develop
- Channel picker tables for both install and verify, so a first-time user can pick a path before reading prose
- Verify section consolidates previously fragmented notes

**Trim (the original aim)**

- Advanced Setup → Claude Code (plugin layout, marketplace publisher details)
- Advanced Setup → Codex (40 lines: schema cross-reference into `codex-rs/`, hook-tool-name coverage table, example-config smoke-test snippets)
- Advanced Setup → GitHub Actions (duplicate of Quickstart; opt-out note moved inline)
- Manual equivalent `<details>` block (paranoid users can read `bootstrap.sh` directly — 104 lines, comprehensible)
- Speculative roadmap text (`Codex parity is not implemented yet`)
- Duplicate verify footnote
- Editorial closing paragraph in Channels section

**Integrate `gitleaks-checksum` helper across every channel**

- Claude Code: `/agent-guard:checksum [VERSION]`
- Codex: `${CODEX_PLUGIN_ROOT}/bin/agent-guard checksum [VERSION]` (slash-command auto-discovery caveat documented)
- Direct CLI install: `agent-guard checksum [VERSION]`
- Make: `make checksum [VERSION=X.Y.Z]`
- No-install (e.g., a fresh CI host): `curl -fsSL https://raw.githubusercontent.com/JeongJaeSoon/agent-guard/v1/scripts/gitleaks-checksum.sh | sh`
- New "Fetching a gitleaks-checksum" section with a five-channel picker table

**Drop redundant info (per in-PR user-perspective review)**

- GitHub Actions section's 3-channel checksum block → one-line link to "Fetching" (5-channel table covers it)
- Reference's Exit codes section + hook-entry-points caveat (not interfaces users invoke directly)
- GitHub Actions pin options condensed from a 3-bullet list to a one-line note
- "Fetching" table's `v1` pin-options aside removed (covered up top)
- Plugin-only section's closing paragraph shortened (reload guidance no longer duplicated)
- MD040 lint fix on the `gitleaks-checksum` output fence (CodeRabbit catch)

## Result

292 → 243 lines (~17% reduction). Headline number is smaller than the original trim target (159) because the checksum-helper integration intentionally adds documentation surface — but every remaining section answers a question a real user has, and every fact lives in exactly one place (single-source-of-truth).

## Verification

- `tests/run.sh`: **106/0** (README has no test surface; baseline grew from 102 → 106 because #31's checksum tests landed on `main`)
- `git diff --stat main..docs/readme-trim`: only `Makefile` (1 line) and `README.md`
- Manual walkthrough as a first-time user: install path → verify path → checksum path — all reachable without forward-references to cut sections
