### PR TITLE
[codex] Add PII filtering provider adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,13 @@ It is not a vault, credential rotator, or replacement for GitHub Secret Scanning
 Agent Guard runs on macOS and Linux and expects:
 
 - `sh`
+- `awk`
 - `git`
 - `jq`
 - `gitleaks` 8.30 or newer recommended
 
 Install paths that download release archives also use `curl`, `tar`, `shasum`, and `ln`.
+PII endpoint providers also use `curl`.
 
 With a direct CLI install:
 
@@ -141,12 +143,55 @@ Common commands:
 agent-guard scan-path .
 agent-guard scan-working-tree
 agent-guard scan-staged
+agent-guard pii-filter
 agent-guard setup
 agent-guard smoke-test
 agent-guard checksum
 ```
 
 Override install defaults with `AGENT_GUARD_VERSION`, `AGENT_GUARD_HOME`, or `AGENT_GUARD_BIN_DIR`.
+
+## PII Filtering
+
+`agent-guard pii-filter` reads text from stdin, masks detected PII, and writes the masked text to stdout. The default provider is `regex`, a built-in shell/awk adapter with no Python runtime dependency:
+
+```sh
+printf '%s\n' 'Email jane@example.com from 203.0.113.42' | agent-guard pii-filter
+# Email [PII:EMAIL] from [PII:IP_ADDRESS]
+```
+
+The built-in regex provider masks common deterministic formats: email addresses, phone numbers, credit cards, US SSNs, and IP addresses. Clean text is passed through unchanged.
+
+Choose a provider with `AGENT_GUARD_PII_PROVIDER`:
+
+```sh
+AGENT_GUARD_PII_PROVIDER=regex agent-guard pii-filter --check
+```
+
+Endpoint-backed providers are available for external redaction services:
+
+```sh
+AGENT_GUARD_PII_PROVIDER=pleno \
+AGENT_GUARD_PII_REDACT_URL=http://127.0.0.1:8080/api/redact \
+agent-guard pii-filter --check
+
+printf '%s\n' 'Customer jane@example.com' \
+  | AGENT_GUARD_PII_PROVIDER=pleno \
+    AGENT_GUARD_PII_REDACT_URL=http://127.0.0.1:8080/api/redact \
+    agent-guard pii-filter
+```
+
+`pleno` and `http` use the same HTTP adapter: POST JSON as `{"text":"..."}` and read a redacted string from `redacted_text`, `anonymized_text`, `text`, or `data.redacted_text`. They require `curl`, `jq`, and `AGENT_GUARD_PII_REDACT_URL`; missing tools, missing URL, HTTP errors, invalid JSON, or unexpected response shapes fail closed.
+
+Agent Guard does not install, import, run, or manage `pleno-anonymize`, Docker, Python, or any hosted service. If you use `pleno`, run pleno-anonymize separately or point `AGENT_GUARD_PII_REDACT_URL` at a hosted compatible endpoint.
+
+Masking is a CLI workflow. Agent hooks cannot safely rewrite pending tool payloads, so hook PII enforcement is off by default. To block tool inputs containing PII, opt in explicitly:
+
+```sh
+AGENT_GUARD_PII_HOOK_MODE=block
+```
+
+In block mode, proposed `Write`, `Edit`, `MultiEdit`, `apply_patch`, `Bash`, `WebFetch`, `WebSearch`, and MCP inputs are blocked when PII is detected, with guidance to run `agent-guard pii-filter` first. `AGENT_GUARD_PII_HOOK_MODE=mask` is rejected because hooks cannot perform safe in-flight masking.
 
 ## Native Git Hook
 
@@ -198,6 +243,7 @@ To enable it, add an Actions secret named `OPENAI_API_KEY` in the GitHub reposit
 - `Write`, `Edit`, `MultiEdit`, and Codex `apply_patch` content containing secret-like values
 - `WebFetch`, `WebSearch`, and MCP tool input JSON containing secret-like values
 - risky shell commands such as `printenv`, `op read`, `vault kv get`, `aws secretsmanager get-secret-value`, `cat .env`, and `git commit --no-verify`
+- PII in proposed write, shell, web, or MCP inputs only when `AGENT_GUARD_PII_HOOK_MODE=block`
 - staged added lines in the native pre-commit hook
 - working-tree added lines and untracked files after agent mutations
 
@@ -211,6 +257,9 @@ Override bundled policies with environment variables:
 AGENT_GUARD_GITLEAKS_CONFIG=/path/to/gitleaks.toml
 AGENT_GUARD_DENY_READ_PATHS=/path/to/deny-read-paths.txt
 AGENT_GUARD_DENY_BASH_PATTERNS=/path/to/deny-bash-patterns.txt
+AGENT_GUARD_PII_PROVIDER=regex
+AGENT_GUARD_PII_REDACT_URL=http://127.0.0.1:8080/api/redact
+AGENT_GUARD_PII_HOOK_MODE=off
 ```
 
 Project-local `.gitleaks.toml` files are not automatically trusted.

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -46,6 +46,7 @@ Usage:
   agent-guard hook-pre-tool
   agent-guard hook-post-tool
   agent-guard hook-stop
