### PR TITLE
Fix real user install and verification flows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,19 @@ permissions:
   contents: read
 
 jobs:
+  secret-guard:
+    name: Agent Guard
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Scan for secrets
+        uses: ./
+        with:
+          paths: "."
+          gitleaks-checksum: "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb"
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Agent Guard — discoverability layer for the existing scripts.
 # Each target is a thin pass-through to install.sh or plugins/agent-guard/bin/agent-guard.
 
-.PHONY: help check install test scan scan-staged checksum
+.PHONY: help check install test smoke-test scan scan-staged checksum
 
 help:
 	@printf 'Agent Guard — make targets\n'
@@ -10,6 +10,7 @@ help:
 	@printf '  make check         Verify deps and print installed gitleaks version.\n'
 	@printf '  make install       Configure the native git pre-commit hook.\n'
 	@printf '  make test          Run the test suite (uses a mock gitleaks).\n'
+	@printf '  make smoke-test    Run real git/jq/gitleaks end-to-end checks.\n'
 	@printf '  make scan          Scan the working tree for secrets.\n'
 	@printf '  make scan-staged   Scan staged changes only.\n'
 	@printf '  make checksum [VERSION=X.Y.Z]   Fetch gitleaks-checksum for every supported OS/arch (CI typically picks linux/x64).\n'
@@ -22,6 +23,9 @@ install:
 
 test:
 	@tests/run.sh
+
+smoke-test:
+	@plugins/agent-guard/bin/agent-guard smoke-test
 
 scan:
 	@plugins/agent-guard/bin/agent-guard scan-working-tree

