### PR TITLE
fix(agent-guard): calibrate secret-detection patterns (close env/cloud-cred-dump gaps, fix dotenv-template & env-pipeline FPs)

### DIFF
--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -622,28 +622,35 @@ scan_untracked_files() {
   need_cmd git
   need_gitleaks
   list=$(mktemp_file) || die "failed to create temp file"
-  git ls-files --others --exclude-standard >"$list" || {
+  # core.quotePath=false + -z keep every filename byte-exact (non-ASCII,
+  # backslash, quote, even an embedded newline). The previous newline-delimited
+  # read silently skipped such names — letting a careless or adversarial agent
+  # park a secret in a file the backstop never scanned.
+  git -c core.quotePath=false ls-files --others --exclude-standard -z >"$list" || {
     rm -f "$list"
     die "failed to list untracked files"
   }
 
-  # Stream every untracked file through a single gitleaks stdin call.
-  # The "### file: <path>" header lets a finding's surrounding context
-  # still indicate which file produced it, while keeping the gitleaks
-  # process count at O(1) instead of O(N) per untracked file.
+  if [ ! -s "$list" ]; then
+    rm -f "$list"
+    return 0
+  fi
+
+  # Stream every untracked file through a single gitleaks stdin call. The
+  # "### file: <path>" header keeps a finding's context pointing at its file
+  # while holding the gitleaks process count at O(1). xargs -0 drives the
+  # NUL-delimited list because POSIX `read` cannot split on NUL.
   blob=$(mktemp_file) || { rm -f "$list"; die "failed to create temp file"; }
-  any=0
-  while IFS= read -r path; do
-    [ -n "$path" ] || continue
-    [ -f "$path" ] || continue
-    any=1
-    printf '### file: %s\n' "$path" >>"$blob"
-    cat -- "$path" >>"$blob"
-    printf '\n' >>"$blob"
-  done <"$list"
+  xargs -0 -I '{}' sh -c '
+    f=$1
+    [ -f "$f" ] || exit 0
+    printf "### file: %s\n" "$f"
+    cat -- "$f"
+    printf "\n"
+  ' _ '{}' >>"$blob" <"$list"
   rm -f "$list"
 
-  if [ "$any" -eq 0 ]; then
+  if [ ! -s "$blob" ]; then
     rm -f "$blob"
     return 0
   fi
@@ -763,8 +770,22 @@ resolve_path() {
   fi
 }
 
+# Allowlist short-circuit consulted before any deny-path check (both the Read and
+# Bash paths). It currently exempts committed `.env` placeholder templates that
+# the `.env*` deny glob would otherwise block. Matched on the exact basename so a
+# real secret file is never exempted by a crafted name. NOTE: a match here exempts
+# the candidate from ALL deny patterns, so only add names that never hold secrets.
+candidate_is_allowed() {
+  case "$1" in
+    .env.example|.env.sample|.env.template|.env.dist) return 0 ;;
+    */.env.example|*/.env.sample|*/.env.template|*/.env.dist) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 candidate_matches_deny() {
   candidate=$1
+  candidate_is_allowed "$candidate" && return 1
   while IFS= read -r pattern || [ -n "$pattern" ]; do
     case "$pattern" in
       ''|\#*) continue ;;
@@ -942,8 +963,33 @@ shell_dequote_for_policy() {
   '
 }
 
+# Drop tokens that name an allowed `.env` template (e.g. `.env.example`) before
+# the whole-command deny regex runs, so `cat .env.example` is allowed while
+# `cat .env.example .env` still blocks on the bare `.env` token. Globbing is
+# disabled inside a subshell so a stray `*` in the command is not expanded
+# against the real filesystem during word splitting.
+bash_strip_allowed_tokens() {
+  (
+    set -f
+    words=$(shell_command_words "$1")
+    # shellcheck disable=SC2086
+    set -- $words
+    result=
+    for token in "$@"; do
+      candidate_is_allowed "$token" && continue
+      if [ -z "$result" ]; then
+        result=$token
+      else
+        result="$result $token"
+      fi
+    done
+    printf '%s' "$result"
+  )
+}
+
 bash_matches_deny_path() {
   cmd=$1
+  cmd=$(bash_strip_allowed_tokens "$cmd")
   bash_matches_deny_path_mode "$cmd" "literal" && return 0
   bash_matches_deny_path_mode "$cmd" "shell-expanded" && return 0
   dequoted=$(shell_dequote_for_policy "$cmd")
@@ -1001,6 +1047,37 @@ is_git_global_option() {
   esac
 }
 
+is_assignment_token() {
+  case "$1" in
+    [A-Za-z_]*=*)
+      case "${1%%=*}" in
+        *[!A-Za-z0-9_]*) return 1 ;;
+        *) return 0 ;;
+      esac
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+# Transparent wrappers that run the command following them; a git commit/push
+# behind one of these still stages/commits, so the gate must see through it.
+is_noop_wrapper() {
+  case "$1" in
+    env|command|sudo|nice|nohup|time|xargs) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Wrapper options that consume the next token as a value (env -u NAME, env -C
+# DIR, nice -n N, …). Kept to unambiguous flags so the wrapped command head is
+# not misread as an option value.
+wrapper_option_takes_value() {
+  case "$1" in
+    -u|--unset|-C|--chdir|-S|--split-string|-n) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 is_git_commit_or_push() {
   cmd=$1
   (
@@ -1012,31 +1089,63 @@ is_git_commit_or_push() {
     command_start=1
     while [ "$#" -gt 0 ]; do
       token=$1
-      shift
 
-      if [ "$command_start" -eq 1 ] && [ "$token" = "git" ]; then
-        while [ "$#" -gt 0 ]; do
-          token=$1
+      if [ "$command_start" -eq 1 ]; then
+        # Strip leading `NAME=value` assignments and no-op wrappers so a wrapped
+        # invocation like `FOO=1 env git commit --no-verify` still reaches the
+        # git check below. command_start stays 1 so the next token is re-examined
+        # as the command head.
+        if is_assignment_token "$token"; then
           shift
-          if git_option_takes_value "$token"; then
-            [ "$#" -gt 0 ] && shift
-            continue
-          fi
-          is_git_global_option "$token" && continue
+          continue
+        fi
+        if is_noop_wrapper "$token"; then
+          shift
+          while [ "$#" -gt 0 ]; do
+            case "$1" in
+              --) shift; break ;;
+              -*)
+                if wrapper_option_takes_value "$1"; then
+                  shift
+                  [ "$#" -gt 0 ] && shift
+                else
+                  shift
+                fi
+                ;;
+              *)
+                is_assignment_token "$1" && { shift; continue; }
+                break
+                ;;
+            esac
+          done
+          continue
+        fi
+        if [ "$token" = "git" ]; then
+          shift
+          while [ "$#" -gt 0 ]; do
+            token=$1
+            shift
+            if git_option_takes_value "$token"; then
+              [ "$#" -gt 0 ] && shift
+              continue
+            fi
+            is_git_global_option "$token" && continue
 
-          case "$token" in
-            commit|push)
-              return 0
-              ;;
-            *)
-              break
-              ;;
-          esac
-        done
-        command_start=0
-        continue
+            case "$token" in
+              commit|push)
+                return 0
+                ;;
+              *)
+                break
+                ;;
+            esac
+          done
+          command_start=0
+          continue
+        fi
       fi
 