+  agent-guard pii-filter [--check]
   agent-guard scan-staged
   agent-guard scan-working-tree
   agent-guard scan-path PATH...
@@ -289,6 +290,9 @@ smoke_test() {
   printf '%s' '{"tool_name":"Read","tool_input":{"file_path":".env"}}' \
     | smoke_expect 2 "hook-pre-tool blocks .env reads" hook_pre_tool
 
+  printf '%s\n' "Contact smoke@example.com from 203.0.113.42" \
+    | smoke_expect 0 "pii-filter runs with the regex provider" pii_filter
+
   write_payload=$(mktemp_file) || die "smoke: failed to create temp file"
   {
     printf '%s' '{"tool_name":"Write","tool_input":{"file_path":"key.pem","content":"'
@@ -305,6 +309,7 @@ smoke_test() {
     git init -q || exit 2
     git config user.email test@example.com || exit 2
     git config user.name "Agent Guard Smoke" || exit 2
+    git config commit.gpgsign false || exit 2
     printf '%s\n' ok >README.md
     git add README.md || exit 2
     git commit -q -m init || exit 2
@@ -327,6 +332,196 @@ smoke_test() {
 
 mktemp_file() {
   mktemp "${TMPDIR:-/tmp}/agent-guard.XXXXXX" 2>/dev/null || mktemp /tmp/agent-guard.XXXXXX
+}
+
+pii_filter_usage() {
+  cat >&2 <<'EOF'
+Usage:
+  agent-guard pii-filter [--check]
+
+Reads text from stdin and writes masked text to stdout.
+Set AGENT_GUARD_PII_PROVIDER=regex|pleno|http to choose a provider.
+EOF
+}
+
+pii_provider() {
+  provider=${AGENT_GUARD_PII_PROVIDER:-regex}
+  case "$provider" in
+    regex|pleno|http) printf '%s' "$provider" ;;
+    *) die "pii-filter: unsupported provider: $provider (expected regex, pleno, or http)" ;;
+  esac
+}
+
+pii_regex_adapter_filter() {
+  need_cmd awk
+  awk '
+    BEGIN {
+      credit_card = "[0-9][0-9][0-9][0-9][ -]?[0-9][0-9][0-9][0-9][ -]?[0-9][0-9][0-9][0-9][ -]?[0-9][0-9][0-9][0-9]([ -]?[0-9][0-9][0-9])?"
+      ssn = "[0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9][0-9][0-9]"
+      ip_addr = "[0-9][0-9]?[0-9]?[.][0-9][0-9]?[0-9]?[.][0-9][0-9]?[0-9]?[.][0-9][0-9]?[0-9]?"
+      email = "[[:alnum:]_%+.-]+@[[:alnum:].-]+[.][[:alpha:]][[:alpha:]][[:alpha:]]*"
+      phone = "([+]?[0-9][ .-]?)?([(][0-9][0-9][0-9][)]|[0-9][0-9][0-9])[ .-]?[0-9][0-9][0-9][ .-]?[0-9][0-9][0-9][0-9]"
+    }
+    {
+      if (NR > 1) {
+        printf "%s", ORS
+      }
+      gsub(credit_card, "[PII:CREDIT_CARD]")
+      gsub(ssn, "[PII:SSN]")
+      gsub(ip_addr, "[PII:IP_ADDRESS]")
+      gsub(email, "[PII:EMAIL]")
+      gsub(phone, "[PII:PHONE]")
+      printf "%s", $0
+    }
+  '
+}
+
+pii_endpoint_adapter_filter() {
+  provider=$1
+  need_cmd curl
+  need_cmd jq
+  url=${AGENT_GUARD_PII_REDACT_URL:-}
+  [ -n "$url" ] || die "pii-filter: AGENT_GUARD_PII_REDACT_URL is required for provider: $provider"
+
+  out=$(mktemp_file) || die "pii-filter: failed to create temp file"
+  if ! jq -Rs '{text: .}' \
+    | curl -fsS -H 'Content-Type: application/json' -d @- "$url" >"$out"; then
+    rm -f "$out"
+    die "pii-filter: $provider provider request failed: $url"
+  fi
+
+  if ! jq -er '
+    if type == "object" and (.redacted_text | type == "string") then .redacted_text
+    elif type == "object" and (.anonymized_text | type == "string") then .anonymized_text
+    elif type == "object" and (.text | type == "string") then .text
+    elif type == "object" and (.data.redacted_text | type == "string") then .data.redacted_text
+    else error("missing redacted text")
+    end
+  ' "$out"; then
+    rm -f "$out"
+    die "pii-filter: $provider provider returned invalid response; expected JSON with redacted_text, anonymized_text, text, or data.redacted_text"
+  fi
+  rm -f "$out"
+}
+
+pii_adapter_filter() {
+  provider=${1:-$(pii_provider)}
+  case "$provider" in
+    regex) pii_regex_adapter_filter ;;
+    pleno|http) pii_endpoint_adapter_filter "$provider" ;;
+    *) die "pii-filter: unsupported provider: $provider (expected regex, pleno, or http)" ;;
+  esac
+}
+
+pii_adapter_check() {
+  provider=$1
+  case "$provider" in
+    regex)
+      need_cmd awk
+      info "$PROGRAM: PII provider regex ok"
+      ;;
+    pleno|http)
+      printf '%s' "agent-guard pii provider check" | pii_endpoint_adapter_filter "$provider" >/dev/null
+      status=$?
+      [ "$status" -eq 0 ] || exit "$status"
+      info "$PROGRAM: PII provider $provider ok"
+      ;;
+    *) die "pii-filter: unsupported provider: $provider (expected regex, pleno, or http)" ;;
+  esac
+}
+
+pii_filter() {
+  check=0
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --check) check=1 ;;
+      -h|--help)
+        pii_filter_usage
+        return 0
+        ;;
+      *) die "pii-filter: unknown argument: $1" ;;
+    esac
+    shift
+  done
+
+  provider=$(pii_provider)
+  if [ "$check" -eq 1 ]; then
+    pii_adapter_check "$provider"
+    return 0
+  fi
+  pii_adapter_filter "$provider"
+}
+
+pii_text_has_match() {
+  text=$1
+  [ -n "$text" ] || return 1
+  masked=$(printf '%s' "$text" | pii_adapter_filter)
+  status=$?
+  [ "$status" -eq 0 ] || exit "$status"
+  [ "$masked" != "$text" ]
+}
+
+pii_hook_block_enabled() {
+  mode=${AGENT_GUARD_PII_HOOK_MODE:-off}
+  case "$mode" in
+    off|'') return 1 ;;
+    block) return 0 ;;
+    mask)
+      die "PII hook mode mask is not supported; hooks cannot rewrite pending tool payloads. Use agent-guard pii-filter before invoking tools, or set AGENT_GUARD_PII_HOOK_MODE=block."
+      ;;
+    *) die "unsupported PII hook mode: $mode (expected off or block)" ;;
+  esac
+}
+
+block_on_pii_text() {
+  label=$1
+  text=$2
+  if pii_text_has_match "$text"; then
+    info "$PROGRAM: blocked PII in $label; run agent-guard pii-filter before using this tool"
+    exit 2
+  fi
+}
+
+check_pii_hook_input() {
+  input=$1
+  tool=$2
+  pii_hook_block_enabled || return 0
+  need_cmd jq
+
+  case "$tool" in
+    Write)
+      content=$(json_value '.tool_input.content // empty' "$input")
+      block_on_pii_text "proposed Write content" "$content"
+      ;;
+    Edit)
+      content=$(json_value '.tool_input.new_string // empty' "$input")
+      block_on_pii_text "proposed Edit content" "$content"
+      ;;
+    MultiEdit)
+      content=$(printf '%s' "$input" | jq -r '[.tool_input.edits[]?.new_string // empty] | join("\n")')
+      block_on_pii_text "proposed MultiEdit content" "$content"
+      ;;
+    apply_patch)
+      patch=$(printf '%s' "$input" | jq -r '
+        .tool_input.patch // .tool_input.input // .tool_input.diff // .tool_input.content // empty
+        | if type == "string" then . else tojson end
+      ')
+      added=$(printf '%s\n' "$patch" | extract_patch_added_lines)
+      block_on_pii_text "proposed apply_patch added lines" "$added"
+      ;;
+    Bash)
+      content=$(json_value '.tool_input.command // .tool_input.cmd // empty' "$input")
+      block_on_pii_text "Bash command" "$content"
+      ;;
+    WebFetch|WebSearch)
+      content=$(printf '%s' "$input" | jq -r '.tool_input // {} | .. | strings')
+      block_on_pii_text "$tool input" "$content"
+      ;;
+    mcp__*)
+      content=$(printf '%s' "$input" | jq -r '.tool_input // {} | .. | strings')
+      block_on_pii_text "MCP tool input" "$content"
+      ;;
+  esac
 }
 
 run_gitleaks_stdin() {
@@ -1045,10 +1240,9 @@ hook_pre_tool() {
     mcp__*)
       scan_mcp_input "$input"
       ;;
-    *)
-      return 0
-      ;;
   esac
