### PR TITLE
[codex] Add plugin layout validation CI

### DIFF
--- a/.github/workflows/plugin-validation.yml
+++ b/.github/workflows/plugin-validation.yml
@@ -1,0 +1,24 @@
+name: Plugin validation
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  plugin-validation:
+    name: Plugin layout
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Run tests
+        run: make test
+
+      - name: Validate plugin layout
+        run: scripts/validate-plugin-layout.sh

--- a/.github/workflows/plugin-validation.yml
+++ b/.github/workflows/plugin-validation.yml
@@ -20,5 +20,14 @@ jobs:
       - name: Run tests
         run: make test
 
-      - name: Validate plugin layout
-        run: scripts/validate-plugin-layout.sh
+      - name: Validate Codex plugin layout
+        run: scripts/validate-plugin-layout.sh --codex
+
+      - name: Validate Claude plugin layout
+        run: scripts/validate-plugin-layout.sh --claude
+
+      - name: Validate plugin marketplaces
+        run: scripts/validate-plugin-layout.sh --marketplace
+
+      - name: Validate release archive layout
+        run: scripts/validate-plugin-layout.sh --archive

--- a/.github/workflows/plugin-validation.yml
+++ b/.github/workflows/plugin-validation.yml
@@ -1,4 +1,4 @@
-name: Plugin validation
+name: Plugin Validation
 
 on:
   pull_request:
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   plugin-validation:
-    name: Plugin layout
+    name: Plugin Layout
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -20,14 +20,14 @@ jobs:
       - name: Run tests
         run: make test
 
-      - name: Validate Codex plugin layout
+      - name: Validate Codex Plugin Layout
         run: scripts/validate-plugin-layout.sh --codex
 
-      - name: Validate Claude plugin layout
+      - name: Validate Claude Plugin Layout
         run: scripts/validate-plugin-layout.sh --claude
 
-      - name: Validate plugin marketplaces
+      - name: Validate Plugin Marketplaces
         run: scripts/validate-plugin-layout.sh --marketplace
 
-      - name: Validate release archive layout
+      - name: Validate Release Archive Layout
         run: scripts/validate-plugin-layout.sh --archive

--- a/scripts/validate-plugin-layout.sh
+++ b/scripts/validate-plugin-layout.sh
@@ -42,8 +42,12 @@ require_json() {
   fi
 }
 
-has_generic_plugin_root() {
-  printf '%s\n' "$1" | grep -Eq '(^|[^A-Z_])PLUGIN_ROOT([^A-Z_]|$)'
+contains_shell_variable_reference() {
+  value=$1
+  name=$2
+  pattern=$(printf '\\$\\{%s([^A-Za-z0-9_]|$)|\\$%s([^A-Za-z0-9_]|$)' "$name" "$name")
+
+  printf '%s\n' "$value" | grep -Eq "($pattern)"
 }
 
 validate_hook_commands() {
@@ -63,26 +67,29 @@ validate_hook_commands() {
   while IFS= read -r command; do
     case "$required" in
       PLUGIN_ROOT)
-        if has_generic_plugin_root "$command"; then
+        if contains_shell_variable_reference "$command" PLUGIN_ROOT; then
           ok "$host hook command uses PLUGIN_ROOT"
         else
           fail "$host hook command uses PLUGIN_ROOT"
         fi
-        case "$command" in
-          *CLAUDE_PLUGIN_ROOT*|*CODEX_PLUGIN_ROOT*) fail "$host hook command avoids CLAUDE_PLUGIN_ROOT and CODEX_PLUGIN_ROOT" ;;
-          *) ok "$host hook command avoids CLAUDE_PLUGIN_ROOT and CODEX_PLUGIN_ROOT" ;;
-        esac
+        if contains_shell_variable_reference "$command" CLAUDE_PLUGIN_ROOT || contains_shell_variable_reference "$command" CODEX_PLUGIN_ROOT; then
+          fail "$host hook command avoids CLAUDE_PLUGIN_ROOT and CODEX_PLUGIN_ROOT"
+        else
+          ok "$host hook command avoids CLAUDE_PLUGIN_ROOT and CODEX_PLUGIN_ROOT"
+        fi
         ;;
       *)
