### PR TITLE
Fix release tarball native hook installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -262,7 +262,7 @@ jobs:
           # layout (~/.agent-guard/bin/agent-guard) stays unchanged for
           # existing v1.2.x Direct-CLI users on update.
           tarball_tmp=$(mktemp -d)/agent-guard-${v}.tar.gz
-          tar -C plugins/agent-guard -czf "$tarball_tmp" .
+          scripts/build-release-tarball.sh "$v" "$tarball_tmp"
           mv "$tarball_tmp" "agent-guard-${v}.tar.gz"
           sha256sum "agent-guard-${v}.tar.gz" > "agent-guard-${v}.tar.gz.sha256"
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -77,6 +77,7 @@ main() {
 
   bin_path="$HOME_DIR/bin/agent-guard"
   [ -x "$bin_path" ] || die "expected executable not found after extraction: $bin_path"
+  [ -x "$HOME_DIR/install.sh" ] || die "expected installer not found after extraction: $HOME_DIR/install.sh"
 
   mkdir -p "$BIN_DIR"
   ln -sf "$bin_path" "$BIN_DIR/agent-guard"

--- a/scripts/build-release-tarball.sh
+++ b/scripts/build-release-tarball.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+set -eu
+
+version=${1:?version required}
+output=${2:-agent-guard-${version}.tar.gz}
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd -P)
+stage=$(mktemp -d "${TMPDIR:-/tmp}/agent-guard-release.XXXXXX")
+trap 'rm -rf "$stage"' EXIT INT TERM
+
+cp -R "$ROOT/plugins/agent-guard/." "$stage/"
+cp "$ROOT/install.sh" "$stage/install.sh"
+tar -C "$stage" -czf "$output" .

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -86,6 +86,7 @@ for file in \
   "$PLUGIN_ROOT/bin/agent-guard" \
   "$ROOT/install.sh" \
   "$ROOT/bootstrap.sh" \
+  "$ROOT/scripts/build-release-tarball.sh" \
   "$ROOT/githooks/pre-commit" \
   "$PLUGIN_ROOT/scripts/gitleaks-checksum.sh" \
   "$ROOT/tests/run.sh"; do
@@ -832,6 +833,17 @@ fi
 
 run_expect 2 "install.sh unknown subcommand exits 2" "$ROOT/install.sh" not-a-command
 run_expect 0 "install.sh check passes" "$ROOT/install.sh" check
+
+RELEASE_TARBALL_DIR="$TMP_ROOT/release-tarball"
+mkdir -p "$RELEASE_TARBALL_DIR/out"
+run_expect 0 "release tarball builder succeeds" \
+  "$ROOT/scripts/build-release-tarball.sh" test "$RELEASE_TARBALL_DIR/agent-guard-test.tar.gz"
+tar -xzf "$RELEASE_TARBALL_DIR/agent-guard-test.tar.gz" -C "$RELEASE_TARBALL_DIR/out"
+if [ -x "$RELEASE_TARBALL_DIR/out/bin/agent-guard" ] && [ -x "$RELEASE_TARBALL_DIR/out/install.sh" ]; then
+  ok "release tarball contains bin/agent-guard and install.sh"
+else
+  not_ok "release tarball contains bin/agent-guard and install.sh"
+fi
 
 # --- githooks/pre-commit invokes scan-staged ------------------------------
 


### PR DESCRIPTION
## Summary
- include the root install.sh inside release tarballs
- build release tarballs through a shared script used by tests and GitHub Actions
- make bootstrap fail fast if install.sh is missing after extraction

## Why
The real release bootstrap installed agent-guard v1.3.2, but the README native hook path failed because ~/.agent-guard/install.sh was not present. The old workflow packaged only plugins/agent-guard and uploaded install.sh as a separate asset, so bootstrap extraction could not provide the installer.

## Validation
- make test
- make smoke-test
- release tarball fixture extraction verifies bin/agent-guard and install.sh are executable
- git diff --check