+
+  check_pii_hook_input "$input" "$tool"
 }
 
 is_mutation_tool() {
@@ -1096,6 +1290,7 @@ case "$cmd" in
   hook-pre-tool) hook_pre_tool ;;
   hook-post-tool) hook_post_tool ;;
   hook-stop) hook_stop ;;
+  pii-filter) shift; pii_filter "$@" ;;
   scan-staged) shift; scan_staged "$@" ;;
   scan-working-tree) shift; scan_working_tree "$@" ;;
   scan-path) shift; scan_path "$@" ;;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -7,6 +7,8 @@ TMP_ROOT=${TMPDIR:-/tmp}/agent-guard-tests.$$
 MOCK_BIN="$TMP_ROOT/bin"
 ORIGINAL_PATH=$PATH
 REAL_GITLEAKS=$(command -v gitleaks 2>/dev/null || true)
+REAL_CURL=$(command -v curl 2>/dev/null || true)
+REAL_JQ=$(command -v jq)
 REAL_SH=$(command -v sh)
 REAL_DIRNAME=$(command -v dirname)
 REAL_PWD=$(command -v pwd)
@@ -331,6 +333,65 @@ expect_json_status 0 "WebSearch benign query is allowed" \
   '{"tool_name":"WebSearch","tool_input":{"query":"agent guard documentation"}}' \
   hook-pre-tool
 