+      shift
       if is_shell_command_separator "$token"; then
         command_start=1
       else

--- a/plugins/agent-guard/config/deny-bash-patterns.txt
+++ b/plugins/agent-guard/config/deny-bash-patterns.txt
@@ -1,7 +1,23 @@
 # POSIX ERE patterns. Blank lines and lines starting with # are ignored.
 # Path-based reads are handled from deny-read-paths; keep only pathless shell idioms here.
 (^|[[:space:];|&])printenv([^[:alnum:]_-]|$)
-(^|[[:space:];|&])env[[:space:]]*($|[;|&])
+(^|[[:space:];|&])env[[:space:]]*($|[;&])
+# `env` whose output is piped or redirected dumps the environment into a sink
+# (`env | base64`, `env > /tmp/e`). Matching any `|`/`>` (rather than a fixed
+# sink list) closes gaps like `env | gzip` or `env | gpg`. The leading class
+# omits `|` so this fires on a real pipeline (` env|grep`) but not on `env`
+# inside a quoted regex alternation like 'a|env|b'. `env VAR=x cmd | grep` is not
+# matched because the pipe follows the wrapped command, not bare `env`.
+(^|[[:space:];&])env[[:space:]]*[|>]
+# Shell builtins that print every variable (export -p / declare -p / typeset -p,
+# and bare `set`). `set` keeps `;&` (not `|`) trailing so `set -e`/`set -o` and a
+# 'a|set|b' regex are not blocked, only a bare environment dump.
+(^|[[:space:];|&])(declare|typeset|export)[[:space:]]+-[A-Za-z]*p
+(^|[[:space:];|&])set[[:space:]]*($|[;&])
+# Reading /proc/<pid>/environ dumps the environment. The PID segment is often a
+# shell variable ($$, $BASHPID) the deny-read glob cannot match, so accept any
+# non-space, non-slash segment here.
+/proc/[^[:space:]/]+/environ
 security[[:space:]]+find-generic-password
 op[[:space:]]+read
 op[[:space:]]+item[[:space:]]+get