--- a/README.md
+++ b/README.md
@@ -4,74 +4,164 @@
 [![CI](https://github.com/JeongJaeSoon/agent-guard/actions/workflows/ci.yml/badge.svg)](https://github.com/JeongJaeSoon/agent-guard/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-> Deterministic secret-scanning guardrails for AI coding agents, native Git hooks, and GitHub Actions.
+Deterministic secret-scanning guardrails for Claude Code, Codex, Git hooks, GitHub Actions, and direct CLI scans.
 
-Agent Guard intercepts AI coding agents (Claude Code, Codex) before they read sensitive files, propose writes containing secrets, or run risky shell commands — and re-scans the working tree after every change. Backed by [gitleaks](https://github.com/gitleaks/gitleaks); no Python, Node, Docker, or vault account required.
+Agent Guard blocks common ways an AI coding agent can accidentally expose secrets: reading `.env`, writing secret-like values, running shell commands that dump credentials, or leaving secrets in the working tree after a tool call. It uses [gitleaks](https://github.com/gitleaks/gitleaks) for detection and plain shell scripts for integration.
+
+It is not a vault, credential rotator, or replacement for GitHub Secret Scanning / Push Protection.
+
+## Pick an install path
+
+| Use case | Install path | Best first check |
+|---|---|---|
+| Claude Code agent guardrails | [Claude Code plugin](#claude-code-plugin) | Ask the agent to read `.env`; it should be blocked. |
+| Codex agent guardrails | [Codex plugin](#codex-plugin) | Ask Codex to read `.env`; it should be blocked. |
+| Local commits | [Native Git hook](#native-git-hook) | Commit a staged fixture secret; commit should fail. |
+| CI / PRs | [GitHub Actions](#github-actions) | Push a test PR with a gitleaks-detectable fixture; workflow should fail. |
+| Manual scans | [Direct CLI](#direct-cli) | Run `agent-guard smoke-test`. |
+
+## Requirements
+
+Agent Guard runs on macOS and Linux and expects:
+
+- `sh`
+- `git`
+- `jq`
+- `gitleaks` 8.30 or newer recommended
+
+With a direct CLI install:
+
+```sh
+agent-guard setup   # prints dependency status and install hints
+agent-guard check   # strict pass/fail dependency check
+agent-guard smoke-test
+```
+
+From a clone of this repo:
+
+```sh
+plugins/agent-guard/bin/agent-guard setup
+make check
+make smoke-test
+```
+
+The Claude Code and Codex plugin installs do not put `agent-guard` on your shell `PATH`; install `jq` and `gitleaks` with your package manager for those paths:
+
+```sh
+brew install jq gitleaks
+```
+
+On Debian / Ubuntu or Fedora, install `jq` with the system package manager and download `gitleaks` from its release page.
+
+## Claude Code Plugin
+
+Install from the marketplace:
 
 ```text
-> Please read .env to set up the project
+/plugin marketplace add JeongJaeSoon/agent-guard
+/plugin install agent-guard@agent-guard
+/reload-plugins
+```
 
+Smoke test:
+
+```text
+Please read .env
+```
+
+Expected result:
+
+```text
 agent-guard: blocked sensitive file access: .env
 ```
 
-It is a thin layer — not a vault, not a credential rotator, not a replacement for GitHub Secret Scanning and Push Protection.
+Useful Claude Code slash commands:
 
-## Contents
+```text
+/agent-guard:verify
+/agent-guard:checksum [VERSION]
+```
 
-- [Channels](#channels) — pick which integration(s) to use
-- [Quick start (Claude Code)](#quick-start-claude-code) — 3 commands, ~1 minute
-- [Install other channels](#install-other-channels) — Codex, GitHub Actions, Direct CLI, Native Git hook
-- [Dependencies & setup](#dependencies--setup) — check `jq` / `gitleaks`, auto-install, fetch a `gitleaks-checksum`
-- [Verify the install](#verify-the-install)
-- [What it catches](#what-it-catches)
-- [Configuration](#configuration)
-- [Reference](#reference)
-- [Development](#development)
+## Codex Plugin
 
-## Channels
+For Codex 0.129+ environments where marketplace hook loading is unavailable, use the direct CLI plus the native Git hook first:
 
-Pick one or more — they don't chain. Each row lists what that channel alone can and cannot block.
+```sh
+curl -fsSL https://github.com/JeongJaeSoon/agent-guard/releases/latest/download/bootstrap.sh | sh
+agent-guard scan-working-tree
+~/.agent-guard/install.sh git-hooks
+```
 
-| Channel | What it blocks | What it cannot see |
-|---|---|---|
-| Agent hook (Claude Code / Codex) | Pre-tool: deny-listed reads (`.env`, `id_rsa`, …), risky shell idioms, secrets in proposed `Write`/`Edit`/`apply_patch`, secrets in MCP tool input. Post-tool & Stop: secrets in working-tree diff & untracked files. | Edits the user makes by hand outside the agent session. |
-| Native Git pre-commit hook | Secrets in staged added lines at commit time. | Reads the agent performed earlier; commits made with `--no-verify`. |
-| GitHub Action | Secrets in any tracked file on a PR/push. | Anything that already merged before the workflow ran. |
-| Direct CLI (`agent-guard scan-*`) | Whatever you point it at, on demand. | Anything outside the invocation. |
-
-## Quick start (Claude Code)
-
-**Prerequisites**: `git`, `jq`, `gitleaks` (>= 8.30 recommended) on macOS or Linux. Missing something? Jump to [Dependencies & setup](#dependencies--setup) — `agent-guard setup` will tell you exactly what to install.
-
-1. **Install the plugin and reload**:
-
-   ```text
-   /plugin marketplace add JeongJaeSoon/agent-guard
-   /plugin install agent-guard@agent-guard
-   /reload-plugins
-   ```
-
-2. **Smoke-test** by asking the agent to read `.env`. The hook should block it:
-
-   ```text
-   agent-guard: blocked sensitive file access: .env
-   ```
-
-   If the read goes through silently, see [Dependencies & setup](#dependencies--setup) — `gitleaks` is most likely missing.
-
-That's it. From here, every `Read`, `Write`, `Edit`, `Bash`, and MCP tool call goes through the guard.
-
-## Install other channels
-
-### Codex
+That path gives you on-demand scans and commit-time blocking. If your Codex build supports plugin hooks, install from the marketplace for pre-tool read/write/bash guardrails:
 
 ```sh
 codex plugin marketplace add JeongJaeSoon/agent-guard
 ```
 
-Then in the Codex TUI open `/plugins`, find **agent-guard**, press space to enable, and restart Codex so the hooks load. Codex does not auto-discover the `commands/` directory, so `/agent-guard:checksum` and `/agent-guard:verify` are not available as slash commands — ask Codex to run `${CODEX_PLUGIN_ROOT}/bin/agent-guard checksum` (or `scan-working-tree`) directly when you need either workflow.
+Then open `/plugins` in the Codex TUI, enable **agent-guard**, and restart Codex so hooks load.
 
-### GitHub Actions
+Smoke test:
+
+```text
+Please read .env
+```
+
+Expected result:
+
+```text
+agent-guard: blocked sensitive file access: .env
+```
+
+Codex does not currently auto-discover this plugin's `commands/` directory. Ask Codex to run the binary directly when you need those workflows:
+
+```sh
+${CODEX_PLUGIN_ROOT}/bin/agent-guard scan-working-tree
+${CODEX_PLUGIN_ROOT}/bin/agent-guard checksum
+```
+
+## Direct CLI
+
+Install the latest release without cloning:
+
+```sh
+curl -fsSL https://github.com/JeongJaeSoon/agent-guard/releases/latest/download/bootstrap.sh | sh
+```
+
+The installer verifies the release archive checksum, extracts to `~/.agent-guard`, links `agent-guard` into `~/.local/bin`, and runs `agent-guard setup`.
+
+Common commands:
+
+```sh
+agent-guard scan-path .
+agent-guard scan-working-tree
+agent-guard scan-staged
+agent-guard setup
+agent-guard smoke-test
+agent-guard checksum
+```
+
+Override install defaults with `AGENT_GUARD_VERSION`, `AGENT_GUARD_HOME`, or `AGENT_GUARD_BIN_DIR`.
+
+## Native Git Hook
+
+Install from a clone or direct CLI install:
+
+```sh
+cd <your-project>
+~/.agent-guard/install.sh git-hooks
+```
+
+From a clone of this repo:
+
+```sh
+./install.sh git-hooks
+```
+
+This sets `core.hooksPath=githooks` only when it will not overwrite an existing hook setup.
+
+## GitHub Actions
+
+Add a workflow step:
 
 ```yaml
 - uses: JeongJaeSoon/agent-guard@v1
@@ -80,166 +170,61 @@ Then in the Codex TUI open `/plugins`, find **agent-guard**, press space to enab
     gitleaks-checksum: "<sha256 of the gitleaks release archive>"
 ```
 
-> Use `@v1` for auto-updates, or pin to a tag (`@v1.2.3`) or commit SHA for reproducibility.
+Use `@v1` for compatible updates, or pin a full tag / commit SHA for stricter reproducibility.
 
-Run [`agent-guard checksum`](#fetching-a-gitleaks-checksum) to fill in `gitleaks-checksum`. Use `require-checksum: "false"` only for local experimentation; never in production CI.
-
-### Direct CLI install (no clone)
+Get the checksum with:
 
 ```sh
-curl -fsSL https://github.com/JeongJaeSoon/agent-guard/releases/latest/download/bootstrap.sh | sh
+agent-guard checksum
 ```
 
-The script downloads the latest release, verifies its sha256, extracts to `~/.agent-guard`, symlinks `~/.local/bin/agent-guard`, and runs `agent-guard setup` to report dependency status. Override with `AGENT_GUARD_VERSION`, `AGENT_GUARD_HOME`, or `AGENT_GUARD_BIN_DIR`.
+CI runners are usually `linux/x64`, so use the `linux/x64` value printed by the checksum command. `require-checksum` defaults to `true`; set it to `false` only for local experimentation.
 
-### Native Git hook
+## What Gets Blocked
 
-Requires `agent-guard` on disk. The Claude Code / Codex plugin install does **not** place a binary on the filesystem, so use Direct CLI install or a clone first:
+- `Read`, `NotebookRead`, `Grep`, and `Glob` access to deny-listed paths such as `.env*`, private keys, `.aws/credentials`, `.npmrc`, and `.pypirc`
+- `Write`, `Edit`, `MultiEdit`, and Codex `apply_patch` content containing secret-like values
+- MCP tool input JSON containing secret-like values
+- risky shell commands such as `printenv`, `op read`, `vault kv get`, `aws secretsmanager get-secret-value`, `cat .env`, and `git commit --no-verify`
+- staged added lines in the native pre-commit hook
+- working-tree added lines and untracked files after agent mutations
 
-```sh
-cd <your-project>
-~/.agent-guard/install.sh git-hooks   # after Direct CLI install
-# or, from a clone of this repo:
-./install.sh git-hooks
-```
-
-Sets `core.hooksPath=githooks` only when it will not overwrite an existing setup. No Husky / npm hook manager required.
-
-## Dependencies & setup
-
-Agent Guard requires `sh`, `git`, `jq`, and `gitleaks` (>= 8.30 recommended) on macOS or Linux. The right setup path depends on whether you have the `agent-guard` binary on disk.
-
-### With `agent-guard` on disk (Direct CLI install or clone)
-
-```sh
-agent-guard check       # strict pass/fail (exit 2 if anything is missing)
-agent-guard setup       # per-dependency status with install hints
-```
-
-`agent-guard setup` is opt-in: by default it only reports status, never installs. To download `gitleaks` automatically with checksum verification:
-
-```sh
-agent-guard setup --install \
-  --gitleaks-checksum <sha256-from-published-checksums.txt> \
-  [--gitleaks-version 8.30.1]
-```
-
-The checksum is required. The fastest way to get it: run [`agent-guard checksum [VERSION]`](#fetching-a-gitleaks-checksum) — it prints every supported OS / arch with paste-ready snippets for both `--gitleaks-checksum` (CLI) and `gitleaks-checksum:` (GitHub Actions YAML).
-
-`jq` is never auto-installed; `setup` prints the right `brew` / `apt-get` / `dnf` command for your OS.
-
-### Fetching a `gitleaks-checksum`
-
-Looking up the right sha256 by hand is the most common chore around dependency setup. The bundled helper does it for you and prints every supported platform — so the value is correct regardless of where you run it from (e.g. on macOS for a Linux CI runner).
-
-```sh
-agent-guard checksum             # uses the version pinned in action.yml (8.30.1)
-agent-guard checksum 8.30.0      # specific version
-```
-
-Output (paste-ready):
-
-```text
-gitleaks v8.30.1 — sha256 by OS/arch
-
-  darwin/arm64: <hex-a>   <- this machine
-  darwin/x64:   <hex-b>
-  linux/arm64:  <hex-c>
-  linux/x64:    <hex-d>
-
-GitHub Actions workflow (CI runners are typically linux/x64):
-  gitleaks-checksum: "<hex-d>"
-
-agent-guard setup CLI (this machine: darwin/arm64):
-  agent-guard setup --install --gitleaks-checksum <hex-a> --gitleaks-version 8.30.1
-```
-
-Equivalent surfaces — pick whichever matches your channel:
-
-| You have | How to invoke |
-|---|---|
-| Claude Code plugin | `/agent-guard:checksum [VERSION]` (slash command, calls the same script under the plugin path) |
-| Codex plugin | Ask Codex to run `${CODEX_PLUGIN_ROOT}/bin/agent-guard checksum [VERSION]` (no automatic slash command) |
-| Direct CLI install / Native hook (binary on PATH) | `agent-guard checksum [VERSION]` |
-| Clone of this repo | `make checksum [VERSION=X.Y.Z]` or `plugins/agent-guard/scripts/gitleaks-checksum.sh [VERSION]` |
-| Nothing installed yet (e.g. preparing a GitHub Actions workflow) | `curl -fsSL https://raw.githubusercontent.com/JeongJaeSoon/agent-guard/v1/plugins/agent-guard/scripts/gitleaks-checksum.sh \| sh` |
-
-### Without `agent-guard` on disk (Claude Code / Codex plugin only)
-
-The plugin install does not place a binary on the filesystem — install dependencies with your package manager:
-
-| OS | Command |
-|---|---|
-| macOS | `brew install jq gitleaks` |
-| Debian / Ubuntu | `sudo apt-get install -y jq` &nbsp;+ download `gitleaks` from its [releases page](https://github.com/gitleaks/gitleaks/releases) |
-| Fedora | `sudo dnf install -y jq` &nbsp;+ download `gitleaks` from its [releases page](https://github.com/gitleaks/gitleaks/releases) |
-
-After installing dependencies, reload the plugin (Claude Code: `/reload-plugins`; Codex: restart) and re-run the smoke test.
-
-## Verify the install
-
-| Channel | How to verify |
-|---|---|
-| Claude Code | `/plugin list` should show `agent-guard`. Run `/agent-guard:verify` for a one-shot working-tree scan, or smoke-test the hook by asking the agent to read `.env` (should be blocked with `blocked sensitive file access: .env`). |
-| Codex | Smoke-test by asking the agent to read `.env`; it should be blocked. (`/agent-guard:verify` is Claude Code only — fall back to `agent-guard scan-working-tree` directly.) |
-| GitHub Actions | A workflow run reporting either "no findings" or a deliberate finding (PR you crafted with a fake high-entropy secret) confirms it. |
-| Direct CLI install | `agent-guard check` for a strict pass/fail. |
-| Cloned repo | `./install.sh check` or `make check`. |
-
-## What it catches
-
-- Proposed writes from `Write`, `Edit`, `MultiEdit`, and Codex `apply_patch`
-- Sensitive read/search paths: `.env*`, private keys, `.aws/credentials`, `.npmrc`, `.pypirc`
-- Risky shell commands: `printenv`, `op read`, `vault kv get`, `aws secretsmanager get-secret-value` (path-referencing forms like `cat .env` are blocked via the deny-read paths)
-- MCP tool input JSON
-- Staged added lines for `pre-commit`
-- Working tree added lines and untracked file content after agent mutations
-
-Patch and diff scans inspect added lines only — removing an existing leaked value is not blocked. Detection is bounded by the rules in your `gitleaks` binary; keep it up to date. Agent Guard layers on top of, not in place of, GitHub Secret Scanning and Push Protection.
+Patch and diff scans inspect added lines only. Removing an existing leaked value is allowed.
 
 ## Configuration
 
-Override the bundled policies via environment variables:
+Override bundled policies with environment variables:
 
-- `AGENT_GUARD_GITLEAKS_CONFIG` — gitleaks rules (default: `plugins/agent-guard/config/gitleaks.toml`)
-- `AGENT_GUARD_DENY_READ_PATHS` — deny-list for `Read` / `NotebookRead` / `Grep` / `Glob` (default: `plugins/agent-guard/config/deny-read-paths.txt`)
-- `AGENT_GUARD_DENY_BASH_PATTERNS` — deny-list for `Bash` (default: `plugins/agent-guard/config/deny-bash-patterns.txt`)
+```sh
+AGENT_GUARD_GITLEAKS_CONFIG=/path/to/gitleaks.toml
+AGENT_GUARD_DENY_READ_PATHS=/path/to/deny-read-paths.txt
+AGENT_GUARD_DENY_BASH_PATTERNS=/path/to/deny-bash-patterns.txt
+```
 
 Project-local `.gitleaks.toml` files are not automatically trusted.
 
-## Reference
+## Checksums and Auto-Install
 
-### CLI subcommands
+`agent-guard setup --install` can install `gitleaks`, but only with an explicit checksum:
 
 ```sh
-agent-guard scan-staged
-agent-guard scan-working-tree
-agent-guard scan-path PATH...
-agent-guard check              # dependency / gitleaks version check
-agent-guard setup              # report dependency status; --install opts in to gitleaks download
-agent-guard checksum [VERSION] # fetch the gitleaks-checksum for every supported OS/arch
-agent-guard version
+agent-guard checksum
+agent-guard setup --install \
+  --gitleaks-version 8.30.1 \
+  --gitleaks-checksum <sha256-for-this-os-and-arch>
 ```
 
-From a clone, the binary lives at `plugins/agent-guard/bin/agent-guard`; `make scan` and `make scan-staged` are thin wrappers if you'd rather not type the full path.
-
-### Slash commands
-
-| Command | What it does |
-|---|---|
-| `/agent-guard:verify` | One-shot deterministic secret scan over the working tree (staged + unstaged + untracked). Claude Code only. |
-| `/agent-guard:checksum [VERSION]` | Fetch the gitleaks release sha256 for every supported OS / arch and emit paste-ready snippets for both GitHub Actions YAML and `agent-guard setup --install`. Claude Code only — Codex / GitHub Action / no-install paths are listed in [Fetching a gitleaks-checksum](#fetching-a-gitleaks-checksum). |
+The checksum helper prints all supported OS / arch values and paste-ready snippets for CLI setup and GitHub Actions.
 
 ## Development
 
 ```sh
-make help          # one-screen index of every target
-make check         # ./install.sh check
-make install       # ./install.sh git-hooks
-make test          # tests/run.sh
-make scan          # plugins/agent-guard/bin/agent-guard scan-working-tree
-make scan-staged   # plugins/agent-guard/bin/agent-guard scan-staged
-make checksum      # fetch the gitleaks-checksum for every supported OS/arch (override with VERSION=X.Y.Z)
+make help
+make test
+make smoke-test
+make scan
+make scan-staged
+make checksum
 ```
 
-`tests/run.sh` uses a mock `gitleaks` to validate routing without downloading dependencies. With real `gitleaks` installed, `plugins/agent-guard/bin/agent-guard scan-path .` does a full scan.
+`make smoke-test` uses real `git`, `jq`, and `gitleaks` in temporary projects. `make test` is the faster deterministic routing suite and uses a mock scanner for some cases.

--- a/install.sh
+++ b/install.sh
@@ -16,6 +16,12 @@ die() {
   exit 2
 }
 
+shell_quote() {
+  printf "'"
+  printf '%s' "$1" | sed "s/'/'\\\\''/g"
+  printf "'"
+}
+
 check() {
   "$SCRIPT_DIR/plugins/agent-guard/bin/agent-guard" check
 }
@@ -23,18 +29,61 @@ check() {
 install_git_hooks() {
   command -v git >/dev/null 2>&1 || die "git is required"
   git rev-parse --is-inside-work-tree >/dev/null 2>&1 || die "must run inside a git work tree"
+  project_root=$(git rev-parse --show-toplevel) || die "cannot resolve git work tree root"
 
   existing=$(git config --get core.hooksPath || true)
   if [ -n "$existing" ] && [ "$existing" != "githooks" ]; then
     die "core.hooksPath is already set to '$existing'; refusing to overwrite"
   fi
 
-  if [ -e ".git/hooks/pre-commit" ] && [ -z "$existing" ]; then
-    die ".git/hooks/pre-commit already exists; refusing to overwrite"
+  if [ -x "$SCRIPT_DIR/plugins/agent-guard/bin/agent-guard" ]; then
+    agent_guard_bin="$SCRIPT_DIR/plugins/agent-guard/bin/agent-guard"
+  elif [ -x "$SCRIPT_DIR/bin/agent-guard" ]; then
+    agent_guard_bin="$SCRIPT_DIR/bin/agent-guard"
+  else
+    die "agent-guard binary not found under $SCRIPT_DIR"
+  fi
+
+  legacy_hook=""
+  if [ -z "$existing" ]; then
+    git_hook=$(git rev-parse --git-path hooks/pre-commit) || die "cannot resolve git hook path"
+    case "$git_hook" in
+      /*) legacy_candidate=$git_hook ;;
+      *) legacy_candidate="$project_root/$git_hook" ;;
+    esac
+    if [ -e "$legacy_candidate" ]; then
+      legacy_hook=$legacy_candidate
+    fi
+  fi
+
+  mkdir -p "$project_root/githooks"
+  hook_path="$project_root/githooks/pre-commit"
+  if [ -e "$hook_path" ]; then
+    if grep -q 'agent-guard.*scan-staged' "$hook_path"; then
+      :
+    else
+      die "githooks/pre-commit already exists; refusing to overwrite"
+    fi
+  else
+    {
+      printf '%s\n' '#!/usr/bin/env sh'
+      printf '%s\n' 'set -u'
+      printf '\n'
+      if [ -n "$legacy_hook" ]; then
+        printf 'legacy_hook=%s\n' "$(shell_quote "$legacy_hook")"
+        printf 'if [ -x "$legacy_hook" ]; then\n'
+        printf '  "$legacy_hook" "$@" || exit $?\n'
+        printf 'fi\n'
+        printf '\n'
+      fi
+      printf 'exec "%s" scan-staged\n' "$agent_guard_bin"
+    } >"$hook_path" || die "failed to write $hook_path"
+    chmod +x "$hook_path" || die "failed to chmod $hook_path"
   fi
 
   git config core.hooksPath githooks
   printf '%s\n' "install.sh: configured core.hooksPath=githooks"
+  printf '%s\n' "install.sh: installed githooks/pre-commit"
 }
 
 cmd=${1:-}

--- a/plugins/agent-guard/.claude-plugin/plugin.json
+++ b/plugins/agent-guard/.claude-plugin/plugin.json
@@ -1,5 +1,8 @@
 {
   "name": "agent-guard",
   "description": "Deterministic secret-scanning guardrails for AI coding agents, Git hooks, and GitHub Actions.",
-  "version": "1.3.1"
+  "version": "1.3.1",
+  "author": {
+    "name": "Agent Guard contributors"
+  }
 }

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -51,6 +51,7 @@ Usage:
   agent-guard scan-path PATH...
   agent-guard check
   agent-guard setup [--install --gitleaks-checksum SHA [--gitleaks-version X.Y.Z]]
+  agent-guard smoke-test
   agent-guard checksum [VERSION]
   agent-guard version
 EOF
@@ -247,6 +248,81 @@ EOF
 
   info "$PROGRAM: setup ok"
   return 0
+}
+
+write_private_key_fixture() {
+  path=$1
+  body=AGENT-GUARD-FIXTURE-NEVER-A-REAL-KEY
+  body="${body}-${body}-${body}-${body}"
+  {
+    printf '%s%s\n' '-----BEGIN RSA ' 'PRIVATE KEY-----'
+    printf '%s\n' "$body"
+    printf '%s%s\n' '-----END RSA ' 'PRIVATE KEY-----'
+  } >"$path"
+}
+
+smoke_expect() {
+  expected=$1
+  label=$2
+  shift 2
+  ( "$@" ) >/dev/null 2>&1
+  status=$?
+  if [ "$status" -eq "$expected" ]; then
+    info "$PROGRAM: smoke ok: $label"
+    return 0
+  fi
+  die "smoke failed: $label (expected exit $expected, got $status)"
+}
+
+smoke_test() {
+  check_deps
+  tmp=$(mktemp -d "${TMPDIR:-/tmp}/agent-guard-smoke.XXXXXX") || die "smoke: failed to create temp dir"
+  trap 'rm -rf "$tmp"' EXIT INT TERM
+
+  mkdir -p "$tmp/clean" "$tmp/dirty"
+  printf '%s\n' "console.log('ok')" >"$tmp/clean/app.js"
+  write_private_key_fixture "$tmp/dirty/key.pem"
+
+  smoke_expect 0 "scan-path allows a clean directory" scan_path "$tmp/clean"
+  smoke_expect 1 "scan-path blocks a private-key fixture" scan_path "$tmp/dirty"
+
+  printf '%s' '{"tool_name":"Read","tool_input":{"file_path":".env"}}' \
+    | smoke_expect 2 "hook-pre-tool blocks .env reads" hook_pre_tool
+
+  write_payload=$(mktemp_file) || die "smoke: failed to create temp file"
+  {
+    printf '%s' '{"tool_name":"Write","tool_input":{"file_path":"key.pem","content":"'
+    sed 's/\\/\\\\/g; s/"/\\"/g; s/$/\\n/' "$tmp/dirty/key.pem" | tr -d '\n'
+    printf '%s\n' '"}}'
+  } >"$write_payload"
+  smoke_expect 2 "hook-pre-tool blocks secret-like writes" hook_pre_tool <"$write_payload"
+  rm -f "$write_payload"
+
+  repo="$tmp/repo"
+  mkdir -p "$repo"
+  (
+    cd "$repo" || exit 2
+    git init -q || exit 2
+    git config user.email test@example.com || exit 2
+    git config user.name "Agent Guard Smoke" || exit 2
+    printf '%s\n' ok >README.md
+    git add README.md || exit 2
+    git commit -q -m init || exit 2
+    mkdir -p githooks
+    {
+      printf '%s\n' '#!/usr/bin/env sh'
+      printf 'exec "%s" scan-staged\n' "$BIN_DIR/agent-guard"
+    } >githooks/pre-commit
+    chmod +x githooks/pre-commit || exit 2
+    git config core.hooksPath githooks || exit 2
+    write_private_key_fixture leak.pem
+    git add leak.pem || exit 2
+    git commit -m leak >/dev/null 2>&1
+    status=$?
+    [ "$status" -ne 0 ] || exit 1
+  ) || die "smoke failed: native pre-commit hook did not block staged fixture"
+  info "$PROGRAM: smoke ok: native pre-commit hook blocks staged fixture"
+  info "$PROGRAM: smoke-test ok"
 }
 
 mktemp_file() {
@@ -859,6 +935,7 @@ case "$cmd" in
   scan-path) shift; scan_path "$@" ;;
   check) check_deps ;;
   setup) shift; do_setup "$@" ;;
+  smoke-test) smoke_test ;;
   checksum) shift; exec sh "$ROOT_DIR/scripts/gitleaks-checksum.sh" "$@" ;;
   version) printf '%s %s\n' "$PROGRAM" "$VERSION" ;;
   ''|-h|--help|help) usage; exit 0 ;;

--- a/plugins/agent-guard/hooks/hooks.json
+++ b/plugins/agent-guard/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/bin/agent-guard hook-pre-tool",
+            "command": "sh -c 'root=${CLAUDE_PLUGIN_ROOT:-${CODEX_PLUGIN_ROOT:-}}; [ -n \"$root\" ] || { echo \"agent-guard: plugin root env not set\" >&2; exit 2; }; \"$root/bin/agent-guard\" hook-pre-tool'",
             "timeout": 10
           }
         ]
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/bin/agent-guard hook-post-tool",
+            "command": "sh -c 'root=${CLAUDE_PLUGIN_ROOT:-${CODEX_PLUGIN_ROOT:-}}; [ -n \"$root\" ] || { echo \"agent-guard: plugin root env not set\" >&2; exit 2; }; \"$root/bin/agent-guard\" hook-post-tool'",
             "timeout": 20
           }
         ]
@@ -30,7 +30,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/bin/agent-guard hook-stop",
+            "command": "sh -c 'root=${CLAUDE_PLUGIN_ROOT:-${CODEX_PLUGIN_ROOT:-}}; [ -n \"$root\" ] || { echo \"agent-guard: plugin root env not set\" >&2; exit 2; }; \"$root/bin/agent-guard\" hook-stop'",
             "timeout": 20
           }
         ]

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -117,6 +117,47 @@ for event in PreToolUse PostToolUse; do
   done
 done
 
+pre_tool_command=$(jq -r '.hooks.PreToolUse[0].hooks[0].command' "$PLUGIN_ROOT/hooks/hooks.json")
+read_env_payload='{"tool_name":"Read","tool_input":{"file_path":".env"}}'
+printf '%s' "$read_env_payload" \
+  | (cd "$PLUGIN_ROOT" && env -u CLAUDE_PLUGIN_ROOT -u CODEX_PLUGIN_ROOT sh -c "$pre_tool_command") \
+  >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "plugin hook command fails closed without root env vars"
+else
+  not_ok "plugin hook command fails closed without root env vars (expected 2, got $status)"
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+if grep -q 'plugin root env not set' /tmp/agent-guard-test.err; then
+  ok "plugin hook command explains missing root env vars"
+else
+  not_ok "plugin hook command explains missing root env vars"
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+
+printf '%s' "$read_env_payload" \
+  | (cd "$TMP_ROOT" && CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" sh -c "$pre_tool_command") \
+  >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "plugin hook command honors CLAUDE_PLUGIN_ROOT"
+else
+  not_ok "plugin hook command honors CLAUDE_PLUGIN_ROOT (expected 2, got $status)"
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+
+printf '%s' "$read_env_payload" \
+  | (cd "$TMP_ROOT" && CODEX_PLUGIN_ROOT="$PLUGIN_ROOT" sh -c "$pre_tool_command") \
+  >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "plugin hook command honors CODEX_PLUGIN_ROOT"
+else
+  not_ok "plugin hook command honors CODEX_PLUGIN_ROOT (expected 2, got $status)"
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+
 # Pinned gitleaks default version is duplicated across three surfaces (the
 # CLI's setup --install default, the checksum helper's lookup default, and
 # the GitHub Action input default). They must stay in lock-step; otherwise
@@ -127,8 +168,10 @@ script_ver=$(awk -F= '/^DEFAULT_VERSION=/ {print $2; exit}' "$PLUGIN_ROOT/script
 action_ver=$(awk '
   /^[[:space:]]*gitleaks-version:/ { in_block=1; next }
   in_block && /^[[:space:]]*default:/ {
-    sub(/.*default:[[:space:]]*"/, "")
-    sub(/".*/, "")
+    sub(/.*default:[[:space:]]*/, "")
+    sub(/[[:space:]]+#.*/, "")
+    gsub(/"/, "")
+    gsub(/^[[:space:]]+|[[:space:]]+$/, "")
     print
     exit
   }
@@ -389,6 +432,11 @@ esac
 run_expect 0 "help subcommand exits 0" "$PLUGIN_ROOT/bin/agent-guard" help
 run_expect 0 "no args exits 0 with usage on stderr" "$PLUGIN_ROOT/bin/agent-guard"
 run_expect 2 "unknown subcommand exits 2" "$PLUGIN_ROOT/bin/agent-guard" not-a-command
+if "$PLUGIN_ROOT/bin/agent-guard" help 2>&1 | grep -q 'smoke-test'; then
+  ok "help lists smoke-test"
+else
+  not_ok "help lists smoke-test"
+fi
 
 run_expect 0 "check passes when deps and configs exist" "$PLUGIN_ROOT/bin/agent-guard" check
 
@@ -693,8 +741,7 @@ INSTALL_REPO="$TMP_ROOT/install-repo"
 mkdir -p "$INSTALL_REPO"
 (
   cd "$INSTALL_REPO" || exit 2
-  # Use an empty template so the user's global init.templateDir cannot drop
-  # a stray pre-commit hook that the install safety check would refuse.
+  # Use an empty template so this case validates the no-existing-hook path.
   git init -q --template="$EMPTY_TEMPLATE"
   git config user.email t@e
   git config user.name t
@@ -713,6 +760,23 @@ if [ "$configured" = "githooks" ]; then
 else
   not_ok "install.sh sets core.hooksPath=githooks (got: $configured)"
 fi
+if [ -x "$INSTALL_REPO/githooks/pre-commit" ]; then
+  ok "install.sh writes an executable githooks/pre-commit"
+else
+  not_ok "install.sh writes an executable githooks/pre-commit"
+fi
+(
+  cd "$INSTALL_REPO" || exit 2
+  printf '%s\n' "AGENT_GUARD_TEST_SECRET" > leak.txt
+  git add leak.txt
+  git commit -m leak >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+)
+status=$?
+if [ "$status" -ne 0 ]; then
+  ok "installed native git hook blocks a staged secret"
+else
+  not_ok "installed native git hook blocks a staged secret"
+fi
 
 CONFLICT_REPO="$TMP_ROOT/conflict-repo"
 mkdir -p "$CONFLICT_REPO"
@@ -730,20 +794,40 @@ else
 fi
 
 PRECOMMIT_REPO="$TMP_ROOT/precommit-repo"
+PRECOMMIT_CANARY="$TMP_ROOT/precommit-canary"
 mkdir -p "$PRECOMMIT_REPO"
 (
   cd "$PRECOMMIT_REPO" || exit 2
   git init -q --template="$EMPTY_TEMPLATE"
+  git config user.email t@e
+  git config user.name t
   mkdir -p .git/hooks
-  printf '%s\n' '#!/bin/sh' > .git/hooks/pre-commit
+  {
+    printf '%s\n' '#!/bin/sh'
+    printf 'printf %%s legacy-ran > "%s"\n' "$PRECOMMIT_CANARY"
+  } > .git/hooks/pre-commit
   chmod +x .git/hooks/pre-commit
   "$ROOT/install.sh" git-hooks >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
 )
 status=$?
-if [ "$status" -eq 2 ]; then
-  ok "install.sh refuses to overwrite an existing .git/hooks/pre-commit"
+if [ "$status" -eq 0 ]; then
+  ok "install.sh chains an existing .git/hooks/pre-commit"
 else
-  not_ok "install.sh refuses to overwrite an existing .git/hooks/pre-commit (expected 2, got $status)"
+  not_ok "install.sh chains an existing .git/hooks/pre-commit (expected 0, got $status)"
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+(
+  cd "$PRECOMMIT_REPO" || exit 2
+  printf '%s\n' ok > README.md
+  git add README.md
+  git commit -m init >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+)
+status=$?
+if [ "$status" -eq 0 ] && [ "$(cat "$PRECOMMIT_CANARY" 2>/dev/null)" = "legacy-ran" ]; then
+  ok "installed hook runs the pre-existing pre-commit hook"
+else
+  not_ok "installed hook runs the pre-existing pre-commit hook"
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
 fi
 
 run_expect 2 "install.sh unknown subcommand exits 2" "$ROOT/install.sh" not-a-command


### PR DESCRIPTION
## Summary

- Simplify README around real user install paths and verification commands.
- Add `agent-guard smoke-test` for real `git` / `jq` / `gitleaks` end-to-end verification.
- Make direct CLI `install.sh git-hooks` install a working native pre-commit hook and chain an existing `.git/hooks/pre-commit` instead of dead-ending.
- Make shared plugin hook commands resolve Claude and Codex plugin roots and fail closed when neither is set.
- Add Agent Guard to CI using the local composite action with a pinned gitleaks checksum.

## Verification

- `make test` -> 117 passed, 0 failed
- `make smoke-test` -> passed with real gitleaks 8.30.1
- `make scan` -> passed
- `claude plugin validate plugins/agent-guard` -> passed

Release version bump / changelog / tag / release assets are intentionally left to the release GitHub Action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated secrets scanning to continuous integration workflow
  * Added smoke-test command for end-to-end validation
  * Enhanced git hooks installation with improved compatibility and legacy hook chaining

* **Documentation**
  * Reorganized README with clearer installation paths, requirements, and configuration guidance

* **Bug Fixes**
  * Improved plugin hook robustness with flexible environment variable handling

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JeongJaeSoon/agent-guard/pull/41)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->