+expect_json_status 0 "PII hook mode defaults off" \
+  '{"tool_name":"Write","tool_input":{"file_path":"note.txt","content":"email jane@example.com"}}' \
+  hook-pre-tool
+
+printf '%s' '{"tool_name":"Write","tool_input":{"file_path":"note.txt","content":"email jane@example.com"}}' \
+  | AGENT_GUARD_PII_HOOK_MODE=block "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool \
+    >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "PII hook block mode blocks proposed Write content"
+else
+  not_ok "PII hook block mode blocks proposed Write content (expected 2, got $status)"
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+
+printf '%s' '{"tool_name":"WebSearch","tool_input":{"query":"look up 203.0.113.42"}}' \
+  | AGENT_GUARD_PII_HOOK_MODE=block "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool \
+    >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "PII hook block mode blocks WebSearch input"
+else
+  not_ok "PII hook block mode blocks WebSearch input (expected 2, got $status)"
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+
+printf '%s' '{"tool_name":"mcp__server__tool","tool_input":{"note":"call 555-123-4567"}}' \
+  | AGENT_GUARD_PII_HOOK_MODE=block "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool \
+    >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "PII hook block mode blocks MCP input"
+else
+  not_ok "PII hook block mode blocks MCP input (expected 2, got $status)"
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+
+printf '%s' '{"tool_name":"Write","tool_input":{"file_path":"note.txt","content":"AGENT_GUARD_TEST_SECRET jane@example.com"}}' \
+  | AGENT_GUARD_PII_HOOK_MODE=block "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool \
+    >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+status=$?
+if [ "$status" -eq 2 ] && grep -q 'secret-like' /tmp/agent-guard-test.err; then
+  ok "secret scanning runs before PII hook scanning"
+else
+  not_ok "secret scanning runs before PII hook scanning (expected secret-like block, got $status)"
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+
+printf '%s' '{"tool_name":"Write","tool_input":{"file_path":"note.txt","content":"clean"}}' \
+  | AGENT_GUARD_PII_HOOK_MODE=mask "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool \
+    >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+status=$?
+if [ "$status" -eq 2 ] && grep -q 'mask is not supported' /tmp/agent-guard-test.err; then
+  ok "PII hook mask mode is rejected"
+else
+  not_ok "PII hook mask mode is rejected (expected 2, got $status)"
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+
 TEST_REPO="$TMP_ROOT/repo"
 mkdir -p "$TEST_REPO"
 (
@@ -494,8 +555,239 @@ if "$PLUGIN_ROOT/bin/agent-guard" help 2>&1 | grep -q 'smoke-test'; then
 else
   not_ok "help lists smoke-test"
 fi
+if "$PLUGIN_ROOT/bin/agent-guard" help 2>&1 | grep -q 'pii-filter'; then
+  ok "help lists pii-filter"
+else
+  not_ok "help lists pii-filter"
+fi
 
 run_expect 0 "check passes when deps and configs exist" "$PLUGIN_ROOT/bin/agent-guard" check
+
+# --- pii-filter -----------------------------------------------------------
+
+PII_SAMPLE='Contact jane@example.com at +1 (415) 555-0199, card 4111 1111 1111 1111, ssn 123-45-6789, ip 203.0.113.42.'
+PII_EXPECTED='Contact [PII:EMAIL] at [PII:PHONE], card [PII:CREDIT_CARD], ssn [PII:SSN], ip [PII:IP_ADDRESS].'
+printf '%s\n' "$PII_SAMPLE" | "$PLUGIN_ROOT/bin/agent-guard" pii-filter \
+  >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+status=$?
+if [ "$status" -eq 0 ] && [ "$(cat /tmp/agent-guard-test.out)" = "$PII_EXPECTED" ]; then
+  ok "pii-filter regex provider masks common PII"
+else
+  not_ok "pii-filter regex provider masks common PII (status $status)"
+  sed 's/^/  stdout: /' /tmp/agent-guard-test.out
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+
+PII_CLEAN='No identifiers in this line.'
+printf '%s\n' "$PII_CLEAN" | "$PLUGIN_ROOT/bin/agent-guard" pii-filter \
+  >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+status=$?
+if [ "$status" -eq 0 ] && [ "$(cat /tmp/agent-guard-test.out)" = "$PII_CLEAN" ]; then
+  ok "pii-filter leaves clean text unchanged"
+else
+  not_ok "pii-filter leaves clean text unchanged (status $status)"
+  sed 's/^/  stdout: /' /tmp/agent-guard-test.out
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+
+printf '%s' "$PII_CLEAN" | "$PLUGIN_ROOT/bin/agent-guard" pii-filter \
+  >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+status=$?
+if [ "$status" -eq 0 ] && [ "$(cat /tmp/agent-guard-test.out)" = "$PII_CLEAN" ]; then
+  ok "pii-filter preserves clean text without trailing newline"
+else
+  not_ok "pii-filter preserves clean text without trailing newline (status $status)"
+  sed 's/^/  stdout: /' /tmp/agent-guard-test.out
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+
+printf '%s' 'Email jane@example.com' | "$PLUGIN_ROOT/bin/agent-guard" pii-filter \
+  >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+status=$?
+if [ "$status" -eq 0 ] && [ "$(cat /tmp/agent-guard-test.out)" = 'Email [PII:EMAIL]' ]; then
+  ok "pii-filter preserves masked text without trailing newline"
+else
+  not_ok "pii-filter preserves masked text without trailing newline (status $status)"
+  sed 's/^/  stdout: /' /tmp/agent-guard-test.out
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+
+run_expect 0 "pii-filter --check passes for default regex provider" \
+  "$PLUGIN_ROOT/bin/agent-guard" pii-filter --check
+
+printf '%s' 'x' | AGENT_GUARD_PII_PROVIDER=bogus "$PLUGIN_ROOT/bin/agent-guard" pii-filter \
+  >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "pii-filter rejects unknown providers"
+else
+  not_ok "pii-filter rejects unknown providers (expected 2, got $status)"
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+
+PII_MOCK_CURL_DIR="$TMP_ROOT/pii-curl-bin"
+PII_REQUEST_FILE="$TMP_ROOT/pii-request.json"
+PII_URL_FILE="$TMP_ROOT/pii-url.txt"
+mkdir -p "$PII_MOCK_CURL_DIR"
+cat > "$PII_MOCK_CURL_DIR/curl" <<'EOSH'
+#!/usr/bin/env sh
+last=
+for arg do
+  last=$arg
+done
+if [ -n "${PII_MOCK_CURL_URL:-}" ]; then
+  printf '%s\n' "$last" >"$PII_MOCK_CURL_URL"
+fi
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -d|--data|--data-raw|--data-binary)
+      shift
+      if [ "${1:-}" = "@-" ]; then
+        cat >"$PII_MOCK_CURL_REQUEST"
+      fi
+      ;;
+  esac
+  [ "$#" -gt 0 ] || break
+  shift
+done
+case "${PII_MOCK_CURL_MODE:-ok}" in
+  ok) printf '%s\n' '{"redacted_text":"masked by endpoint"}' ;;
+  data) printf '%s\n' '{"data":{"redacted_text":"masked by nested endpoint"}}' ;;
+  bad-json) printf '%s\n' 'not json' ;;
+  bad-response) printf '%s\n' '{"unexpected":"value"}' ;;
+  fail) printf '%s\n' 'synthetic curl failure' >&2; exit 7 ;;
+esac
+EOSH
+chmod +x "$PII_MOCK_CURL_DIR/curl"
+
+printf '%s' 'endpoint text jane@example.com' \
+  | PATH="$PII_MOCK_CURL_DIR:$PATH" \
+    AGENT_GUARD_PII_PROVIDER=pleno \
+    AGENT_GUARD_PII_REDACT_URL='http://127.0.0.1:8080/api/redact' \
+    PII_MOCK_CURL_REQUEST="$PII_REQUEST_FILE" \
+    PII_MOCK_CURL_URL="$PII_URL_FILE" \
+    "$PLUGIN_ROOT/bin/agent-guard" pii-filter \
+    >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+status=$?
+if [ "$status" -eq 0 ] && [ "$(cat /tmp/agent-guard-test.out)" = "masked by endpoint" ]; then
+  ok "pii-filter pleno provider uses endpoint adapter response"
+else
+  not_ok "pii-filter pleno provider uses endpoint adapter response (status $status)"
+  sed 's/^/  stdout: /' /tmp/agent-guard-test.out
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+if jq -e '.text == "endpoint text jane@example.com"' "$PII_REQUEST_FILE" >/dev/null 2>&1; then
+  ok "pii-filter endpoint adapter sends text JSON payload"
+else
+  not_ok "pii-filter endpoint adapter sends text JSON payload"
+  sed 's/^/  request: /' "$PII_REQUEST_FILE"
+fi
+if [ "$(cat "$PII_URL_FILE")" = "http://127.0.0.1:8080/api/redact" ]; then
+  ok "pii-filter endpoint adapter uses AGENT_GUARD_PII_REDACT_URL"
+else
+  not_ok "pii-filter endpoint adapter uses AGENT_GUARD_PII_REDACT_URL"
+fi
+
+PATH="$PII_MOCK_CURL_DIR:$PATH" \
+  AGENT_GUARD_PII_PROVIDER=http \
+  AGENT_GUARD_PII_REDACT_URL='http://127.0.0.1:8080/api/redact' \
+  PII_MOCK_CURL_REQUEST="$PII_REQUEST_FILE" \
+  PII_MOCK_CURL_MODE=data \
+  "$PLUGIN_ROOT/bin/agent-guard" pii-filter --check \
+  >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+status=$?
+if [ "$status" -eq 0 ]; then
+  ok "pii-filter http provider passes endpoint check"
+else
+  not_ok "pii-filter http provider passes endpoint check (expected 0, got $status)"
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+
+printf '%s' 'x' \
+  | env -u AGENT_GUARD_PII_REDACT_URL AGENT_GUARD_PII_PROVIDER=pleno \
+    "$PLUGIN_ROOT/bin/agent-guard" pii-filter \
+    >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "pii-filter endpoint provider fails closed when URL is missing"
+else
+  not_ok "pii-filter endpoint provider fails closed when URL is missing (expected 2, got $status)"
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+
+printf '%s' 'x' \
+  | PATH="$PII_MOCK_CURL_DIR:$PATH" \
+    AGENT_GUARD_PII_PROVIDER=pleno \
+    AGENT_GUARD_PII_REDACT_URL='http://127.0.0.1:8080/api/redact' \
+    PII_MOCK_CURL_REQUEST="$PII_REQUEST_FILE" \
+    PII_MOCK_CURL_MODE=fail \
+    "$PLUGIN_ROOT/bin/agent-guard" pii-filter \
+    >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "pii-filter endpoint provider fails closed on HTTP failure"
+else
+  not_ok "pii-filter endpoint provider fails closed on HTTP failure (expected 2, got $status)"
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+
+printf '%s' 'x' \
+  | PATH="$PII_MOCK_CURL_DIR:$PATH" \
+    AGENT_GUARD_PII_PROVIDER=pleno \
+    AGENT_GUARD_PII_REDACT_URL='http://127.0.0.1:8080/api/redact' \
+    PII_MOCK_CURL_REQUEST="$PII_REQUEST_FILE" \
+    PII_MOCK_CURL_MODE=bad-response \
+    "$PLUGIN_ROOT/bin/agent-guard" pii-filter \
+    >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "pii-filter endpoint provider fails closed on bad response shape"
+else
+  not_ok "pii-filter endpoint provider fails closed on bad response shape (expected 2, got $status)"
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+
+NO_CURL_BIN="$TMP_ROOT/no-curl-bin"
+mkdir -p "$NO_CURL_BIN"
+ln -s "$REAL_SH" "$NO_CURL_BIN/sh"
+ln -s "$REAL_DIRNAME" "$NO_CURL_BIN/dirname"
+ln -s "$REAL_PWD" "$NO_CURL_BIN/pwd"
+ln -s "$REAL_JQ" "$NO_CURL_BIN/jq"
+PATH="$NO_CURL_BIN" \
+  AGENT_GUARD_PII_PROVIDER=pleno \
+  AGENT_GUARD_PII_REDACT_URL='http://127.0.0.1:8080/api/redact' \
+  "$PLUGIN_ROOT/bin/agent-guard" pii-filter --check \
+  >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "pii-filter endpoint provider fails closed when curl is missing"
+else
+  not_ok "pii-filter endpoint provider fails closed when curl is missing (expected 2, got $status)"
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+
+if [ -n "$REAL_CURL" ]; then
+  NO_JQ_BIN="$TMP_ROOT/no-jq-bin"
+  mkdir -p "$NO_JQ_BIN"
+  ln -s "$REAL_SH" "$NO_JQ_BIN/sh"
+  ln -s "$REAL_DIRNAME" "$NO_JQ_BIN/dirname"
+  ln -s "$REAL_PWD" "$NO_JQ_BIN/pwd"
+  ln -s "$REAL_CURL" "$NO_JQ_BIN/curl"
+  PATH="$NO_JQ_BIN" \
+    AGENT_GUARD_PII_PROVIDER=pleno \
+    AGENT_GUARD_PII_REDACT_URL='http://127.0.0.1:8080/api/redact' \
+    "$PLUGIN_ROOT/bin/agent-guard" pii-filter --check \
+    >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+  status=$?
+  if [ "$status" -eq 2 ]; then
+    ok "pii-filter endpoint provider fails closed when jq is missing"
+  else
+    not_ok "pii-filter endpoint provider fails closed when jq is missing (expected 2, got $status)"
+    sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+  fi
+else
+  say "real curl not available; skipped missing-jq endpoint dependency test"
+fi
 
 # --- setup -----------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Add `agent-guard pii-filter`, reading stdin and writing masked text to stdout.
