### PR TITLE
[codex] Harden agent tool input scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ CI runners are usually `linux/x64`, so use the `linux/x64` value printed by the 
 
 - `Read`, `NotebookRead`, `Grep`, and `Glob` access to deny-listed paths such as `.env*`, private keys, `.aws/credentials`, `.npmrc`, and `.pypirc`
 - `Write`, `Edit`, `MultiEdit`, and Codex `apply_patch` content containing secret-like values
-- MCP tool input JSON containing secret-like values
+- `WebFetch`, `WebSearch`, and MCP tool input JSON containing secret-like values
 - risky shell commands such as `printenv`, `op read`, `vault kv get`, `aws secretsmanager get-secret-value`, `cat .env`, and `git commit --no-verify`
 - staged added lines in the native pre-commit hook
 - working-tree added lines and untracked files after agent mutations

--- a/examples/claude/settings.project.json
+++ b/examples/claude/settings.project.json
@@ -2,7 +2,7 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Write|Edit|MultiEdit|Read|NotebookRead|Grep|Glob|Bash|apply_patch|mcp__.*",
+        "matcher": "Write|Edit|MultiEdit|Read|NotebookRead|Grep|Glob|Bash|WebFetch|WebSearch|apply_patch|mcp__.*",
         "hooks": [
           {
             "type": "command",

--- a/examples/codex/hooks.json
+++ b/examples/codex/hooks.json
@@ -2,7 +2,7 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Write|Edit|MultiEdit|Read|NotebookRead|Grep|Glob|Bash|apply_patch|mcp__.*",
+        "matcher": "Write|Edit|MultiEdit|Read|NotebookRead|Grep|Glob|Bash|WebFetch|WebSearch|apply_patch|mcp__.*",
         "hooks": [
           {
             "type": "command",

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -619,20 +619,30 @@ check_sensitive_reads() {
   rm -f "$tmp"
 }
 
-deny_path_basename_pattern() {
-  # Convert the supported deny-read shell globs to POSIX ERE.
+deny_path_regex_fragment() {
+  # Convert supported deny-read shell globs to POSIX ERE fragments. The
+  # shell-expanded mode also catches command words that the shell can expand
+  # into a deny-listed path, such as .e[n]v, .e?v, .e*v, or $'.e\x6ev'.
   pattern=$1
+  mode=${2:-literal}
   py=
   remaining=$pattern
   while [ -n "$remaining" ]; do
     ch=${remaining%"${remaining#?}"}
     remaining=${remaining#?}
-    case "$ch" in
-      '*') py=${py}'[^[:space:]<>|;&`$()]*' ;;
-      '.'|'^'|'$'|'+'|'?'|'('|')'|'['|']'|'{'|'}'|'|'|'\\') py=${py}'\'${ch} ;;
-      '/') py=${py}'/' ;;
-      *) py=${py}${ch} ;;
-    esac
+    if [ "$mode" = "shell-expanded" ]; then
+      case "$ch" in
+        '*') py=${py}'[^[:space:]<>|;&`$()]*' ;;
+        *) py=${py}$(deny_path_shell_expansion_char_pattern "$ch") ;;
+      esac
+    else
+      case "$ch" in
+        '*') py=${py}'[^[:space:]<>|;&`$()]*' ;;
+        '.'|'^'|'$'|'+'|'?'|'('|')'|'['|']'|'{'|'}'|'|'|'\\') py=${py}'\'${ch} ;;
+        '/') py=${py}'/' ;;
+        *) py=${py}${ch} ;;
+      esac
+    fi
   done
   printf '%s' "$py"
 }
@@ -689,51 +699,24 @@ deny_path_shell_expansion_char_pattern() {
   esac
 }
 
