### PR TITLE
simplify: narrow PostToolUse matcher, dedupe deny-read path, guard gitleaks version drift

### DIFF
--- a/examples/claude/settings.project.json
+++ b/examples/claude/settings.project.json
@@ -14,7 +14,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Write|Edit|MultiEdit|Read|NotebookRead|Grep|Glob|Bash|apply_patch|mcp__.*",
+        "matcher": "Write|Edit|MultiEdit|Bash|apply_patch|mcp__.*",
         "hooks": [
           {
             "type": "command",

--- a/examples/codex/hooks.json
+++ b/examples/codex/hooks.json
@@ -14,7 +14,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Write|Edit|MultiEdit|Read|NotebookRead|Grep|Glob|Bash|apply_patch|mcp__.*",
+        "matcher": "Write|Edit|MultiEdit|Bash|apply_patch|mcp__.*",
         "hooks": [
           {
             "type": "command",

--- a/plugins/agent-guard/config/deny-read-paths.txt
+++ b/plugins/agent-guard/config/deny-read-paths.txt
@@ -1,6 +1,4 @@
 # Shell case patterns. Blank lines and lines starting with # are ignored.
-.env
-.env.*
 .env*
 *.pem
 *.key

--- a/plugins/agent-guard/hooks/hooks.json
+++ b/plugins/agent-guard/hooks/hooks.json
@@ -14,7 +14,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Write|Edit|MultiEdit|Read|NotebookRead|Grep|Glob|Bash|apply_patch|mcp__.*",
+        "matcher": "Write|Edit|MultiEdit|Bash|apply_patch|mcp__.*",
         "hooks": [
           {
             "type": "command",

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -117,6 +117,28 @@ for event in PreToolUse PostToolUse; do
   done
 done
 
+# Pinned gitleaks default version is duplicated across three surfaces (the
+# CLI's setup --install default, the checksum helper's lookup default, and
+# the GitHub Action input default). They must stay in lock-step; otherwise
+# a user who copies the checksum from one channel into another silently
+# installs a different binary than the bundled rules expect.
+bin_ver=$(awk -F= '/^GITLEAKS_DEFAULT_VERSION=/ {print $2; exit}' "$PLUGIN_ROOT/bin/agent-guard")
+script_ver=$(awk -F= '/^DEFAULT_VERSION=/ {print $2; exit}' "$PLUGIN_ROOT/scripts/gitleaks-checksum.sh")
+action_ver=$(awk '
+  /^[[:space:]]*gitleaks-version:/ { in_block=1; next }
+  in_block && /^[[:space:]]*default:/ {
+    sub(/.*default:[[:space:]]*"/, "")
+    sub(/".*/, "")
+    print
+    exit
+  }
+' "$ROOT/action.yml")
+if [ -n "$bin_ver" ] && [ "$bin_ver" = "$script_ver" ] && [ "$bin_ver" = "$action_ver" ]; then
+  ok "gitleaks default version in sync across bin/agent-guard, gitleaks-checksum.sh, and action.yml ($bin_ver)"
+else
+  not_ok "gitleaks default version drift: bin=$bin_ver script=$script_ver action=$action_ver"
+fi
+
 expect_json_status 2 "Claude Write secret is blocked" \
   '{"tool_name":"Write","tool_input":{"file_path":"app.txt","content":"AGENT_GUARD_TEST_SECRET"}}' \
   hook-pre-tool


### PR DESCRIPTION
## Summary

Three independent, behavior-preserving improvements surfaced during a full-project audit pass.

---

### 1. Deduplicate env-file deny-read path

**File:** `plugins/agent-guard/config/deny-read-paths.txt`

Removed two redundant entries (bare env-file name and dot-star variant). The wildcard
glob entry already covers all three: in POSIX pattern matching, `*` matches zero or
more characters, so a trailing-star pattern matches the bare name as well as any suffix.
The same wildcard is used in `bash_matches_deny_path` via the ERE conversion path —
verified against all existing Read/Bash test cases.

**Change:** −2 lines in config, zero behavior delta.

---

### 2. Narrow PostToolUse matcher to mutation tools only

**Files:** `plugins/agent-guard/hooks/hooks.json`, `examples/claude/settings.project.json`,
`examples/codex/hooks.json`

Before: `Write|Edit|MultiEdit|Read|NotebookRead|Grep|Glob|Bash|apply_patch|mcp__.*`
After:  `Write|Edit|MultiEdit|Bash|apply_patch|mcp__.*`

The PostToolUse handler (`hook_post_tool`) immediately calls `is_mutation_tool` and
returns 0 if the tool is non-mutating — so Read/Grep/Glob/NotebookRead always exited 0
before doing any work. The new matcher skips the fork/exec entirely for those tools,
aligning the hook activation surface with the actual handler set.

All three files must be equal (CI enforces matcher equality), so all three were updated.

---

### 3. CI guard for gitleaks default-version drift

**File:** `tests/run.sh`

The gitleaks default version is hard-coded in three independent surfaces:
- `plugins/agent-guard/bin/agent-guard` — `GITLEAKS_DEFAULT_VERSION`
- `plugins/agent-guard/scripts/gitleaks-checksum.sh` — `DEFAULT_VERSION`
- `action.yml` — `inputs.gitleaks-version.default`

Added a static-assert test that extracts all three values and fails if they differ.
Diagnostic message includes all three values so the drifted file is immediately
visible without opening additional files.

---

## Functional Verification

```
tests/run.sh
passed: 109
failed: 0
```

Drift guard verified bidirectionally:
- **Sync:** passes with `gitleaks default version in sync … (8.30.1)`
- **Drift:** temporarily patched script to 9.99.99 →
  `not ok - gitleaks default version drift: bin=8.30.1 script=9.99.99 action=8.30.1`
  → CI fails, 108/109

---

## Considered but Not Changed

| Item | Reason deferred |
|---|---|
| Codex `${CLAUDE_PLUGIN_ROOT}` hooks variable | Codex plugin runtime behavior cannot be confirmed from repo source alone; fail-closed on misconfiguration is acceptable. Requires a live Codex integration test. |
| Shell deny pattern case-sensitivity for network credential commands | False-positive / false-negative trade-off is unclear without empirical data; uppercase convention in agent-generated shell is the dominant pattern. |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Configuration Updates**
  * Refined hook matchers to exclude read-based operations from certain triggers
  * Updated file access control patterns for environment variable files

* **Tests**
  * Added regression test to verify version consistency across core components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->