- Add user-facing PII provider selection and internal adapter structure.
- Add the built-in `regex` provider for deterministic masking of email, phone, credit card, SSN, and IP address values.
- Add endpoint-backed adapter support using `AGENT_GUARD_PII_REDACT_URL`, `curl`, and `jq` with fail-closed validation.
- Add opt-in hook PII block mode via `AGENT_GUARD_PII_HOOK_MODE=block`; hook masking is explicitly rejected.

## Design notes

- `regex` remains the default so the base install does not add Python, Docker, pleno-anonymize, or service startup requirements.
- Agent hooks cannot safely rewrite pending tool payloads, so masking is CLI-only. Hook enforcement is off by default and block-only when opted in.
- Existing secret guard behavior keeps priority: secret/network scanning runs before PII scanning in pre-tool paths.
- Follow-up PR #54 narrows the public provider scope to `regex` and `http`; verified real pleno-anonymize provider support remains tracked in #53.

## Review feedback addressed

- Fixed the regex provider so it no longer adds a trailing newline when stdin does not end with `\n`.
- Added regression tests for clean and masked text without trailing newline.

## Conflict resolution

- Rebased onto latest `origin/main` after #49 and #55 landed.
- Kept the new WebFetch/WebSearch secret-scanning tests from main and the PII hook tests from this branch.
- Kept main's hardened network input scanning before opt-in PII hook scanning.
- Disabled commit signing inside the smoke-test temp repo so inherited local Git signing config cannot break `make smoke-test`.

## Validation

- `make test`
- `make smoke-test`
- `git diff --check`
- `plugins/agent-guard/bin/agent-guard scan-path README.md plugins/agent-guard/bin/agent-guard tests/run.sh`

## Main-base check

- Rebased on `origin/main` at `de71825`.
- `origin/main...HEAD` contains one commit: `72fb631 feat: add PII filtering provider adapters`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PII filtering capability with configurable providers (regex and HTTP endpoint support).
  * Optional hook-based PII enforcement for proposed inputs (requires explicit opt-in via configuration).

* **Documentation**
  * Added PII filtering workflow and usage guide.
  * Updated tooling requirements and configuration examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JeongJaeSoon/agent-guard/pull/51?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->