### PR TITLE
[codex] Fix install hook quoting and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Agent Guard runs on macOS and Linux and expects:
 - `jq`
 - `gitleaks` 8.30 or newer recommended
 
+Install paths that download release archives also use `curl`, `tar`, `shasum`, and `ln`.
+
 With a direct CLI install:
 
 ```sh

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
     required: false
     default: "8.30.1"
   gitleaks-checksum:
-    description: Optional sha256 checksum for the selected gitleaks archive.
+    description: Sha256 checksum for the selected gitleaks archive. Required by default when gitleaks must be installed.
     required: false
     default: ""
   require-checksum:

--- a/examples/github/secret-guard.yml
+++ b/examples/github/secret-guard.yml
@@ -9,7 +9,7 @@ jobs:
   secret-guard:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: JeongJaeSoon/agent-guard@v1
         with:
           paths: "."

--- a/install.sh
+++ b/install.sh
@@ -76,7 +76,7 @@ install_git_hooks() {
         printf 'fi\n'
         printf '\n'
       fi
-      printf 'exec "%s" scan-staged\n' "$agent_guard_bin"
+      printf 'exec %s scan-staged\n' "$(shell_quote "$agent_guard_bin")"
     } >"$hook_path" || die "failed to write $hook_path"
     chmod +x "$hook_path" || die "failed to chmod $hook_path"
   fi

--- a/plugins/agent-guard/commands/checksum.md
+++ b/plugins/agent-guard/commands/checksum.md
@@ -13,7 +13,7 @@ Fetches the published `gitleaks_<VER>_checksums.txt` from the gitleaks releases 
 
 ## Interpretation
 
-- **Exit 0** — the script prints all platform `sha256:` entries and emits both the `gitleaks-checksum:` YAML snippet and the `agent-guard setup --install` command; surface them verbatim.
+- **Exit 0** — the script prints all platform checksums and emits both the `gitleaks-checksum:` YAML snippet and the `agent-guard setup --install` command; surface them verbatim.
 - **`failed to fetch`** — the version probably does not exist. Suggest the user double-check the version on https://github.com/gitleaks/gitleaks/releases.
 - **`missing one or more required entries`** — gitleaks doesn't publish a binary for one of the four supported platforms at that version. The script lists the available archive names; relay them.
 - **`curl is required`** — instruct the user to install `curl`, then re-run.

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -779,6 +779,38 @@ else
   not_ok "installed native git hook blocks a staged secret"
 fi
 
+QUOTE_SOURCE="$TMP_ROOT/source-with-quote\"dir"
+QUOTE_REPO="$TMP_ROOT/quote-install-repo"
+mkdir -p "$QUOTE_SOURCE/plugins/agent-guard/bin" "$QUOTE_REPO"
+ln -s "$ROOT/install.sh" "$QUOTE_SOURCE/install.sh"
+ln -s "$PLUGIN_ROOT/bin/agent-guard" "$QUOTE_SOURCE/plugins/agent-guard/bin/agent-guard"
+(
+  cd "$QUOTE_REPO" || exit 2
+  git init -q --template="$EMPTY_TEMPLATE"
+  git config user.email t@e
+  git config user.name t
+  "$QUOTE_SOURCE/install.sh" git-hooks >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+)
+status=$?
+if [ "$status" -eq 0 ] && sh -n "$QUOTE_REPO/githooks/pre-commit"; then
+  ok "install.sh quotes generated hook paths safely"
+else
+  not_ok "install.sh quotes generated hook paths safely (expected install success and shell syntax ok)"
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+(
+  cd "$QUOTE_REPO" || exit 2
+  printf '%s\n' "AGENT_GUARD_TEST_SECRET" > leak.txt
+  git add leak.txt
+  git commit -m leak >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+)
+status=$?
+if [ "$status" -ne 0 ]; then
+  ok "installed hook works when agent path contains a quote"
+else
+  not_ok "installed hook works when agent path contains a quote"
+fi
+
 CONFLICT_REPO="$TMP_ROOT/conflict-repo"
 mkdir -p "$CONFLICT_REPO"
 (


### PR DESCRIPTION
## Summary

- Quote the generated `agent-guard` path in `install.sh` so native hook installation works when the install path contains shell-sensitive characters.
- Add a regression test that installs from a path containing a quote and verifies the generated hook still blocks a staged fixture secret.
- Align docs and examples with current behavior: release download dependencies, checksum requirement wording, checkout v5, and checksum command output.

## Why

The generated native pre-commit hook previously wrapped the resolved `agent-guard` path in double quotes directly. That works for normal paths, but can produce invalid shell when the install location itself contains a double quote. The installer already had a `shell_quote` helper for legacy hooks, so the generated `exec` line now uses the same quoting path.

## Validation

- `make test` — 122 passed, 0 failed
- `make smoke-test`
- `make scan`
- `git diff --check`

Note: `shellcheck` was not available in the local environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated requirements documentation with additional required tools (curl, tar, shasum, ln)
  * Clarified that gitleaks-checksum is required by default when gitleaks must be installed
  * Updated example workflow to use latest checkout action version

* **Bug Fixes**
  * Fixed shell quoting in git hooks installation when paths contain special characters

* **Tests**
  * Added regression test for quoted paths in hook installation

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JeongJaeSoon/agent-guard/pull/48)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->