### PR TITLE
docs: fix v1 raw URL for gitleaks-checksum.sh after plugin restructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Equivalent surfaces — pick whichever matches your channel:
 | Codex plugin | Ask Codex to run `${CODEX_PLUGIN_ROOT}/bin/agent-guard checksum [VERSION]` (no automatic slash command) |
 | Direct CLI install / Native hook (binary on PATH) | `agent-guard checksum [VERSION]` |
 | Clone of this repo | `make checksum [VERSION=X.Y.Z]` or `plugins/agent-guard/scripts/gitleaks-checksum.sh [VERSION]` |
-| Nothing installed yet (e.g. preparing a GitHub Actions workflow) | `curl -fsSL https://raw.githubusercontent.com/JeongJaeSoon/agent-guard/v1/scripts/gitleaks-checksum.sh \| sh` |
+| Nothing installed yet (e.g. preparing a GitHub Actions workflow) | `curl -fsSL https://raw.githubusercontent.com/JeongJaeSoon/agent-guard/v1/plugins/agent-guard/scripts/gitleaks-checksum.sh \| sh` |
 
 ### Without `agent-guard` on disk (Claude Code / Codex plugin only)
 


### PR DESCRIPTION
## Summary

The v1.3.0 plugin restructure moved `scripts/gitleaks-checksum.sh` to `plugins/agent-guard/scripts/gitleaks-checksum.sh`. The `v1` floating tag now points at v1.3.1, so the raw.githubusercontent.com URL in the checksums table was returning 404.

## Change

```diff
- curl -fsSL https://raw.githubusercontent.com/JeongJaeSoon/agent-guard/v1/scripts/gitleaks-checksum.sh | sh
+ curl -fsSL https://raw.githubusercontent.com/JeongJaeSoon/agent-guard/v1/plugins/agent-guard/scripts/gitleaks-checksum.sh | sh
```

**README.md:165** — checksums table row for "Nothing installed yet" channel.

## Verification

Confirmed the old path is absent from v1.3.1:
```
git show v1.3.1:scripts/gitleaks-checksum.sh
# fatal: path 'scripts/gitleaks-checksum.sh' does not exist in 'v1.3.1'
```

New path exists at v1.3.1:
```
git show v1.3.1:plugins/agent-guard/scripts/gitleaks-checksum.sh
# #!/usr/bin/env sh  ← confirmed present
```

Grep confirms this was the only `v1` raw URL reference remaining in the repo:
```
grep -rn "raw.githubusercontent.com/JeongJaeSoon/agent-guard/v1/"
# README.md:165  ← single result, now fixed
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to reference the correct resource URL path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->