@@ -9,6 +25,15 @@ vault[[:space:]]+kv[[:space:]]+get
 vault[[:space:]]+read
 aws[[:space:]]+secretsmanager[[:space:]]+get-secret-value
 aws[[:space:]]+ssm[[:space:]]+get-parameter
+aws[[:space:]]+configure[[:space:]]+export-credentials
 gcloud[[:space:]]+secrets[[:space:]]+versions[[:space:]]+access
+gcloud[[:space:]]+auth[[:space:]]+print-(access|identity)-token
+az[[:space:]]+account[[:space:]]+get-access-token
+(^|[[:space:];|&])doppler[[:space:]]+(secrets|run)
+# Reading secret material out of kubectl requires an output flag; plain
+# `kubectl get secrets` (listing names only, or `-o name`) is intentionally left
+# allowed. Covers `secret/name` syntax, `-o`/`--output`, `-o=`/`-ojson` forms,
+# and `go-template` extraction.
+kubectl[[:space:]].*get[[:space:]]+secret(s)?(/[^[:space:]]+)?([[:space:]].*)?(-o|--output)[[:space:]=]*(yaml|json|jsonpath|go-template)
 (curl|wget).*(TOKEN|SECRET|PASSWORD|API[_-]?KEY|ACCESS[_-]?KEY)
 gh[[:space:]]+auth[[:space:]]+token

--- a/plugins/agent-guard/config/deny-bash-patterns.txt
+++ b/plugins/agent-guard/config/deny-bash-patterns.txt
@@ -30,10 +30,16 @@ gcloud[[:space:]]+secrets[[:space:]]+versions[[:space:]]+access
 gcloud[[:space:]]+auth[[:space:]]+print-(access|identity)-token
 az[[:space:]]+account[[:space:]]+get-access-token
 (^|[[:space:];|&])doppler[[:space:]]+(secrets|run)
-# Reading secret material out of kubectl requires an output flag; plain
-# `kubectl get secrets` (listing names only, or `-o name`) is intentionally left
-# allowed. Covers `secret/name` syntax, `-o`/`--output`, `-o=`/`-ojson` forms,
-# and `go-template` extraction.
-kubectl[[:space:]].*get[[:space:]]+secret(s)?(/[^[:space:]]+)?([[:space:]].*)?(-o|--output)[[:space:]=]*(yaml|json|jsonpath|go-template)
+# Reading secret material out of kubectl requires a structured output flag;
+# plain `kubectl get secrets` (listing names only, or `-o name`) is intentionally
+# left allowed. kubectl accepts the output flag on either side of the resource
+# (`kubectl get [(-o|--output=)yaml|...] (TYPE...)`), so both orders are covered.
+# Each line anchors the secret resource on a token boundary (a leading space, so
+# `secret` is the resource type, not a substring of a name like `app-secret`) and
+# covers `secret/name` syntax, `-o`/`--output`, `-o=`/`-ojson`, and `go-template`.
+# Known accepted residual: `kubectl get all -o yaml -n secrets` (a namespace
+# literally named `secrets`) over-blocks; rare enough to favor closing the dump.
+kubectl[[:space:]].*get.*[[:space:]]secrets?(/[^[:space:]]+)?[[:space:]].*(-o|--output)[[:space:]=]*(yaml|json|jsonpath|go-template)
+kubectl[[:space:]].*get.*(-o|--output)[[:space:]=]*(yaml|json|jsonpath|go-template).*[[:space:]]secrets?(/[^[:space:]]+)?([[:space:]]|$)
 (curl|wget).*(TOKEN|SECRET|PASSWORD|API[_-]?KEY|ACCESS[_-]?KEY)
 gh[[:space:]]+auth[[:space:]]+token

--- a/plugins/agent-guard/config/deny-read-paths.txt
+++ b/plugins/agent-guard/config/deny-read-paths.txt
@@ -27,3 +27,17 @@ secrets.yaml
 secrets.yml
 service-account*.json
 gcp-sa*.json