-deny_path_shell_expansion_pattern() {
-  # Match shell forms that can expand to a deny-listed path, such as
-  # .e[n]v, .e?v, .e*v, or $'.e\x6ev'.
+deny_path_command_regex() {
   pattern=$1
-  py=
-  remaining=$pattern
-  while [ -n "$remaining" ]; do
-    ch=${remaining%"${remaining#?}"}
-    remaining=${remaining#?}
-    case "$ch" in
-      '*') py=${py}'[^[:space:]<>|;&`$()]*' ;;
-      *) py=${py}$(deny_path_shell_expansion_char_pattern "$ch") ;;
-    esac
-  done
-  printf '%s' "$py"
+  mode=$2
+  converted=$(deny_path_regex_fragment "$pattern" "$mode")
+  [ -n "$converted" ] || return 1
+  # Catch path arguments and shell words without matching substrings like myenv.
+  printf '%s' '(^|[^[:alnum:]_./~-])('"${converted}"'|[^[:space:]<>|;&`$()]*/'"${converted}"')([^[:alnum:]_.-]|$)'
 }
 
-bash_matches_deny_path_literal() {
+bash_matches_deny_path_mode() {
   cmd=$1
+  mode=$2
   [ -f "$DENY_READ_PATHS" ] || return 1
   while IFS= read -r entry || [ -n "$entry" ]; do
     case "$entry" in
       ''|\#*) continue ;;
     esac
-    converted=$(deny_path_basename_pattern "$entry")
-    [ -n "$converted" ] || continue
-    # Catch path arguments and shell words without matching substrings like myenv.
-    regex='(^|[^[:alnum:]_./~-])('${converted}'|[^[:space:]<>|;&`$()]*/'${converted}')([^[:alnum:]_.-]|$)'
-    if printf '%s\n' "$cmd" | grep -Eq "$regex"; then
-      return 0
-    fi
-  done <"$DENY_READ_PATHS"
-  return 1
-}
-
-bash_matches_deny_path_shell_expansion() {
-  cmd=$1
-  [ -f "$DENY_READ_PATHS" ] || return 1
-  while IFS= read -r entry || [ -n "$entry" ]; do
-    case "$entry" in
-      ''|\#*) continue ;;
-    esac
-    converted=$(deny_path_shell_expansion_pattern "$entry")
-    [ -n "$converted" ] || continue
-    regex='(^|[^[:alnum:]_./~-])('${converted}'|[^[:space:]<>|;&`$()]*/'${converted}')([^[:alnum:]_.-]|$)'
+    regex=$(deny_path_command_regex "$entry" "$mode") || continue
     if printf '%s\n' "$cmd" | grep -Eq "$regex"; then
       return 0
     fi
@@ -766,12 +749,12 @@ shell_dequote_for_policy() {
 
 bash_matches_deny_path() {
   cmd=$1
-  bash_matches_deny_path_literal "$cmd" && return 0
-  bash_matches_deny_path_shell_expansion "$cmd" && return 0
+  bash_matches_deny_path_mode "$cmd" "literal" && return 0
+  bash_matches_deny_path_mode "$cmd" "shell-expanded" && return 0
   dequoted=$(shell_dequote_for_policy "$cmd")
   [ "$dequoted" = "$cmd" ] && return 1
-  bash_matches_deny_path_literal "$dequoted" && return 0
-  bash_matches_deny_path_shell_expansion "$dequoted"
+  bash_matches_deny_path_mode "$dequoted" "literal" && return 0
+  bash_matches_deny_path_mode "$dequoted" "shell-expanded"
 }
 
 is_shell_command_separator() {

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -637,7 +637,7 @@ deny_path_basename_pattern() {
   printf '%s' "$py"
 }
 
-bash_matches_deny_path() {
+bash_matches_deny_path_literal() {
   cmd=$1
   [ -f "$DENY_READ_PATHS" ] || return 1
   while IFS= read -r entry || [ -n "$entry" ]; do
@@ -653,6 +653,37 @@ bash_matches_deny_path() {
     fi
   done <"$DENY_READ_PATHS"
   return 1
+}
+
+shell_dequote_for_policy() {
+  printf '%s\n' "$1" | awk '
+    {
+      out = ""
+      for (i = 1; i <= length($0); i++) {
+        c = substr($0, i, 1)
+        if (c == "\\") {
+          i++
+          if (i <= length($0)) {
+            out = out substr($0, i, 1)
+          }
+          continue
+        }
+        if (c == "\"" || c == "\047") {
+          continue
+        }
+        out = out c
+      }
+      print out
+    }
+  '
+}
+
+bash_matches_deny_path() {
+  cmd=$1
+  bash_matches_deny_path_literal "$cmd" && return 0
+  dequoted=$(shell_dequote_for_policy "$cmd")
+  [ "$dequoted" = "$cmd" ] && return 1
+  bash_matches_deny_path_literal "$dequoted"
 }
 
 is_shell_command_separator() {
@@ -816,15 +847,29 @@ check_bash_command() {
     exit 2
   fi
 
+  scan_text_direct "shell command" "$cmd"
+  block_on_scan_status "$?" "shell command contains secret-like values"
+
   check_git_command "$cmd"
 }
 
-scan_mcp_input() {
+scan_tool_input() {
   input=$1
+  label=$2
   need_cmd jq
   text=$(printf '%s' "$input" | jq -c '.tool_input // {}')
-  scan_text_direct "MCP tool input" "$text"
-  block_on_scan_status "$?" "MCP tool input contains secret-like values"
+  scan_text_direct "$label" "$text"
+  block_on_scan_status "$?" "$label contains secret-like values"
+}
+
+scan_mcp_input() {
+  scan_tool_input "$1" "MCP tool input"
+}
+
+scan_network_input() {
+  input=$1
+  check_sensitive_reads "$input"
+  scan_tool_input "$input" "network tool input"
 }
 
 scan_proposed_write() {
@@ -860,6 +905,50 @@ scan_proposed_write() {
   esac
 }
 
+is_broad_search_path() {
+  path=${1:-}
+  normalized=$(normalize_path "$path")
+  case "$normalized" in
+    ''|'.'|'./'|'/') return 0 ;;
+  esac
+  cwd=$(pwd -P 2>/dev/null || pwd)
+  [ "$normalized" = "$cwd" ] && return 0
+  return 1
+}
+
+is_broad_grep_glob() {
+  case "${1:-}" in
+    ''|'*'|'**'|'**/*'|'./**/*'|'*.*') return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+is_secret_search_pattern() {
+  pattern=$1
+  case "$pattern" in
+    ''|'.*'|'.+'|'^.*$'|'[[:print:]]*'|'[\\s\\S]*') return 0 ;;
+  esac
+  printf '%s\n' "$pattern" \
+    | grep -Eiq '(secret|token|password|passwd|credential|api[^[:alnum:]]*key|access[^[:alnum:]]*key|private[^[:alnum:]]*key|authorization|bearer|aws|openai|anthropic|stripe|github|ghp_|sk-)'
+}
+
+check_broad_grep_content() {
+  input=$1
+  output_mode=$(json_value '.tool_input.output_mode // empty' "$input")
+  [ "$output_mode" = "content" ] || return 0
+
+  path=$(json_value '.tool_input.path // empty' "$input")
+  glob=$(json_value '.tool_input.glob // empty' "$input")
+  pattern=$(json_value '.tool_input.pattern // empty' "$input")
+
+  is_broad_search_path "$path" || return 0
+  is_broad_grep_glob "$glob" || return 0
+  if is_secret_search_pattern "$pattern"; then
+    info "$PROGRAM: blocked broad Grep content search that could expose secrets"
+    exit 2
+  fi
+}
+
 hook_pre_tool() {
   need_cmd jq
   input=$(cat)
@@ -872,9 +961,15 @@ hook_pre_tool() {
       ;;
     Read|NotebookRead|Grep|Glob)
       check_sensitive_reads "$input"
+      if [ "$tool" = "Grep" ]; then
+        check_broad_grep_content "$input"
+      fi
       ;;
     Bash)
       check_bash_command "$input"
+      ;;
+    WebFetch|WebSearch)
+      scan_network_input "$input"
       ;;
     mcp__*)
       scan_mcp_input "$input"

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -637,6 +637,75 @@ deny_path_basename_pattern() {
   printf '%s' "$py"
 }
 
+deny_path_char_hex_pattern() {
+  case "$1" in
+    0) printf '3[0]' ;; 1) printf '3[1]' ;; 2) printf '3[2]' ;; 3) printf '3[3]' ;;
+    4) printf '3[4]' ;; 5) printf '3[5]' ;; 6) printf '3[6]' ;; 7) printf '3[7]' ;;
+    8) printf '3[8]' ;; 9) printf '3[9]' ;;
+    a|A) printf '6[1]' ;; b|B) printf '6[2]' ;; c|C) printf '6[3]' ;;
+    d|D) printf '6[4]' ;; e|E) printf '6[5]' ;; f|F) printf '6[6]' ;;
+    g|G) printf '6[7]' ;; h|H) printf '6[8]' ;; i|I) printf '6[9]' ;;
+    j|J) printf '6[aA]' ;; k|K) printf '6[bB]' ;; l|L) printf '6[cC]' ;;
+    m|M) printf '6[dD]' ;; n|N) printf '6[eE]' ;; o|O) printf '6[fF]' ;;
+    p|P) printf '7[0]' ;; q|Q) printf '7[1]' ;; r|R) printf '7[2]' ;;
+    s|S) printf '7[3]' ;; t|T) printf '7[4]' ;; u|U) printf '7[5]' ;;
+    v|V) printf '7[6]' ;; w|W) printf '7[7]' ;; x|X) printf '7[8]' ;;
+    y|Y) printf '7[9]' ;; z|Z) printf '7[aA]' ;;
+    '.') printf '2[eE]' ;; '_') printf '5[fF]' ;; '-') printf '2[dD]' ;;
+    *) return 1 ;;
+  esac
+}
+
+deny_path_shell_expansion_char_pattern() {
+  ch=$1
+  case "$ch" in
+    '.'|'^'|'$'|'+'|'?'|'('|')'|'['|']'|'{'|'}'|'|'|'\\')
+      literal=\\$ch
+      ;;
+    *)
+      literal=$ch
+      ;;
+  esac
+
+  hex=$(deny_path_char_hex_pattern "$ch" 2>/dev/null || true)
+  case "$ch" in
+    '/')
+      printf '/'
+      ;;
+    '.')
+      if [ -n "$hex" ]; then
+        printf '(%s|\\\\x%s)' "$literal" "$hex"
+      else
+        printf '%s' "$literal"
+      fi
+      ;;
+    *)
+      if [ -n "$hex" ]; then
+        printf '(%s|\\\\x%s|\\?|\\*|\\[[^]]+\\])' "$literal" "$hex"
+      else
+        printf '(%s|\\?|\\*|\\[[^]]+\\])' "$literal"
+      fi
+      ;;
+  esac
+}
+
+deny_path_shell_expansion_pattern() {
+  # Match shell forms that can expand to a deny-listed path, such as
+  # .e[n]v, .e?v, .e*v, or $'.e\x6ev'.
+  pattern=$1
+  py=
+  remaining=$pattern
+  while [ -n "$remaining" ]; do
+    ch=${remaining%"${remaining#?}"}
+    remaining=${remaining#?}
+    case "$ch" in
+      '*') py=${py}'[^[:space:]<>|;&`$()]*' ;;
+      *) py=${py}$(deny_path_shell_expansion_char_pattern "$ch") ;;
+    esac
+  done
+  printf '%s' "$py"
+}
+
 bash_matches_deny_path_literal() {
   cmd=$1
   [ -f "$DENY_READ_PATHS" ] || return 1
@@ -647,6 +716,23 @@ bash_matches_deny_path_literal() {
     converted=$(deny_path_basename_pattern "$entry")
     [ -n "$converted" ] || continue
     # Catch path arguments and shell words without matching substrings like myenv.
+    regex='(^|[^[:alnum:]_./~-])('${converted}'|[^[:space:]<>|;&`$()]*/'${converted}')([^[:alnum:]_.-]|$)'
+    if printf '%s\n' "$cmd" | grep -Eq "$regex"; then
+      return 0
+    fi
+  done <"$DENY_READ_PATHS"
+  return 1
+}
+
+bash_matches_deny_path_shell_expansion() {
+  cmd=$1
+  [ -f "$DENY_READ_PATHS" ] || return 1
+  while IFS= read -r entry || [ -n "$entry" ]; do
+    case "$entry" in
+      ''|\#*) continue ;;
+    esac
+    converted=$(deny_path_shell_expansion_pattern "$entry")
+    [ -n "$converted" ] || continue
     regex='(^|[^[:alnum:]_./~-])('${converted}'|[^[:space:]<>|;&`$()]*/'${converted}')([^[:alnum:]_.-]|$)'
     if printf '%s\n' "$cmd" | grep -Eq "$regex"; then
       return 0
@@ -681,9 +767,11 @@ shell_dequote_for_policy() {
 bash_matches_deny_path() {
   cmd=$1
   bash_matches_deny_path_literal "$cmd" && return 0
+  bash_matches_deny_path_shell_expansion "$cmd" && return 0
   dequoted=$(shell_dequote_for_policy "$cmd")
   [ "$dequoted" = "$cmd" ] && return 1
-  bash_matches_deny_path_literal "$dequoted"
+  bash_matches_deny_path_literal "$dequoted" && return 0
+  bash_matches_deny_path_shell_expansion "$dequoted"
 }
 
 is_shell_command_separator() {

--- a/plugins/agent-guard/hooks/hooks.json
+++ b/plugins/agent-guard/hooks/hooks.json
@@ -2,7 +2,7 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Write|Edit|MultiEdit|Read|NotebookRead|Grep|Glob|Bash|apply_patch|mcp__.*",
+        "matcher": "Write|Edit|MultiEdit|Read|NotebookRead|Grep|Glob|Bash|WebFetch|WebSearch|apply_patch|mcp__.*",
         "hooks": [
           {
             "type": "command",

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -239,6 +239,18 @@ expect_json_status 2 "Bash escaped path fragment bypass is blocked" \
   '{"tool_name":"Bash","tool_input":{"command":"cat .e\\nv"}}' \
   hook-pre-tool
 
+expect_json_status 2 "Bash ANSI-C quoted path bypass is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"cat $'\''.e\\x6ev'\''"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Bash glob bracket path bypass is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"cat .e[n]v"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Bash glob wildcard path bypass is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"cat .e?v"}}' \
+  hook-pre-tool
+
 expect_json_status 2 "Bash command literal secret is blocked" \
   '{"tool_name":"Bash","tool_input":{"command":"printf AGENT_GUARD_TEST_SECRET > leaked.txt"}}' \
   hook-pre-tool

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -231,6 +231,18 @@ expect_json_status 2 "Bash absolute-path .env access is blocked" \
   '{"tool_name":"Bash","tool_input":{"command":"awk 1 /tmp/.env"}}' \
   hook-pre-tool
 
+expect_json_status 2 "Bash quoted path fragment bypass is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"cat .e\"nv"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Bash escaped path fragment bypass is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"cat .e\\nv"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Bash command literal secret is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"printf AGENT_GUARD_TEST_SECRET > leaked.txt"}}' \
+  hook-pre-tool
+
 expect_json_status 0 "myenv-like substring is allowed" \
   '{"tool_name":"Bash","tool_input":{"command":"echo myenvironment"}}' \
   hook-pre-tool
@@ -263,6 +275,22 @@ expect_json_status 2 "NotebookRead on sensitive path is blocked" \
   '{"tool_name":"NotebookRead","tool_input":{"notebook_path":".env"}}' \
   hook-pre-tool
 
+expect_json_status 2 "Grep on explicit sensitive path is blocked" \
+  '{"tool_name":"Grep","tool_input":{"pattern":"API_KEY","path":".env"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "broad Grep content search for secrets is blocked" \
+  '{"tool_name":"Grep","tool_input":{"pattern":"API_KEY","path":".","output_mode":"content"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "broad Grep files-only search for secrets is allowed" \
+  '{"tool_name":"Grep","tool_input":{"pattern":"API_KEY","path":".","output_mode":"files_with_matches"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "broad Grep content search for benign text is allowed" \
+  '{"tool_name":"Grep","tool_input":{"pattern":"TODO","path":".","output_mode":"content"}}' \
+  hook-pre-tool
+
 expect_json_status 2 "Codex Add File payload secret is blocked" \
   '{"tool_name":"apply_patch","tool_input":{"patch":"*** Begin Patch\n*** Add File: x\nAGENT_GUARD_TEST_SECRET\n*** End Patch"}}' \
   hook-pre-tool
@@ -273,6 +301,18 @@ expect_json_status 2 "Codex double-plus added secret is blocked" \
 
 expect_json_status 2 "MCP input secret is blocked" \
   '{"tool_name":"mcp__server__tool","tool_input":{"token":"AGENT_GUARD_TEST_SECRET"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "WebFetch file URL to sensitive path is blocked" \
+  '{"tool_name":"WebFetch","tool_input":{"url":"file:///.env","prompt":"summarize"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "WebSearch query with secret is blocked" \
+  '{"tool_name":"WebSearch","tool_input":{"query":"AGENT_GUARD_TEST_SECRET"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "WebSearch benign query is allowed" \
+  '{"tool_name":"WebSearch","tool_input":{"query":"agent guard documentation"}}' \
   hook-pre-tool
 
 TEST_REPO="$TMP_ROOT/repo"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -251,6 +251,10 @@ expect_json_status 2 "Bash glob wildcard path bypass is blocked" \
   '{"tool_name":"Bash","tool_input":{"command":"cat .e?v"}}' \
   hook-pre-tool
 
+expect_json_status 0 "Bash benign glob remains allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"ls *.md"}}' \
+  hook-pre-tool
+
 expect_json_status 2 "Bash command literal secret is blocked" \
   '{"tool_name":"Bash","tool_input":{"command":"printf AGENT_GUARD_TEST_SECRET > leaked.txt"}}' \
   hook-pre-tool


### PR DESCRIPTION
## Summary
- Add hook coverage for `WebFetch` and `WebSearch` so network tool input is scanned for secret-like values.
- Harden Bash path matching against quoted or escaped deny-listed path fragments.
- Block broad `Grep` content searches for secret-oriented patterns while allowing files-only or benign broad searches.

## Validation
- `make test`
- `make smoke-test`
- `git diff --check`
- `plugins/agent-guard/bin/agent-guard scan-path README.md examples/claude/settings.project.json examples/codex/hooks.json plugins/agent-guard/bin/agent-guard plugins/agent-guard/hooks/hooks.json tests/run.sh`

Note: local untracked `.env` was intentionally excluded from the PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Security Improvements**
  * Enhanced blocking of `WebFetch` and `WebSearch` operations that could expose sensitive data.
  * Expanded secret detection in tool inputs and bash commands to prevent accidental leaks.
  * Added guardrails against broad search patterns combined with secret-like queries.

* **Documentation**
  * Updated documentation to reflect expanded Web/MCP-related security restrictions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JeongJaeSoon/agent-guard/pull/49?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->