### PR TITLE
fix: use string source format in marketplace.json (v1.3.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,14 +7,9 @@
   "plugins": [
     {
       "name": "agent-guard",
-      "source": {
-        "source": "github",
-        "repo": "JeongJaeSoon/agent-guard",
-        "ref": "v1",
-        "path": "./plugins/agent-guard"
-      },
+      "source": "./plugins/agent-guard",
       "description": "Deterministic secret-scanning guardrails for AI coding agents.",
-      "version": "1.3.0"
+      "version": "1.3.1"
     }
   ]
 }

--- a/plugins/agent-guard/.claude-plugin/plugin.json
+++ b/plugins/agent-guard/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "agent-guard",
   "description": "Deterministic secret-scanning guardrails for AI coding agents, Git hooks, and GitHub Actions.",
-  "version": "1.3.0"
+  "version": "1.3.1"
 }

--- a/plugins/agent-guard/.codex-plugin/plugin.json
+++ b/plugins/agent-guard/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-guard",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Deterministic secret-scanning guardrails for AI coding agents, Git hooks, and GitHub Actions.",
   "author": {
     "name": "Agent Guard contributors"

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -2,7 +2,7 @@
 set -u
 
 PROGRAM=agent-guard
-VERSION=1.3.0
+VERSION=1.3.1
 
 # Resolve the script's own path, following symlinks. The bootstrap installer
 # drops a symlink at ~/.local/bin/agent-guard that points into ~/.agent-guard/


### PR DESCRIPTION
## Bug

Live verify of v1.3.0 immediately after release uncovered: Claude Code 2.1.133 silently fails to resolve the plugin payload when `source` is an object form with a `path` field for github sources. Symptom: `marketplace update` + `reload-plugins` drops hook count from 17 → 14 (agent-guard's 3 hooks vanish) and `/agent-guard:verify` becomes `Unknown command`.

The cache directory was correctly populated with the v1.3.0 download containing `plugins/agent-guard/` substructure, but Claude Code searched for `.claude-plugin/plugin.json` at the cache root rather than at the path-resolved subdirectory.

## Fix

Switch to the string source format that openai-codex marketplace ships successfully:

```json
"source": "./plugins/agent-guard"
```

This is resolved relative to the marketplace clone root (which Claude Code creates from the GitHub repo when the user runs `/plugin marketplace add owner/repo`).

## Verification

- `tests/run.sh`: 108 passed / 0 failed
- After v1.3.1 release: `/plugin marketplace update agent-guard` + `/reload-plugins` should restore hook count to 17 and re-enable `/agent-guard:verify`. Will live-verify post-merge.