### PR TITLE
fix(cli): follow symlinks when resolving SCRIPT_DIR

### DIFF
--- a/bin/agent-guard
+++ b/bin/agent-guard
@@ -4,9 +4,26 @@ set -u
 PROGRAM=agent-guard
 VERSION=1.2.0
 
+# Resolve the script's own path, following symlinks. The bootstrap installer
+# drops a symlink at ~/.local/bin/agent-guard that points into ~/.agent-guard/
+# bin/agent-guard, so dirname "$0" alone (without symlink follow) computes the
+# config / scripts directory relative to ~/.local/ instead of ~/.agent-guard/.
+# POSIX-portable: walk the readlink chain by hand (BSD readlink lacks -f).
+script_path() {
+  p=$0
+  while [ -L "$p" ]; do
+    target=$(readlink -- "$p")
+    case "$target" in
+      /*) p=$target ;;
+      *) p="$(dirname -- "$p")/$target" ;;
+    esac
+  done
+  printf '%s\n' "$p"
+}
+
 script_dir() {
   # shellcheck disable=SC2164
-  CDPATH= cd -- "$(dirname -- "$0")" && pwd -P
+  CDPATH= cd -- "$(dirname -- "$(script_path)")" && pwd -P
 }
 
 BIN_DIR=$(script_dir)

--- a/bin/agent-guard
+++ b/bin/agent-guard
@@ -11,7 +11,14 @@ VERSION=1.2.0
 # POSIX-portable: walk the readlink chain by hand (BSD readlink lacks -f).
 script_path() {
   p=$0
+  hops=0
+  max_hops=40
   while [ -L "$p" ]; do
+    hops=$((hops + 1))
+    if [ "$hops" -gt "$max_hops" ]; then
+      printf '%s: too many symlink hops while resolving script path: %s\n' "$PROGRAM" "$p" >&2
+      exit 2
+    fi
     target=$(readlink -- "$p")
     case "$target" in
       /*) p=$target ;;


### PR DESCRIPTION
## Summary

P0 bug fix: `bin/agent-guard` did not follow symlinks when computing its own install directory, causing `check`, `checksum`, and any subcommand needing config or scripts to fail with `config not found` when invoked through the symlink that `bootstrap.sh` places at `~/.local/bin/agent-guard`.

## Root cause

`script_dir()` used `dirname "$0"` without resolving the symlink. The bootstrap installer creates:

```
~/.local/bin/agent-guard  ->  ~/.agent-guard/bin/agent-guard
```

So `$0 = ~/.local/bin/agent-guard`, `dirname = ~/.local/bin`, `pwd -P = ~/.local/bin` (parent is a real dir), and `ROOT_DIR = ~/.local`. All config / scripts paths then resolve under `~/.local/` which is empty.

## Fix

Added `script_path()` that walks the `readlink` chain portably (no `-f` — BSD readlink on macOS lacks it), then feeds the resolved path into `script_dir()`.

## Verification

- `bin/agent-guard check` (canonical path) → exit 0
- `/tmp/test-link check` (symlink → repo binary) → exit 0 (was: `gitleaks config not found: ~/.local/config/gitleaks.toml`)
- `tests/run.sh` → **106/0** (no regression)

Caught during end-to-end install verification against v1.2.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed symlink installation issue where agent-guard would miscompute configuration and directory paths. The script now correctly resolves its location and all related paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->