### PR TITLE
fix: install/runtime path bugs surfaced by latest Claude Code & Codex

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
         "ref": "v1"
       },
       "description": "Deterministic secret-scanning guardrails for AI coding agents.",
-      "version": "1.2.1"
+      "version": "1.2.2"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,5 @@
 {
   "name": "agent-guard",
   "description": "Deterministic secret-scanning guardrails for AI coding agents, Git hooks, and GitHub Actions.",
-  "version": "1.2.1",
-  "hooks": "./hooks/hooks.json"
+  "version": "1.2.2"
 }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-guard",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Deterministic secret-scanning guardrails for AI coding agents, Git hooks, and GitHub Actions.",
   "author": {
     "name": "Agent Guard contributors"

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Pick one or more — they don't chain. Each row lists what that channel alone ca
 
    ```text
    /plugin marketplace add JeongJaeSoon/agent-guard
-   /plugin install agent-guard@latest
+   /plugin install agent-guard@agent-guard
    /reload-plugins
    ```
 
@@ -65,11 +65,13 @@ That's it. From here, every `Read`, `Write`, `Edit`, `Bash`, and MCP tool call g
 
 ### Codex
 
-```text
-/plugin install JeongJaeSoon/agent-guard@latest
+```sh
+codex plugin marketplace add JeongJaeSoon/agent-guard
 ```
 
-Restart Codex so the hooks load. Codex does not auto-discover the `commands/` directory, so `/agent-guard:checksum` and `/agent-guard:verify` are not available — ask Codex to run `${CODEX_PLUGIN_ROOT}/bin/agent-guard checksum` (or `scan-working-tree`) directly when you need them.
+Then in the Codex TUI open `/plugins`, find **agent-guard**, press space to enable, and restart Codex so the hooks load. Codex does not auto-discover the `commands/` directory, so `/agent-guard:checksum` and `/agent-guard:verify` are not available — ask Codex to run `${CODEX_PLUGIN_ROOT}/bin/agent-guard checksum` (or `scan-working-tree`) directly when you need them.
+
+> **Codex 0.129+ note**: the marketplace adds successfully but the plugin is currently filtered out of the Codex `/plugins` browser (Codex 0.129 enforces `path` schema constraints that the v1.x layout doesn't satisfy). A `plugins/agent-guard/` subdirectory restructure is planned for v1.3.0. For now, install via Direct CLI (next section) and invoke `agent-guard scan-working-tree` from Codex directly.
 
 ### GitHub Actions
 

--- a/bin/agent-guard
+++ b/bin/agent-guard
@@ -2,7 +2,7 @@
 set -u
 
 PROGRAM=agent-guard
-VERSION=1.2.1
+VERSION=1.2.2
 
 # Resolve the script's own path, following symlinks. The bootstrap installer
 # drops a symlink at ~/.local/bin/agent-guard that points into ~/.agent-guard/
@@ -823,6 +823,9 @@ hook_post_tool() {
   tool=$(json_value '.tool_name // .tool // .name // empty' "$input")
   is_mutation_tool "$tool" || return 0
 
+  # Best-effort: silently skip when the agent runs outside a git work tree.
+  inside_git_repo || return 0
+
   scan_working_tree
   block_on_scan_status "$?" "changed files contain secret-like values after tool execution"
 }
@@ -837,6 +840,8 @@ hook_stop() {
       return 0
     fi
   fi
+
+  inside_git_repo || return 0
 
   scan_working_tree
   block_on_scan_status "$?" "changed files contain secret-like values before stop"

--- a/bin/agent-guard
+++ b/bin/agent-guard
@@ -818,6 +818,7 @@ is_mutation_tool() {
 
 hook_post_tool() {
   need_cmd jq
+  need_cmd git
   input=$(cat)
   [ -n "$input" ] || return 0
   tool=$(json_value '.tool_name // .tool // .name // empty' "$input")
@@ -832,6 +833,7 @@ hook_post_tool() {
 
 hook_stop() {
   need_cmd jq
+  need_cmd git
   input=$(cat)
   if [ -n "$input" ]; then
     active=$(json_value '.stop_hook_active // false' "$input")

--- a/commands/checksum.md
+++ b/commands/checksum.md
@@ -9,7 +9,7 @@ Fetches the published `gitleaks_<VER>_checksums.txt` from the gitleaks releases 
 
 ## Run
 
-!`sh "${CLAUDE_PLUGIN_ROOT:-.}/scripts/gitleaks-checksum.sh" $ARGUMENTS`
+!`sh "${CLAUDE_PLUGIN_ROOT}/scripts/gitleaks-checksum.sh" $ARGUMENTS`
 
 ## Interpretation
 

--- a/commands/verify.md
+++ b/commands/verify.md
@@ -9,7 +9,7 @@ One-shot secret scan over everything currently on disk: staged changes, unstaged
 
 ## Run
 
-!`"${CLAUDE_PLUGIN_ROOT:-.}/bin/agent-guard" scan-working-tree`
+!`"${CLAUDE_PLUGIN_ROOT}/bin/agent-guard" scan-working-tree`
 
 ## Interpretation
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT:-.}/bin/agent-guard hook-pre-tool",
+            "command": "${CLAUDE_PLUGIN_ROOT}/bin/agent-guard hook-pre-tool",
             "timeout": 10
           }
         ]
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT:-.}/bin/agent-guard hook-post-tool",
+            "command": "${CLAUDE_PLUGIN_ROOT}/bin/agent-guard hook-post-tool",
             "timeout": 20
           }
         ]
@@ -30,7 +30,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT:-.}/bin/agent-guard hook-stop",
+            "command": "${CLAUDE_PLUGIN_ROOT}/bin/agent-guard hook-stop",
             "timeout": 20
           }
         ]

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -500,6 +500,39 @@ else
   sed 's/^/  stderr: /' /tmp/agent-guard-test.err
 fi
 
+# --- hook silent-skip outside a git work tree ------------------------------
+# Regression: when the agent runs in a non-git cwd (e.g. ~), hook-post-tool
+# and hook-stop must exit 0 silently instead of erroring on every Stop event.
+
+NO_GIT_DIR="$TMP_ROOT/no-git"
+mkdir -p "$NO_GIT_DIR"
+
+(
+  cd "$NO_GIT_DIR" || exit 2
+  printf '%s' '{"tool_name":"Write","tool_input":{"file_path":"x.txt","content":"x"}}' \
+    | "$ROOT/bin/agent-guard" hook-post-tool >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+)
+status=$?
+if [ "$status" -eq 0 ] && [ ! -s /tmp/agent-guard-test.err ]; then
+  ok "hook-post-tool silently skips when cwd is not a git work tree"
+else
+  not_ok "hook-post-tool silently skips when cwd is not a git work tree (expected 0 + empty stderr, got $status)"
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+
+(
+  cd "$NO_GIT_DIR" || exit 2
+  printf '%s' '{"stop_hook_active":false}' \
+    | "$ROOT/bin/agent-guard" hook-stop >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+)
+status=$?
+if [ "$status" -eq 0 ] && [ ! -s /tmp/agent-guard-test.err ]; then
+  ok "hook-stop silently skips when cwd is not a git work tree"
+else
+  not_ok "hook-stop silently skips when cwd is not a git work tree (expected 0 + empty stderr, got $status)"
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+
 # --- gitleaks fail-closed when scanner errors ------------------------------
 
 ERROR_BIN="$TMP_ROOT/error-bin"


### PR DESCRIPTION
## Summary

Live e2e verification of v1.2.1 surfaced 4 bugs that block first-time install and usage on current Claude Code (v2.1.133) and Codex (v0.129). All fixed here as v1.2.2.

### Bugs fixed

#### 1. Slash commands `/agent-guard:verify` and `/agent-guard:checksum` fail

`commands/{verify,checksum}.md` used `${CLAUDE_PLUGIN_ROOT:-.}`. Claude Code's slash-command preprocessor does not handle the POSIX `:-` default-value form — it passes the literal text through, the shell falls back to `.` (user's CWD), and `./bin/agent-guard not found` is raised.

**Fix**: use bare `${CLAUDE_PLUGIN_ROOT}` (same form as other plugins like openai-codex). Same applied to `hooks/hooks.json` for consistency.

#### 2. Plugin manifest double-loads hooks (/doctor error)

`.claude-plugin/plugin.json` declared `"hooks": "./hooks/hooks.json"`. Claude Code 2.1.133 auto-discovers `hooks/hooks.json` automatically, so the explicit field causes a **"Duplicate hooks file detected"** error visible in `/doctor`.

**Fix**: remove the `hooks` field from `.claude-plugin/plugin.json`. (`.codex-plugin/plugin.json` keeps it — Codex requires explicit declaration.)

#### 3. README documents wrong slash-command install syntax

`/plugin install agent-guard@latest` raises `Marketplace 'latest' not found`. Claude Code's actual syntax is `<plugin>@<marketplace-name>`.

**Fix**: corrected to `/plugin install agent-guard@agent-guard`; Codex section updated with the `codex plugin marketplace add` CLI step; Codex 0.129+ plugin browser limitation documented inline.

#### 4. `hook-stop` / `hook-post-tool` crash in non-git cwd

Both hooks call `scan_working_tree` which calls `inside_git_repo || die`. When the agent runs in a non-repo directory (e.g. `~`), every Stop event fails with `scan-working-tree must run inside a git work tree` — polluting the transcript and triggering self-debug loops.

**Fix**: add `inside_git_repo || return 0` before scanning in both `hook_post_tool` and `hook_stop`. Direct CLI (`scan-staged`, `scan-working-tree`) still errors loudly.

### Out of scope

**Codex 0.129 plugin browser install** (path schema): Codex 0.129 enforces that the plugin source `path` must start with `./` AND point at a sub-directory of the marketplace root. agent-guard's whole-repo-as-plugin layout can't satisfy this without moving `bin/`, `hooks/`, `commands/`, etc. into a subdirectory. Deferred to v1.3.0. README notes the limitation and points to the Direct CLI workaround.

## Testing

```
passed: 108
failed: 0
```

Two regression tests added (lines 502–533 in `tests/run.sh`):
- `hook-post-tool silently skips when cwd is not a git work tree`
- `hook-stop silently skips when cwd is not a git work tree`

## Functional verification

- `/agent-guard:verify` and `/agent-guard:checksum` registered and executable after `/plugin enable agent-guard@agent-guard` + `/reload-plugins` in Claude Code 2.1.133 (verified live in tmux pane)
- `/doctor` shows no Plugin errors for agent-guard after enabling
- `cd ~ && hook-stop < /dev/null` exits 0 with no stderr
- `cd /tmp && agent-guard scan-staged` still exits 2 with error (direct CLI not silently skipped)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced hook reliability when operating outside Git repositories.

* **Documentation**
  * Updated installation instructions for Claude and Codex plugins.
  * Improved command documentation for security verification workflows.

* **Chores**
  * Version bumped to 1.2.2 across all plugin manifests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->