-        case "$command" in
-          *"$required"*) ok "$host hook command uses $required" ;;
-          *) fail "$host hook command uses $required" ;;
-        esac
-        case "$command" in
-          *CODEX_PLUGIN_ROOT*) fail "$host hook command avoids CODEX_PLUGIN_ROOT" ;;
-          *) ok "$host hook command avoids CODEX_PLUGIN_ROOT" ;;
-        esac
-        if has_generic_plugin_root "$command"; then
+        if contains_shell_variable_reference "$command" "$required"; then
+          ok "$host hook command uses $required"
+        else
+          fail "$host hook command uses $required"
+        fi
+        if contains_shell_variable_reference "$command" CODEX_PLUGIN_ROOT; then
+          fail "$host hook command avoids CODEX_PLUGIN_ROOT"
+        else
+          ok "$host hook command avoids CODEX_PLUGIN_ROOT"
+        fi
+        if contains_shell_variable_reference "$command" PLUGIN_ROOT; then
           fail "$host hook command avoids generic PLUGIN_ROOT"
         else
           ok "$host hook command avoids generic PLUGIN_ROOT"
@@ -124,7 +131,7 @@ validate_claude() {
   for command_file in "$PLUGIN_ROOT"/commands/*.md; do
     [ -e "$command_file" ] || continue
     command_count=$((command_count + 1))
-    if grep -q 'CLAUDE_PLUGIN_ROOT' "$command_file"; then
+    if grep -Eq '(\$\{CLAUDE_PLUGIN_ROOT([^A-Za-z0-9_]|$)|\$CLAUDE_PLUGIN_ROOT([^A-Za-z0-9_]|$))' "$command_file"; then
       ok "$command_file uses CLAUDE_PLUGIN_ROOT"
     else
       fail "$command_file uses CLAUDE_PLUGIN_ROOT"

--- a/scripts/validate-plugin-layout.sh
+++ b/scripts/validate-plugin-layout.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd -P)
+PLUGIN_ROOT="$ROOT/plugins/agent-guard"
+tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/agent-guard-layout.XXXXXX")
+trap 'rm -rf "$tmpdir"' EXIT INT TERM
+
+failures=0
+
+ok() {
+  printf 'ok: %s\n' "$1"
+}
+
+fail() {
+  printf 'not ok: %s\n' "$1" >&2
+  failures=$((failures + 1))
+}
+
+require_file() {
+  if [ -f "$1" ]; then
+    ok "$1 exists"
+  else
+    fail "$1 exists"
+  fi
+}
+
+require_json() {
+  require_file "$1"
+  if [ -f "$1" ] && jq -e . "$1" >/dev/null; then
+    ok "$1 is valid JSON"
+  else
+    fail "$1 is valid JSON"
+  fi
+}
+
+has_generic_plugin_root() {
+  printf '%s\n' "$1" | grep -Eq '(^|[^A-Z_])PLUGIN_ROOT([^A-Z_]|$)'
+}
+
+validate_hook_commands() {
+  manifest=$1
+  host=$2
+  required=$3
+
+  command_list="$tmpdir/$host-commands.txt"
+  jq -r '.hooks | to_entries[] | .value[] | .hooks[]? | select(.type == "command") | .command' "$manifest" >"$command_list"
+  if [ -s "$command_list" ]; then
+    ok "$host hook commands are declared"
+  else
+    fail "$host hook commands are declared"
+    return
+  fi
+
+  while IFS= read -r command; do
+    case "$required" in
+      PLUGIN_ROOT)
+        if has_generic_plugin_root "$command"; then
+          ok "$host hook command uses PLUGIN_ROOT"
+        else
+          fail "$host hook command uses PLUGIN_ROOT"
+        fi
+        case "$command" in
+          *CLAUDE_PLUGIN_ROOT*|*CODEX_PLUGIN_ROOT*) fail "$host hook command avoids CLAUDE_PLUGIN_ROOT and CODEX_PLUGIN_ROOT" ;;
+          *) ok "$host hook command avoids CLAUDE_PLUGIN_ROOT and CODEX_PLUGIN_ROOT" ;;
+        esac
+        ;;
+      *)
+        case "$command" in
+          *"$required"*) ok "$host hook command uses $required" ;;
+          *) fail "$host hook command uses $required" ;;
+        esac
+        case "$command" in
+          *CODEX_PLUGIN_ROOT*) fail "$host hook command avoids CODEX_PLUGIN_ROOT" ;;
+          *) ok "$host hook command avoids CODEX_PLUGIN_ROOT" ;;
+        esac
+        if has_generic_plugin_root "$command"; then
+          fail "$host hook command avoids generic PLUGIN_ROOT"
+        else
+          ok "$host hook command avoids generic PLUGIN_ROOT"
+        fi
+        ;;
+    esac
+  done <"$command_list"
+}
+
+validate_archive_contains() {
+  archive=$1
+  path=$2
+
+  if grep -Fxq "$path" "$archive.list"; then
+    ok "release archive includes $path"
+  else
+    fail "release archive includes $path"
+  fi
+}
+
+require_json "$PLUGIN_ROOT/.codex-plugin/plugin.json"
+require_json "$PLUGIN_ROOT/hooks.json"
+require_json "$PLUGIN_ROOT/hooks/hooks.json"
+require_json "$ROOT/.agents/plugins/marketplace.json"
+require_json "$ROOT/.claude-plugin/marketplace.json"
+
+if jq -e 'has("hooks") or has("apps") or has("mcpServers")' "$PLUGIN_ROOT/.codex-plugin/plugin.json" >/dev/null; then
+  fail "Codex plugin manifest does not declare unsupported companion fields"
+else
+  ok "Codex plugin manifest does not declare unsupported companion fields"
+fi
+
+validate_hook_commands "$PLUGIN_ROOT/hooks.json" "Codex" "PLUGIN_ROOT"
+validate_hook_commands "$PLUGIN_ROOT/hooks/hooks.json" "Claude" "CLAUDE_PLUGIN_ROOT"
+
+command_count=0
+for command_file in "$PLUGIN_ROOT"/commands/*.md; do
+  [ -e "$command_file" ] || continue
+  command_count=$((command_count + 1))
+  if grep -q 'CLAUDE_PLUGIN_ROOT' "$command_file"; then
+    ok "$command_file uses CLAUDE_PLUGIN_ROOT"
+  else
+    fail "$command_file uses CLAUDE_PLUGIN_ROOT"
+  fi
+done
+
+if [ "$command_count" -gt 0 ]; then
+  ok "Claude slash command markdown files are present"
+else
+  fail "Claude slash command markdown files are present"
+fi
+
+if jq -e '.plugins[] | select(.name == "agent-guard" and .source.path == "./plugins/agent-guard")' "$ROOT/.agents/plugins/marketplace.json" >/dev/null; then
+  ok "Codex marketplace points to ./plugins/agent-guard"
+else
+  fail "Codex marketplace points to ./plugins/agent-guard"
+fi
+
+if jq -e '.plugins[] | select(.name == "agent-guard" and .source == "./plugins/agent-guard")' "$ROOT/.claude-plugin/marketplace.json" >/dev/null; then
+  ok "Claude marketplace points to ./plugins/agent-guard"
+else
+  fail "Claude marketplace points to ./plugins/agent-guard"
+fi
+
+archive="$tmpdir/agent-guard-validation.tar.gz"
+
+"$ROOT/scripts/build-release-tarball.sh" 0.0.0 "$archive"
+tar -tzf "$archive" | sed 's#^\./##' >"$archive.list"
+
+validate_archive_contains "$archive" ".codex-plugin/plugin.json"
+validate_archive_contains "$archive" ".claude-plugin/plugin.json"
+validate_archive_contains "$archive" "hooks.json"
+validate_archive_contains "$archive" "hooks/hooks.json"
+
+archive_command_count=$(find "$PLUGIN_ROOT/commands" -type f -name '*.md' | wc -l | tr -d ' ')
+if [ "$archive_command_count" -gt 0 ]; then
+  for command_file in "$PLUGIN_ROOT"/commands/*.md; do
+    command_name=${command_file#"$PLUGIN_ROOT/"}
+    validate_archive_contains "$archive" "$command_name"
+  done
+else
+  fail "release archive has command markdown files to validate"
+fi
+
+if [ "$failures" -eq 0 ]; then
+  printf 'plugin layout validation passed\n'
+else
+  printf 'plugin layout validation failed: %s issue(s)\n' "$failures" >&2
+  exit 1
+fi

--- a/scripts/validate-plugin-layout.sh
+++ b/scripts/validate-plugin-layout.sh
@@ -7,6 +7,14 @@ tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/agent-guard-layout.XXXXXX")
 trap 'rm -rf "$tmpdir"' EXIT INT TERM
 
 failures=0
+run_codex=0
+run_claude=0
+run_marketplace=0
+run_archive=0
+
+usage() {
+  printf 'usage: %s [--all|--codex|--claude|--marketplace|--archive]\n' "$0" >&2
+}
 
 ok() {
   printf 'ok: %s\n' "$1"
@@ -95,69 +103,118 @@ validate_archive_contains() {
   fi
 }
 
-require_json "$PLUGIN_ROOT/.codex-plugin/plugin.json"
-require_json "$PLUGIN_ROOT/hooks.json"
-require_json "$PLUGIN_ROOT/hooks/hooks.json"
-require_json "$ROOT/.agents/plugins/marketplace.json"
-require_json "$ROOT/.claude-plugin/marketplace.json"
+validate_codex() {
+  require_json "$PLUGIN_ROOT/.codex-plugin/plugin.json"
+  require_json "$PLUGIN_ROOT/hooks.json"
 
-if jq -e 'has("hooks") or has("apps") or has("mcpServers")' "$PLUGIN_ROOT/.codex-plugin/plugin.json" >/dev/null; then
-  fail "Codex plugin manifest does not declare unsupported companion fields"
-else
-  ok "Codex plugin manifest does not declare unsupported companion fields"
+  if jq -e 'has("hooks") or has("apps") or has("mcpServers")' "$PLUGIN_ROOT/.codex-plugin/plugin.json" >/dev/null; then
+    fail "Codex plugin manifest does not declare unsupported companion fields"
+  else
+    ok "Codex plugin manifest does not declare unsupported companion fields"
+  fi
+
+  validate_hook_commands "$PLUGIN_ROOT/hooks.json" "Codex" "PLUGIN_ROOT"
+}
+
+validate_claude() {
+  require_json "$PLUGIN_ROOT/hooks/hooks.json"
+  validate_hook_commands "$PLUGIN_ROOT/hooks/hooks.json" "Claude" "CLAUDE_PLUGIN_ROOT"
+
+  command_count=0
+  for command_file in "$PLUGIN_ROOT"/commands/*.md; do
+    [ -e "$command_file" ] || continue
+    command_count=$((command_count + 1))
+    if grep -q 'CLAUDE_PLUGIN_ROOT' "$command_file"; then
+      ok "$command_file uses CLAUDE_PLUGIN_ROOT"
+    else
+      fail "$command_file uses CLAUDE_PLUGIN_ROOT"
+    fi
+  done
+
+  if [ "$command_count" -gt 0 ]; then
+    ok "Claude slash command markdown files are present"
+  else
+    fail "Claude slash command markdown files are present"
+  fi
+}
+
+validate_marketplace() {
+  require_json "$ROOT/.agents/plugins/marketplace.json"
+  require_json "$ROOT/.claude-plugin/marketplace.json"
+
+  if jq -e '.plugins[] | select(.name == "agent-guard" and .source.path == "./plugins/agent-guard")' "$ROOT/.agents/plugins/marketplace.json" >/dev/null; then
+    ok "Codex marketplace points to ./plugins/agent-guard"
+  else
+    fail "Codex marketplace points to ./plugins/agent-guard"
+  fi
+
+  if jq -e '.plugins[] | select(.name == "agent-guard" and .source == "./plugins/agent-guard")' "$ROOT/.claude-plugin/marketplace.json" >/dev/null; then
+    ok "Claude marketplace points to ./plugins/agent-guard"
+  else
+    fail "Claude marketplace points to ./plugins/agent-guard"
+  fi
+}
+
+validate_archive() {
+  archive="$tmpdir/agent-guard-validation.tar.gz"
+
+  "$ROOT/scripts/build-release-tarball.sh" 0.0.0 "$archive"
+  tar -tzf "$archive" | sed 's#^\./##' >"$archive.list"
+
+  validate_archive_contains "$archive" ".codex-plugin/plugin.json"
+  validate_archive_contains "$archive" ".claude-plugin/plugin.json"
+  validate_archive_contains "$archive" "hooks.json"
+  validate_archive_contains "$archive" "hooks/hooks.json"
+
+  if [ -d "$PLUGIN_ROOT/commands" ]; then
+    archive_command_count=$(find "$PLUGIN_ROOT/commands" -type f -name '*.md' | wc -l | tr -d ' ')
+  else
+    archive_command_count=0
+  fi
+  if [ "$archive_command_count" -gt 0 ]; then
+    for command_file in "$PLUGIN_ROOT"/commands/*.md; do
+      command_name=${command_file#"$PLUGIN_ROOT/"}
+      validate_archive_contains "$archive" "$command_name"
+    done
+  else
+    fail "release archive has command markdown files to validate"
+  fi
+}
+
+if [ "$#" -eq 0 ]; then
+  run_codex=1
+  run_claude=1
+  run_marketplace=1
+  run_archive=1
 fi
 
-validate_hook_commands "$PLUGIN_ROOT/hooks.json" "Codex" "PLUGIN_ROOT"
-validate_hook_commands "$PLUGIN_ROOT/hooks/hooks.json" "Claude" "CLAUDE_PLUGIN_ROOT"
-
-command_count=0
-for command_file in "$PLUGIN_ROOT"/commands/*.md; do
-  [ -e "$command_file" ] || continue
-  command_count=$((command_count + 1))
-  if grep -q 'CLAUDE_PLUGIN_ROOT' "$command_file"; then
-    ok "$command_file uses CLAUDE_PLUGIN_ROOT"
-  else
-    fail "$command_file uses CLAUDE_PLUGIN_ROOT"
-  fi
+for mode in "$@"; do
+  case "$mode" in
+    --all)
+      run_codex=1
+      run_claude=1
+      run_marketplace=1
+      run_archive=1
+      ;;
+    --codex) run_codex=1 ;;
+    --claude) run_claude=1 ;;
+    --marketplace) run_marketplace=1 ;;
+    --archive) run_archive=1 ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
 done
 
-if [ "$command_count" -gt 0 ]; then
-  ok "Claude slash command markdown files are present"
-else
-  fail "Claude slash command markdown files are present"
-fi
-
-if jq -e '.plugins[] | select(.name == "agent-guard" and .source.path == "./plugins/agent-guard")' "$ROOT/.agents/plugins/marketplace.json" >/dev/null; then
-  ok "Codex marketplace points to ./plugins/agent-guard"
-else
-  fail "Codex marketplace points to ./plugins/agent-guard"
-fi
-
-if jq -e '.plugins[] | select(.name == "agent-guard" and .source == "./plugins/agent-guard")' "$ROOT/.claude-plugin/marketplace.json" >/dev/null; then
-  ok "Claude marketplace points to ./plugins/agent-guard"
-else
-  fail "Claude marketplace points to ./plugins/agent-guard"
-fi
-
-archive="$tmpdir/agent-guard-validation.tar.gz"
-
-"$ROOT/scripts/build-release-tarball.sh" 0.0.0 "$archive"
-tar -tzf "$archive" | sed 's#^\./##' >"$archive.list"
-
-validate_archive_contains "$archive" ".codex-plugin/plugin.json"
-validate_archive_contains "$archive" ".claude-plugin/plugin.json"
-validate_archive_contains "$archive" "hooks.json"
-validate_archive_contains "$archive" "hooks/hooks.json"
-
-archive_command_count=$(find "$PLUGIN_ROOT/commands" -type f -name '*.md' | wc -l | tr -d ' ')
-if [ "$archive_command_count" -gt 0 ]; then
-  for command_file in "$PLUGIN_ROOT"/commands/*.md; do
-    command_name=${command_file#"$PLUGIN_ROOT/"}
-    validate_archive_contains "$archive" "$command_name"
-  done
-else
-  fail "release archive has command markdown files to validate"
-fi
+[ "$run_codex" -eq 1 ] && validate_codex
+[ "$run_claude" -eq 1 ] && validate_claude
+[ "$run_marketplace" -eq 1 ] && validate_marketplace
+[ "$run_archive" -eq 1 ] && validate_archive
 
 if [ "$failures" -eq 0 ]; then
   printf 'plugin layout validation passed\n'


### PR DESCRIPTION
## Summary

- Add a repo-local plugin layout validation script for the merged Codex/Claude plugin structure.
- Add a dedicated GitHub Actions workflow that runs `make test` and the new layout validation on pull requests and `main` pushes.
- Validate release tarball contents so missing plugin manifests, hook files, or Claude command docs are caught before release.

## Context

PR #56 has been merged first, so this validation PR is based on the new host-specific plugin layout. After this PR is merged, future plugin layout changes should be checked by CI instead of relying on manual review.

## Verification

- `scripts/validate-plugin-layout.sh`
- `make test` (`passed: 171`, `failed: 0`)
- `git diff --check`
- `git diff --cached --check`