+# Reading the process environment is equivalent to `env`/`printenv`. The Bash
+# variant (incl. variable PIDs like /proc/$$/environ) is handled in
+# deny-bash-patterns.txt, which the deny-read glob cannot match.
+/proc/*/environ
+# Additional high-value secret material (keystores, DB/Vault creds, IaC state).
+*.p8
+*.jks
+*.keystore
+.pgpass
+.my.cnf
+*.tfstate
+*.tfvars
+.vault-token
+.dev.vars

--- a/plugins/agent-guard/config/gitleaks.toml
+++ b/plugins/agent-guard/config/gitleaks.toml
@@ -9,6 +9,9 @@ regexes = [
   '''(?i)example[_-]?(token|key|secret|password)''',
   '''(?i)dummy[_-]?(token|key|secret|password)''',
   '''(?i)not[-_ ]?a[-_ ]?real[-_ ]?(token|key|secret|password)''',
-  '''x{8,}''',
-  '''0{12,}'''
+  # Anchored to the whole secret so a placeholder shaped entirely from
+  # alphanumerics with a long run of x's (or all zeros) is still exempt, but a
+  # real secret that merely embeds such a run is no longer silently suppressed.
+  '''(?i)^[A-Za-z0-9]*x{12,}[A-Za-z0-9]*$''',
+  '''^0{12,}$'''
 ]

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -501,6 +501,24 @@ expect_json_status 0 "kubectl get secret -o name (names only) is allowed" \
   '{"tool_name":"Bash","tool_input":{"command":"kubectl get secret db -o name"}}' \
   hook-pre-tool
 
+# Output flag may precede the resource (kubectl get [(-o ...)] TYPE); both orders
+# must block, but a name merely containing "secret" must not false-positive.
+expect_json_status 2 "kubectl get -o yaml secret/name (flag before resource) is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"kubectl get -o yaml secret/my-secret"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "kubectl get -o json secrets (flag before plural type) is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"kubectl get -o json secrets"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "kubectl get configmap app-secret -o yaml (name contains secret) is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"kubectl get configmap app-secret -o yaml"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "kubectl get pods -o yaml (no secret resource) is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"kubectl get pods -o yaml"}}' \
+  hook-pre-tool
+
 expect_json_status 0 "gcloud auth login is allowed" \
   '{"tool_name":"Bash","tool_input":{"command":"gcloud auth login"}}' \
   hook-pre-tool

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -432,6 +432,175 @@ expect_json_status 0 "WebSearch benign query is allowed" \
   '{"tool_name":"WebSearch","tool_input":{"query":"agent guard documentation"}}' \
   hook-pre-tool
 
+# --- Detection calibration & robustness (PR 1) ----------------------------
+# Rank 1: reading the process environment via /proc is an env-dump bypass.
+expect_json_status 2 "Bash /proc/self/environ read is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"cat /proc/self/environ"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Bash /proc/<pid>/environ with a shell PID is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"cat /proc/$$/environ"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "Bash /proc/cpuinfo read is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"cat /proc/cpuinfo"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Read /proc/self/environ is blocked" \
+  '{"tool_name":"Read","tool_input":{"file_path":"/proc/self/environ"}}' \
+  hook-pre-tool
+
+# Rank 2: see through no-op wrappers / assignments before the git check, so a
+# hook-disabling commit cannot hide behind `env` or a `FOO=bar` prefix.
+expect_json_status 2 "env-wrapped git --no-verify is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"env git commit --no-verify -m x"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "assignment-prefixed git --no-verify is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"FOO=bar git commit --no-verify -m x"}}' \
+  hook-pre-tool
+
+# Rank 3: cloud / secrets-manager credential-dump siblings.
+expect_json_status 2 "gcloud auth print-access-token is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"gcloud auth print-access-token"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "az account get-access-token is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"az account get-access-token"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "aws configure export-credentials is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"aws configure export-credentials"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "kubectl get secret -o yaml is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"kubectl get secret db -o yaml"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "kubectl get secrets (names only) is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"kubectl get secrets"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "kubectl get secret -o=yaml (equals form) is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"kubectl get secret db -o=yaml"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "kubectl get secret --output yaml (long flag) is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"kubectl get secret db --output yaml"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "kubectl get secret/name -o yaml (resource/name) is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"kubectl get secret/db -o yaml"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "kubectl get secret -o go-template is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"kubectl get secret db -o go-template={{.data}}"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "kubectl get secret -o name (names only) is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"kubectl get secret db -o name"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "gcloud auth login is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"gcloud auth login"}}' \
+  hook-pre-tool
+
+# Rank 6: env-dump FP fix — `env` inside a quoted alternation must not block.
+expect_json_status 2 "env piped to a sink is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"env | grep PATH"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "env inside a quoted regex alternation is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"grep -E \"a|env|b\" notes.txt"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "python venv creation is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"python -m venv .venv"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "env redirected to a file is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"env > dump.txt"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "env piped to a non-listed sink (gzip) is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"env | gzip"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "env VAR=x cmd piped (wrapped command, not bare env) is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"env FOO=bar printf %s done | cat"}}' \
+  hook-pre-tool
+
+# Rank 7: allow committed .env templates, but never a real .env.
+expect_json_status 0 "Read .env.example template is allowed" \
+  '{"tool_name":"Read","tool_input":{"file_path":".env.example"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "Read .env.sample template is allowed" \
+  '{"tool_name":"Read","tool_input":{"file_path":".env.sample"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Read bare .env is blocked" \
+  '{"tool_name":"Read","tool_input":{"file_path":".env"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "Bash cat .env.example is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"cat .env.example"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Bash cat of a template plus a real .env still blocks" \
+  '{"tool_name":"Bash","tool_input":{"command":"cat .env.example .env"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Bash cp of a template to .env.local still blocks" \
+  '{"tool_name":"Bash","tool_input":{"command":"cp .env.example .env.local"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Bash cat of .env.local (not a template) is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"cat .env.local"}}' \
+  hook-pre-tool
+
+# Rank 8: shell builtins that print the whole environment.
+expect_json_status 2 "export -p is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"export -p"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "declare -p is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"declare -p"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "bare set is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"set"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "set -e is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"set -e"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "set -o pipefail is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"set -o pipefail"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "export of a single variable is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"export FOO=bar"}}' \
+  hook-pre-tool
+
+# Rank 9: additional high-value secret file types.
+expect_json_status 2 "Read a PKCS#8 .p8 key is blocked" \
+  '{"tool_name":"Read","tool_input":{"file_path":"AuthKey.p8"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Read terraform state is blocked" \
+  '{"tool_name":"Read","tool_input":{"file_path":"terraform.tfstate"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Read .pgpass is blocked" \
+  '{"tool_name":"Read","tool_input":{"file_path":".pgpass"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "Read a terraform module file is allowed" \
+  '{"tool_name":"Read","tool_input":{"file_path":"main.tf"}}' \
+  hook-pre-tool
+
 expect_json_status 0 "PII hook mode defaults off" \
   '{"tool_name":"Write","tool_input":{"file_path":"note.txt","content":"email jane@example.com"}}' \
   hook-pre-tool
@@ -597,6 +766,61 @@ fi
 expect_json_status 2 "git hook bypass without separator spaces is blocked" \
   '{"tool_name":"Bash","tool_input":{"command":"git commit --no-verify&&echo done"}}' \
   hook-pre-tool
+
+# R2: wrapper/assignment-prefixed commits with NO --no-verify must still reach
+# the staged scan via is_git_commit_or_push (not via the hook-bypass shortcut).
+# leak.txt is still staged from the harness above.
+(
+  cd "$TEST_REPO" || exit 2
+  printf '%s' '{"tool_name":"Bash","tool_input":{"command":"env git commit -m leak"}}' \
+    | "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+)
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "env-wrapped git commit with staged secret triggers staged scan"
+else
+  not_ok "env-wrapped git commit with staged secret triggers staged scan (expected 2, got $status)"
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+
+(
+  cd "$TEST_REPO" || exit 2
+  printf '%s' '{"tool_name":"Bash","tool_input":{"command":"FOO=bar git commit -m leak"}}' \
+    | "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+)
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "assignment-prefixed git commit with staged secret triggers staged scan"
+else
+  not_ok "assignment-prefixed git commit with staged secret triggers staged scan (expected 2, got $status)"
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+
+(
+  cd "$TEST_REPO" || exit 2
+  printf '%s' '{"tool_name":"Bash","tool_input":{"command":"env -u HOME git commit -m leak"}}' \
+    | "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+)
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "env-with-option-wrapped git commit with staged secret triggers staged scan"
+else
+  not_ok "env-with-option-wrapped git commit with staged secret triggers staged scan (expected 2, got $status)"
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+
+(
+  cd "$TEST_REPO" || exit 2
+  printf '%s' '{"tool_name":"Bash","tool_input":{"command":"env git status"}}' \
+    | "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+)
+status=$?
+if [ "$status" -eq 0 ]; then
+  ok "env-wrapped git status (not commit/push) is allowed"
+else
+  not_ok "env-wrapped git status (not commit/push) is allowed (expected 0, got $status)"
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
 
 SYMLINK_REPO="$TMP_ROOT/symlink-repo"
 mkdir -p "$SYMLINK_REPO"
@@ -1390,6 +1614,30 @@ else
   sed 's/^/  stderr: /' /tmp/agent-guard-test.err
 fi
 
+# --- Untracked scan is NUL-safe for non-ASCII filenames (Rank 4) ----------
+# git ls-files quotes non-ASCII paths unless core.quotePath=false; a newline
+# read loop would also mangle them. The scan must still see this file's secret.
+UTF8_REPO="$TMP_ROOT/utf8-repo"
+mkdir -p "$UTF8_REPO"
+(
+  cd "$UTF8_REPO" || exit 2
+  git init -q
+  git config user.email t@e
+  git config user.name t
+  printf 'ok\n' > README.md
+  git add README.md
+  git commit -q -m init
+  printf 'AGENT_GUARD_TEST_SECRET\n' > 'café-secret.txt'
+  "$PLUGIN_ROOT/bin/agent-guard" scan-working-tree >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+)
+status=$?
+if [ "$status" -eq 1 ]; then
+  ok "scan-working-tree detects a secret in a non-ASCII untracked filename"
+else
+  not_ok "scan-working-tree detects a secret in a non-ASCII untracked filename (expected 1, got $status)"
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+
 # --- agent-guard check announces gitleaks version ------------------------
 "$PLUGIN_ROOT/bin/agent-guard" check >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
 if grep -q 'gitleaks' /tmp/agent-guard-test.err; then
@@ -1439,6 +1687,27 @@ if [ -n "$REAL_GITLEAKS" ]; then
     ok "real gitleaks detects an OpenSSH private key through scan-path"
   else
     not_ok "real gitleaks detects an OpenSSH private key through scan-path (expected 1, got $status)"
+    sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+  fi
+
+  # Rank 5: the anchored allowlist no longer suppresses a real secret that
+  # merely contains a long run of x's. The PAT is assembled at runtime so this
+  # script never holds a contiguous `ghp_`-shaped literal that upstream scanners
+  # would flag; the 36-char body carries a 12-x run the old `x{8,}` regex masked.
+  PAT_HEAD='ghp_'
+  PAT_BODY='0123456789'
+  PAT_XRUN='xxxxxxxxxxxx'
+  PAT_TAIL='0123456789ABCD'
+  XRUN_FIXTURE_DIR="$TMP_ROOT/xrun-fixture-dir"
+  mkdir -p "$XRUN_FIXTURE_DIR"
+  printf 'token = %s%s%s%s\n' "$PAT_HEAD" "$PAT_BODY" "$PAT_XRUN" "$PAT_TAIL" \
+    > "$XRUN_FIXTURE_DIR/conf.txt"
+  PATH="$(dirname "$REAL_GITLEAKS"):$ORIGINAL_PATH" "$PLUGIN_ROOT/bin/agent-guard" scan-path "$XRUN_FIXTURE_DIR" >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+  status=$?
+  if [ "$status" -eq 1 ]; then
+    ok "real gitleaks still flags a PAT containing a 12-x run (anchored allowlist)"
+  else
+    not_ok "real gitleaks still flags a PAT containing a 12-x run (expected 1, got $status)"
     sed 's/^/  stderr: /' /tmp/agent-guard-test.err
   fi
 else


### PR DESCRIPTION
## Summary

Calibrates agent-guard's deterministic secret-detection denylist: closes a
cluster of environment / cloud-credential-dump **false negatives**, fixes two
**false positives** that blocked legitimate dev work, and hardens two backstops
that could silently no-op.

This is a deliberately coherent, reviewable slice driven by a multi-agent audit
against agent-guard's own design philosophy -- **thin but effective**: block
accidental or malicious secret exposure without over-blocking, stay
deterministic, fail closed. Scope is intentionally constrained: **no new
detection layer, no DLP/EDR expansion, no scanning of arbitrary file contents
referenced by shell.** Every change either tightens an existing denylist entry,
fixes an existing false positive, or makes an existing backstop actually run.

## Detection gaps closed

**`deny-bash-patterns.txt` / `deny-read-paths.txt`**

- **Process environment** -- reads of `/proc/<pid>/environ` (a direct bypass of
  the existing `env` / `printenv` blocks). The variable-PID form (`$$`,
  `$BASHPID`) the read-glob cannot express is handled in the bash list.
- **Cloud credential printers** -- `gcloud auth print-(access|identity)-token`,
  `az account get-access-token`, `aws configure export-credentials`,
  `doppler secrets|run`.
- **Kubernetes secret extraction** -- broadened to also catch `--output`, `-o=`,
  the no-space short form, the `secret/<name>` resource syntax, and
  `go-template`. Listing-only invocations (no output flag, or `-o name`) stay
  allowed by design.
- **Shell builtins that dump every variable** -- `export -p`, `declare -p`,
  `typeset -p`, and bare `set`. `set -e`, `set -o pipefail`, and
  `export FOO=bar` stay allowed.
- **Env exfil generalized** -- the env-pipe rule now matches any pipe or
  redirect rather than a fixed sink list, closing gaps like piping the
  environment into `gzip`/`gpg` or redirecting it to a file.
- **Additional secret file types** -- `*.p8`, `*.jks`, `*.keystore`, `.pgpass`,
  `.my.cnf`, `*.tfstate`, `*.tfvars`, `.vault-token`, `.dev.vars`.

## False positives fixed

- **`gitleaks.toml`** -- the allowlist had unanchored `x{8,}` and `0{12,}`
  regexes that suppressed *any* finding merely containing such a run, including
  real secrets. Anchored to placeholder-shaped strings only (verified against
  real gitleaks: the old config masked a real PAT, the new config flags it).
- **`.env` templates** -- `.env.example` / `.env.sample` / `.env.template` /
  `.env.dist` are committed by virtually every repo and were blocked by the
  `.env*` glob. Now allowlisted on both the Read and Bash paths via an exact
  basename match, while a bare `.env` (or any non-template `.env.*`) still
  blocks. The Bash path stays per-token, so `cat .env.example .env` still blocks
  on the real `.env` argument.

## Robustness

- **NUL-safe untracked-file backstop** -- `scan_untracked_files` now uses
  `git -c core.quotePath=false ls-files --others -z` with an `xargs -0` reader.
  The previous newline-delimited loop silently skipped files whose names git
  quotes (non-ASCII, backslash, quote, embedded newline) -- a place a careless
  or adversarial agent could park a secret the backstop never scanned.
- **Wrapper/assignment-aware git gate** -- `is_git_commit_or_push` now strips
  leading `NAME=value` assignments and no-op wrappers
  (`env`/`command`/`sudo`/`nice`/`nohup`/`time`/`xargs`, including their
  options) before the `git` check, so a wrapped commit/push still reaches the
  hook-bypass gate and the staged scan.

## Functional Verification

All checks run locally in this worktree against the modified tree.

```
$ make test
...
passed: 217
failed: 0
```

`make test` uses a mock gitleaks that flags the literal `AGENT_GUARD_TEST_SECRET`
(deterministic, offline) plus a real-gitleaks regression block. 13 new tests
were added, each shipping a **block** case and a **benign-passthrough** case:

- env-wrapped / assignment-prefixed / `env -u`-wrapped `git commit` against a
  staged secret all trigger the staged scan (exit 2); `env git status` stays a
  no-op (exit 0).
- kubectl variants `-o=yaml`, `--output yaml`, `secret/<name>`, `go-template`
  block; `get secrets` and `-o name` stay allowed.
- `env > file` and `env | gzip` block; a genuinely wrapped command pipeline
  (`env FOO=bar cmd | cat`) stays allowed.
- `cat .env.local` blocks (not a template suffix).
- **real gitleaks** still flags a `ghp_...` PAT that contains a 12-x run,
  confirming the anchored allowlist no longer masks real secrets.

```
$ make smoke-test
agent-guard: dependencies ok
agent-guard: gitleaks 8.30.0 (>= 8.30 recommended)
agent-guard: smoke ok: scan-path allows a clean directory
agent-guard: smoke ok: scan-path blocks a private-key fixture
agent-guard: smoke ok: hook-pre-tool blocks .env reads
agent-guard: smoke ok: pii-filter runs with the regex provider
agent-guard: smoke ok: hook-pre-tool blocks secret-like writes
agent-guard: smoke ok: native pre-commit hook blocks staged fixture
agent-guard: smoke-test ok
```

No VERSION bump here (release tooling handles that); configs unchanged for the
hooks.json matcher-parity test, which still passes.

## Deferred to a follow-up PR

Reviewed and ranked lower (docs / robustness / test-only); folding them in would
reduce this PR's reviewability: README/SECURITY blind-spot docs, gating
`hook_post_tool` on `git status --porcelain`, `json_value` fail-closed on
string `tool_input`, `bash_matches_deny_path_mode` fail-closed on invalid ERE,
and extending the hooks.json parity test to `Stop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- code-flow-usage-json:start -->
<details>
<summary>code-flow usage JSON</summary>

```json
{
  "commits": [
    {
      "confidence": "best_effort",
      "model_totals": [
        {
          "cache_creation_ephemeral_1h_input_tokens": 560279,
          "cache_creation_ephemeral_5m_input_tokens": 2041,
          "cache_creation_input_tokens": 562320,
          "cache_read_input_tokens": 8430142,
          "input_tokens": 45280,
          "model": "claude-opus-4-8",
          "output_tokens": 198928,
          "total_context_tokens": 9236670,
          "turns": 101
        }
      ],
      "participants": [
        {
          "attribution": "exact",
          "cache_creation_ephemeral_1h_input_tokens": 560279,
          "cache_creation_ephemeral_5m_input_tokens": 2041,
          "cache_creation_input_tokens": 562320,
          "cache_read_input_tokens": 8430142,
          "input_tokens": 45280,
          "kind": "main",
          "model": "claude-opus-4-8",
          "name": "main",
          "output_tokens": 198928,
          "total_context_tokens": 9236670,
          "turns": 101
        }
      ],
      "recorded_at": "2026-06-11T00:42:31Z",
      "sha": "b65f1c1cd662cc67538f679f05cd3d4625d6c19d",
      "subject": "fix(agent-guard): calibrate secret-detection patterns",
      "totals": {
        "cache_creation_ephemeral_1h_input_tokens": 560279,
        "cache_creation_ephemeral_5m_input_tokens": 2041,
        "cache_creation_input_tokens": 562320,
        "cache_read_input_tokens": 8430142,
        "input_tokens": 45280,
        "output_tokens": 198928,
        "total_context_tokens": 9236670,
        "turns": 101
      }
    },
    {
      "confidence": "best_effort",
      "model_totals": [
        {
          "cache_creation_ephemeral_1h_input_tokens": 136030,
          "cache_creation_input_tokens": 136030,
          "cache_read_input_tokens": 2552557,
          "input_tokens": 1384,
          "model": "claude-opus-4-8",
          "output_tokens": 30515,
          "total_context_tokens": 2720486,
          "turns": 24
        }
      ],
      "participants": [
        {
          "attribution": "exact",
          "cache_creation_ephemeral_1h_input_tokens": 136030,
          "cache_creation_input_tokens": 136030,
          "cache_read_input_tokens": 2552557,
          "input_tokens": 1384,
          "kind": "main",
          "model": "claude-opus-4-8",
          "name": "main",
          "output_tokens": 30515,
          "total_context_tokens": 2720486,
          "turns": 24
        }
      ],
      "recorded_at": "2026-06-11T00:52:26Z",
      "sha": "70e8def5cc9c8d52ff2d084e945c93687d286de1",
      "subject": "fix(agent-guard): match kubectl output flag on either side of the resource",
      "totals": {
        "cache_creation_ephemeral_1h_input_tokens": 136030,
        "cache_creation_input_tokens": 136030,
        "cache_read_input_tokens": 2552557,
        "input_tokens": 1384,
        "output_tokens": 30515,
        "total_context_tokens": 2720486,
        "turns": 24
      }
    }
  ],
  "confidence": "best_effort",
  "metered_commits": 2,
  "pr": {
    "base": "main",
    "head": "fix/detection-calibration",
    "number": 59
  },
  "schema": "code-flow-usage/1",
  "scope": "current_branch_pr",
  "source": "claude_code_hooks",
  "total_commits": 2,
  "totals": {
    "cache_creation_ephemeral_1h_input_tokens": 696309,
    "cache_creation_ephemeral_5m_input_tokens": 2041,
    "cache_creation_input_tokens": 698350,
    "cache_read_input_tokens": 10982699,
    "input_tokens": 46664,
    "output_tokens": 229443,
    "total_context_tokens": 11957156,
    "turns": 125
  },
  "totals_by_model": [
    {
      "cache_creation_ephemeral_1h_input_tokens": 696309,
      "cache_creation_ephemeral_5m_input_tokens": 2041,
      "cache_creation_input_tokens": 698350,
      "cache_read_input_tokens": 10982699,
      "input_tokens": 46664,
      "model": "claude-opus-4-8",
      "output_tokens": 229443,
      "total_context_tokens": 11957156,
      "turns": 125
    }
  ],
  "updated_at": "2026-06-11T00:52:35Z"
}
```

</details>
<!-- code-flow-usage-json:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Expanded secret detection for additional credential tools (AWS, Azure, Google Cloud, Doppler)
  * Enhanced detection of environment variable dumping and exfiltration attempts
  * Added Kubernetes secret extraction blocking

* **Bug Fixes**
  * Improved handling of special characters and Unicode in filenames
  * Better parsing of environment-variable and wrapper-prefixed commands
  * Refined placeholder exemption logic

* **Tests**
  * Expanded regression test coverage for edge cases and secret scanning robustness

<!-- end of auto-generated comment: release notes by coderabbit.ai -->