### PR TITLE
fix(agent-guard): close fail-open gaps in hook input handling and deny-read Bash scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,18 @@ To enable it, add an Actions secret named `OPENAI_API_KEY` in the GitHub reposit
 
 Patch and diff scans inspect added lines only. Removing an existing leaked value is allowed.
 
+## Known Limitations
+
+Agent Guard is a deterministic, thin guardrail — not a DLP system, EDR, or vault. It scans tracked diffs, staged changes, and untracked files with gitleaks, and blocks a fixed list of sensitive paths and shell idioms. It deliberately does **not** inspect arbitrary file contents that a command reads, and it has these blind spots by design:
+
+- **Gitignored files are not scanned.** The working-tree and post-tool/stop backstops use `git ls-files --others --exclude-standard` and `git diff`, both of which skip `.gitignore`d paths. A secret written to a gitignored file (e.g. `secrets/` or `*.local`) is not caught by the backstop. Keep real secrets out of the repo entirely.
+- **Only files inside the git work tree are covered.** The post-tool and stop hooks no-op outside a git repository, and scans are scoped to the current repo. Files outside the repo root, or written when no repo is present, get no backstop. Use `agent-guard scan-path <dir>` to scan an arbitrary tree on demand.
+- **Path and command blocking use fixed lists.** Read/Grep/Glob blocking matches the paths in `deny-read-paths.txt`; shell blocking matches the idioms in `deny-bash-patterns.txt`. A secret in an unlisted path, or read by an unlisted tool or flag, is not blocked. Extend the lists with `AGENT_GUARD_DENY_READ_PATHS` / `AGENT_GUARD_DENY_BASH_PATTERNS`.
+- **Command output is not inspected.** Blocking a `Read` or `Bash` invocation is based on the requested path and the command text, not on what the command prints. A command that reads an unlisted secret file or expands a variable at runtime (e.g. `echo "$TOKEN"`) can surface a secret the pre-tool check never sees.
+- **Bash detection is pattern-based.** The denylist targets common-accident and obvious-malicious idioms; an actively-evading agent can craft a command that matches none of them. Treat shell blocking as defense in depth, not a complete adversarial boundary.
+
+For defense in depth, pair Agent Guard with GitHub Secret Scanning / Push Protection and a secrets manager so credentials never reach the working tree.
+
 ## Configuration
 
 Override bundled policies with environment variables:

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -933,9 +933,19 @@ bash_matches_deny_path_mode() {
       ''|\#*) continue ;;
     esac
     regex=$(deny_path_command_regex "$entry" "$mode") || continue
-    if printf '%s\n' "$cmd" | grep -Eq "$regex"; then
-      return 0
-    fi
+    printf '%s\n' "$cmd" | grep -Eq "$regex"
+    grep_status=$?
+    case "$grep_status" in
+      0) return 0 ;;   # command references a deny-listed path -> block
+      1) ;;            # no match -> keep scanning
+      *)
+        # grep failed (e.g. a custom deny-read entry produced an invalid ERE).
+        # Fail closed, mirroring check_bash_command: silently allowing here
+        # would let one bad entry disable the rest of the deny-read path check.
+        info "$PROGRAM: deny-read-paths Bash scan failed; refusing to allow command"
+        exit 2
+        ;;
+    esac
   done <"$DENY_READ_PATHS"
   return 1
 }
@@ -1328,6 +1338,20 @@ hook_pre_tool() {
   need_cmd jq
   input=$(cat)
   [ -n "$input" ] || return 0
+
+  # A host may serialize tool_input as a JSON-encoded string instead of an
+  # object. Left as-is, every `.tool_input.<field>` extraction errors and `jq`
+  # emits nothing, so the scan no-ops (fail-open). Recover by decoding it back
+  # into an object so the existing checks see real fields. Anything that does
+  # not decode to an object (non-JSON text, or a JSON array/scalar) becomes {} —
+  # there are no structured fields to scan, which is correct. Normalizing keeps
+  # the checks effective rather than blocking, so a host that uses string
+  # encoding is not over-blocked.
+  if [ "$(json_value '.tool_input | type' "$input")" = "string" ]; then
+    input=$(printf '%s' "$input" \
+      | jq -c '.tool_input |= (try (fromjson | if type == "object" then . else {} end) catch {})')
+  fi
+
   tool=$(json_value '.tool_name // .tool // .name // empty' "$input")
 
   case "$tool" in

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -1340,16 +1340,23 @@ hook_pre_tool() {
   [ -n "$input" ] || return 0
 
   # A host may serialize tool_input as a JSON-encoded string instead of an
-  # object. Left as-is, every `.tool_input.<field>` extraction errors and `jq`
-  # emits nothing, so the scan no-ops (fail-open). Recover by decoding it back
-  # into an object so the existing checks see real fields. Anything that does
-  # not decode to an object (non-JSON text, or a JSON array/scalar) becomes {} —
-  # there are no structured fields to scan, which is correct. Normalizing keeps
-  # the checks effective rather than blocking, so a host that uses string
-  # encoding is not over-blocked.
+  # object. When that string decodes to an *object*, the precise-field extractors
+  # (.tool_input.command / .content / .file_path) would otherwise error on a
+  # string and yield nothing, so the Bash/Write checks silently no-op
+  # (fail-open). Decode it back into an object so those checks see real fields.
+  #
+  # Only an object is substituted. A string that does NOT decode to an object
+  # (plain text, or JSON that decodes to an array/scalar) is left UNCHANGED: the
+  # generic scanners for Read/Grep/WebFetch/WebSearch/MCP use
+  # `.tool_input // {} | .. | strings`, which already inspects a raw string leaf.
+  # Coercing such input to {} would drop that leaf and let a bare secret string
+  # (e.g. an mcp__* tool_input of "AGENT_GUARD_TEST_SECRET") through — a
+  # regression. Recover-not-block keeps a string-encoding host from being
+  # over-blocked.
   if [ "$(json_value '.tool_input | type' "$input")" = "string" ]; then
     input=$(printf '%s' "$input" \
-      | jq -c '.tool_input |= (try (fromjson | if type == "object" then . else {} end) catch {})')
+      | jq -c '(.tool_input | try fromjson catch null) as $decoded
+               | if ($decoded | type) == "object" then .tool_input = $decoded else . end')
   fi
 
   tool=$(json_value '.tool_name // .tool // .name // empty' "$input")

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -114,7 +114,7 @@ else
   not_ok "Codex plugin manifest leaves hooks to the root hooks.json companion"
 fi
 
-for event in PreToolUse PostToolUse; do
+for event in PreToolUse PostToolUse Stop; do
   claude_canonical=$(jq -r ".hooks.${event}[0].matcher" "$PLUGIN_ROOT/hooks/hooks.json")
   codex_canonical=$(jq -r ".hooks.${event}[0].matcher" "$PLUGIN_ROOT/hooks.json")
   if [ "$codex_canonical" = "$claude_canonical" ]; then
@@ -130,6 +130,69 @@ for event in PreToolUse PostToolUse; do
       ok "$event matcher in $file matches hooks/hooks.json"
     else
       not_ok "$event matcher in $file matches hooks/hooks.json (got: $actual)"
+    fi
+  done
+done
+
+# Full hook-object parity: type, timeout, and the trailing hook-* subcommand
+# must agree across all four manifests. Command STRINGS legitimately differ by
+# host (CLAUDE_PLUGIN_ROOT vs PLUGIN_ROOT vs relative/absolute paths), so only
+# the stable trailing subcommand token is compared, not the whole command. This
+# catches a copy-paste swap (e.g. Stop wired to hook-post-tool, or a 10/20
+# timeout mismatch) that the matcher-only check above misses.
+hook_subcommand() {
+  jq -r ".hooks.${2}[0].hooks[0].command" "$1" \
+    | grep -oE 'hook-(pre-tool|post-tool|stop)' | tail -n1
+}
+
+for event in PreToolUse PostToolUse Stop; do
+  case "$event" in
+    PreToolUse)  expected_sub=hook-pre-tool;  expected_timeout=10 ;;
+    PostToolUse) expected_sub=hook-post-tool; expected_timeout=20 ;;
+    Stop)        expected_sub=hook-stop;      expected_timeout=20 ;;
+  esac
+
+  claude_type=$(jq -r ".hooks.${event}[0].hooks[0].type" "$PLUGIN_ROOT/hooks/hooks.json")
+  claude_timeout=$(jq -r ".hooks.${event}[0].hooks[0].timeout" "$PLUGIN_ROOT/hooks/hooks.json")
+  claude_sub=$(hook_subcommand "$PLUGIN_ROOT/hooks/hooks.json" "$event")
+
+  if [ "$claude_type" = "command" ]; then
+    ok "$event hook type is command in hooks/hooks.json"
+  else
+    not_ok "$event hook type is command in hooks/hooks.json (got: $claude_type)"
+  fi
+  if [ "$claude_timeout" = "$expected_timeout" ]; then
+    ok "$event timeout is $expected_timeout in hooks/hooks.json"
+  else
+    not_ok "$event timeout is $expected_timeout in hooks/hooks.json (got: $claude_timeout)"
+  fi
+  if [ "$claude_sub" = "$expected_sub" ]; then
+    ok "$event command invokes $expected_sub in hooks/hooks.json"
+  else
+    not_ok "$event command invokes $expected_sub in hooks/hooks.json (got: $claude_sub)"
+  fi
+
+  for file in \
+    "$PLUGIN_ROOT/hooks.json" \
+    "$ROOT/examples/claude/settings.project.json" \
+    "$ROOT/examples/codex/hooks.json"; do
+    actual_type=$(jq -r ".hooks.${event}[0].hooks[0].type" "$file")
+    actual_timeout=$(jq -r ".hooks.${event}[0].hooks[0].timeout" "$file")
+    actual_sub=$(hook_subcommand "$file" "$event")
+    if [ "$actual_type" = "$claude_type" ]; then
+      ok "$event hook type in $file matches hooks/hooks.json"
+    else
+      not_ok "$event hook type in $file matches hooks/hooks.json (got: $actual_type)"
+    fi
+    if [ "$actual_timeout" = "$claude_timeout" ]; then
+      ok "$event timeout in $file matches hooks/hooks.json"
+    else
+      not_ok "$event timeout in $file matches hooks/hooks.json (got: $actual_timeout)"
+    fi
+    if [ "$actual_sub" = "$claude_sub" ]; then
+      ok "$event command subcommand in $file matches hooks/hooks.json"
+    else
+      not_ok "$event command subcommand in $file matches hooks/hooks.json (got: $actual_sub)"
     fi
   done
 done
@@ -1342,6 +1405,100 @@ else
   not_ok "deny-bash-patterns invalid ERE fails closed (expected 2, got $status)"
   sed 's/^/  stderr: /' /tmp/agent-guard-test.err
 fi
+
+# --- deny-read-paths Bash scan fail-closed on invalid generated ERE --------
+# Parity with the deny-bash guard above: a custom deny-read entry that converts
+# to a grep-rejected ERE (here a trailing backslash) must hard-block during a
+# Bash command scan, not silently allow the rest of the deny-read check.
+BAD_READ_FILE="$TMP_ROOT/bad-deny-read.txt"
+printf '%s\n' 'x\' >"$BAD_READ_FILE"
+printf '%s' '{"tool_name":"Bash","tool_input":{"command":"echo hi"}}' \
+  | AGENT_GUARD_DENY_READ_PATHS="$BAD_READ_FILE" \
+    "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "deny-read-paths invalid generated ERE fails closed in Bash scan"
+else
+  not_ok "deny-read-paths invalid generated ERE fails closed in Bash scan (expected 2, got $status)"
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+
+# No-regression: a valid custom deny-read file must still allow benign commands
+# and still block a deny-listed path, so the fail-closed change does not over-block.
+GOOD_READ_FILE="$TMP_ROOT/good-deny-read.txt"
+printf '%s\n' '.env' >"$GOOD_READ_FILE"
+printf '%s' '{"tool_name":"Bash","tool_input":{"command":"echo hi"}}' \
+  | AGENT_GUARD_DENY_READ_PATHS="$GOOD_READ_FILE" \
+    "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool >/dev/null 2>&1
+status=$?
+if [ "$status" -eq 0 ]; then
+  ok "valid deny-read file still allows a benign Bash command"
+else
+  not_ok "valid deny-read file still allows a benign Bash command (expected 0, got $status)"
+fi
+printf '%s' '{"tool_name":"Bash","tool_input":{"command":"cat .env"}}' \
+  | AGENT_GUARD_DENY_READ_PATHS="$GOOD_READ_FILE" \
+    "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool >/dev/null 2>&1
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "valid deny-read file still blocks a deny-listed path in a Bash command"
+else
+  not_ok "valid deny-read file still blocks a deny-listed path in a Bash command (expected 2, got $status)"
+fi
+
+# Loop-level fail-closed: a bad-ERE entry placed AFTER a valid one must still
+# hard-block, even for a command that matches neither entry. This distinguishes
+# the real behavior (the scan reaches the bad entry and exits 2) from a
+# silent-skip regression where the bad entry is `continue`d and the command,
+# matching no valid entry, would slip through allowed.
+MULTI_READ_FILE="$TMP_ROOT/multi-deny-read.txt"
+printf '%s\n' '.env' 'x\' >"$MULTI_READ_FILE"
+printf '%s' '{"tool_name":"Bash","tool_input":{"command":"echo hi"}}' \
+  | AGENT_GUARD_DENY_READ_PATHS="$MULTI_READ_FILE" \
+    "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool >/dev/null 2>&1
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "deny-read-paths loop fails closed when a bad entry follows a valid one"
+else
+  not_ok "deny-read-paths loop fails closed when a bad entry follows a valid one (expected 2, got $status)"
+fi
+
+# --- string-encoded tool_input is normalized, not silently skipped ----------
+# A host may serialize tool_input as a JSON string. Without normalization every
+# .tool_input.<field> extraction errors and yields empty, so the scan no-ops
+# (fail-open). hook_pre_tool decodes a string tool_input back into an object so
+# the existing checks still see the real fields. These cases take plain JSON, a
+# single subcommand, and assert only on exit status, so they use the
+# expect_json_status helper like the rest of the hook-pre-tool table.
+expect_json_status 2 "object tool_input blocks a deny pattern (baseline)" \
+  '{"tool_name":"Bash","tool_input":{"command":"printenv"}}' \
+  hook-pre-tool
+expect_json_status 2 "string-encoded tool_input blocks a deny pattern (no fail-open)" \
+  '{"tool_name":"Bash","tool_input":"{\"command\":\"printenv\"}"}' \
+  hook-pre-tool
+# The normalization lives in hook_pre_tool before the per-tool dispatch, so it
+# must also rescue content-scanning tools, not just Bash. A string-encoded Write
+# whose decoded content holds a secret must block (without the fix, extracting
+# .tool_input.content errors -> empty content -> scan finds nothing -> fail-open).
+expect_json_status 2 "string-encoded Write tool_input with a secret is blocked" \
+  '{"tool_name":"Write","tool_input":"{\"file_path\":\"app.txt\",\"content\":\"AGENT_GUARD_TEST_SECRET\"}"}' \
+  hook-pre-tool
+# Benign string-encoded commands/writes stay allowed (normalization does not over-block).
+expect_json_status 0 "benign string-encoded tool_input is allowed" \
+  '{"tool_name":"Bash","tool_input":"{\"command\":\"ls\"}"}' \
+  hook-pre-tool
+expect_json_status 0 "benign string-encoded Write tool_input is allowed" \
+  '{"tool_name":"Write","tool_input":"{\"file_path\":\"app.txt\",\"content\":\"example_token\"}"}' \
+  hook-pre-tool
+# A non-JSON string tool_input decodes to {} (nothing structured to scan) -> allowed.
+expect_json_status 0 "non-JSON string tool_input is allowed (no crash, nothing to scan)" \
+  '{"tool_name":"Bash","tool_input":"not json at all"}' \
+  hook-pre-tool
+# A string tool_input that decodes to a non-object (here a JSON array) is coerced
+# to {} so downstream .tool_input.<field> extraction cannot error -> allowed.
+expect_json_status 0 "string tool_input decoding to a non-object is coerced to {} (no crash)" \
+  '{"tool_name":"Bash","tool_input":"[1,2,3]"}' \
+  hook-pre-tool
 
 # --- gitleaks not installed -----------------------------------------------
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1490,14 +1490,28 @@ expect_json_status 0 "benign string-encoded tool_input is allowed" \
 expect_json_status 0 "benign string-encoded Write tool_input is allowed" \
   '{"tool_name":"Write","tool_input":"{\"file_path\":\"app.txt\",\"content\":\"example_token\"}"}' \
   hook-pre-tool
-# A non-JSON string tool_input decodes to {} (nothing structured to scan) -> allowed.
-expect_json_status 0 "non-JSON string tool_input is allowed (no crash, nothing to scan)" \
+# Only a string that decodes to an *object* is substituted. A non-object string
+# (plain text, or JSON decoding to an array/scalar) is left UNCHANGED -- coercing
+# it to {} would drop the leaf for the generic `.tool_input // {} | .. | strings`
+# scanners (see the regression guard below). For Bash the precise .command
+# extractor simply finds no field on a raw string, so there is nothing to scan.
+expect_json_status 0 "non-JSON string Bash tool_input is allowed (no command to scan)" \
   '{"tool_name":"Bash","tool_input":"not json at all"}' \
   hook-pre-tool
-# A string tool_input that decodes to a non-object (here a JSON array) is coerced
-# to {} so downstream .tool_input.<field> extraction cannot error -> allowed.
-expect_json_status 0 "string tool_input decoding to a non-object is coerced to {} (no crash)" \
+expect_json_status 0 "array-decoding string Bash tool_input is allowed (no command to scan)" \
   '{"tool_name":"Bash","tool_input":"[1,2,3]"}' \
+  hook-pre-tool
+# Regression guard (P1, PR #60 review): a raw-string tool_input MUST still reach
+# the generic scanners. mcp__*/WebFetch/WebSearch route through
+# `.tool_input // {} | .. | strings`, which inspects the raw string leaf, so a
+# string-encoded secret -- whether plain text or a JSON array/scalar that does
+# not decode to an object -- must still block. Coercing such input to {} (the
+# original R12 attempt) dropped the leaf and let a bare secret through.
+expect_json_status 2 "raw-string MCP tool_input with a secret is blocked (no coerce-to-{} fail-open)" \
+  '{"tool_name":"mcp__server__tool","tool_input":"AGENT_GUARD_TEST_SECRET"}' \
+  hook-pre-tool
+expect_json_status 2 "array-encoded-string MCP tool_input with a secret is blocked" \
+  '{"tool_name":"mcp__server__tool","tool_input":"[\"AGENT_GUARD_TEST_SECRET\"]"}' \
   hook-pre-tool
 
 # --- gitleaks not installed -----------------------------------------------


### PR DESCRIPTION
## Summary

Two **fail-closed correctness fixes**, an **honest limitations doc**, and **extended hook-manifest test coverage** for agent-guard. These are the items deliberately deferred from PR #59 so that slice stayed reviewable; a parallel multi-agent audit re-verified each against agent-guard's design philosophy — **thin but effective**: block accidental or malicious secret exposure without over-blocking, stay deterministic, **fail closed**, and do *not* grow into a DLP/EDR or scan arbitrary file contents.

Scope is intentionally constrained: **no new detection layer, no DLP/EDR expansion, no scanning of arbitrary file contents.** Every change either makes an existing fail-closed guard actually fail closed, documents the boundary honestly, or extends test coverage.

## Fail-open gaps closed

**`hook_pre_tool` — normalize a string-encoded `tool_input` (R12)**

A host may serialize the hook envelope's `tool_input` as a JSON *string* instead of an object. Left as-is, every `.tool_input.<field>` extraction aborts with a hard `jq` error and emits nothing — `// empty` does not catch it — so `json_value` returns empty, the matching `case` arm scans nothing, and the call is **allowed**. A single anomalous envelope shape silently disabled the Read/Write/Bash/MCP checks.

The fix decodes a string `tool_input` back into an object *before* the per-tool dispatch — **only when it decodes to an object** — so the precise-field extractors (`.tool_input.command` / `.content` / `.file_path`) see real fields. A string that does **not** decode to an object (plain text, or JSON decoding to an array/scalar) is left **unchanged**, so the generic `.tool_input // {} | .. | strings` scanners used by `mcp__*`/`WebFetch`/`WebSearch` still inspect the raw string leaf. (An earlier revision coerced such input to `{}`, which dropped that leaf and let a bare secret string through — a fail-open regression caught in review and fixed in `0a5a83f`.) **Recover, not block**: a host that legitimately uses string encoding is not over-blocked, while the scan stays effective. (The envelope is host-built, so this is host-compat / defense-in-depth rather than a directly agent-controlled bypass — but a fail-closed guard must not silently no-op.)

**`bash_matches_deny_path_mode` — fail closed on an invalid generated ERE (R13)**

The deny-**bash** path already fails closed: `check_bash_command` captures `grep`'s exit status and treats anything other than 0/1 as a hard block. The deny-**read-path-as-Bash** path did **not** — it ran `grep -Eq` purely as an `if` condition, so `grep` exit ≥2 (invalid generated ERE) was indistinguishable from exit 1 (no match). One custom `AGENT_GUARD_DENY_READ_PATHS` entry that converts to a bad ERE (e.g. a trailing backslash) thus silently disabled the rest of the deny-read check during Bash scans.

The fix captures `grep_status` and `exit 2` on grep error, in exact parity with `check_bash_command`. The pre-existing `deny_path_command_regex … || continue` stays: an *empty* conversion legitimately means "no pattern for this entry" and is distinct from a grep runtime error.

## Documentation

**`README.md` — "Known Limitations" (R10)**

The README documented *what gets blocked* but not the blind spots, risking over-trust. Adds a concise section stating the intended boundary: gitignored files are not scanned by the working-tree backstop, only files inside the git work tree are covered, path/command blocking uses fixed (env-overridable) lists, command output is not inspected, and Bash detection is pattern-based (defense in depth, not a complete adversarial boundary). Framed positively as the thin-but-effective scope, and closes by recommending pairing with GitHub Secret Scanning / Push Protection and a secrets manager.

## Test coverage

**`tests/run.sh` (R15 + R12/R13 assertions)**

- **Hook-manifest parity** extended from `PreToolUse`/`PostToolUse` to also cover **`Stop`**, and from matcher-only to the **full hook object** — `type`, `timeout`, and the trailing `hook-*` subcommand — across all four manifests against the Claude canonical. Only the stable trailing subcommand token is compared (command *prefixes* legitimately differ per host), pinning each event to its expected subcommand/timeout. Catches a copy-paste swap (Stop wired to `hook-post-tool`, a 10/20 timeout mismatch) the matcher-only check missed.
- **R12** assertions: string-encoded `tool_input` blocks a deny pattern on the **Bash** path *and* on the **Write** content-scanning path (the normalization lives before tool dispatch, so it must rescue content scanning too — without the fix, `.tool_input.content` extraction errors → empty content → fail-open); benign string-encoded Bash/Write stay allowed; and — **regression guard** for the object-only normalization — a raw-string (non-object) `tool_input` carrying a secret, plain (`"AGENT_GUARD_TEST_SECRET"`) or array-encoded (`"[\"AGENT_GUARD_TEST_SECRET\"]"`), still blocks via the generic `mcp__*` scanner, while benign non-object strings stay allowed.
- **R13** assertions: an invalid generated ERE fails closed (exit 2) during a Bash scan, including the **loop-level** case (a bad entry after a valid one still hard-blocks a command matching neither); a valid custom deny-read file still allows benign commands and still blocks a deny-listed path (no over-block).

## Out of scope (decided)

- **Perf gating of the post-tool backstop** — dropped. Gating on `git status --porcelain` walks the work tree just like the existing `git diff` + `git ls-files`, adding a walk in the common case and a branch (and FN risk) to a security backstop for a marginal, possibly net-negative win. Anti-philosophy.
- **A `*.key` public-suffix allowlist** — rejected in PR #59; FP risk is lower than FN risk, so `*.key` blocking stays.

## Functional Verification

All commands run locally in the worktree on this branch.

- **`make test`** → **273/273 pass, 0 failed.** Includes the new R12 (string-encoded `tool_input` on Bash and Write, plus the two raw-string `mcp__*` regression guards), R13 (invalid-ERE fail-closed, plus loop-level), and R15 (Stop + full-object hook-manifest parity) assertions. The mock gitleaks deterministically flags the literal `AGENT_GUARD_TEST_SECRET`; deny-pattern assertions need no real secret.
- **`make smoke-test`** → **ok** (real gitleaks 8.30.0): clean-dir allow, private-key block, sensitive-read block, secret-write block, and native pre-commit hook block all pass end to end.
- **Targeted spot-checks** (now codified as suite assertions): object vs string-encoded `tool_input` both block on a deny pattern (exit 2); a benign string-encoded command/write stays allowed (exit 0); a custom invalid deny-read entry hard-blocks a benign Bash command (exit 2).
- **No VERSION bump** (release tooling owns it); the hooks.json manifests are unchanged — R15 only adds assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- code-flow-usage-json:start -->
<details>
<summary>code-flow usage JSON</summary>

```json
{
  "commits": [
    {
      "confidence": "best_effort",
      "model_totals": [
        {
          "cache_creation_ephemeral_1h_input_tokens": 285424,
          "cache_creation_input_tokens": 285424,
          "cache_read_input_tokens": 5982411,
          "input_tokens": 38445,
          "model": "claude-opus-4-8",
          "output_tokens": 66823,
          "total_context_tokens": 6373103,
          "turns": 52
        }
      ],
      "participants": [
        {
          "attribution": "exact",
          "cache_creation_ephemeral_1h_input_tokens": 285424,
          "cache_creation_input_tokens": 285424,
          "cache_read_input_tokens": 5982411,
          "input_tokens": 38445,
          "kind": "main",
          "model": "claude-opus-4-8",
          "name": "main",
          "output_tokens": 66823,
          "total_context_tokens": 6373103,
          "turns": 52
        }
      ],
      "recorded_at": "2026-06-11T03:40:47Z",
      "sha": "b5b44f86f884ac8d72fd72dca37818acb44c94e7",
      "subject": "fix(agent-guard): close fail-open gaps in hook input handling and deny-read Bash scan",
      "totals": {
        "cache_creation_ephemeral_1h_input_tokens": 285424,
        "cache_creation_input_tokens": 285424,
        "cache_read_input_tokens": 5982411,
        "input_tokens": 38445,
        "output_tokens": 66823,
        "total_context_tokens": 6373103,
        "turns": 52
      }
    },
    {
      "confidence": "best_effort",
      "model_totals": [
        {
          "cache_creation_ephemeral_1h_input_tokens": 230873,
          "cache_creation_input_tokens": 230873,
          "cache_read_input_tokens": 4352523,
          "input_tokens": 33704,
          "model": "claude-opus-4-8",
          "output_tokens": 38707,
          "total_context_tokens": 4655807,
          "turns": 43
        }
      ],
      "participants": [
        {
          "attribution": "exact",
          "cache_creation_ephemeral_1h_input_tokens": 230873,
          "cache_creation_input_tokens": 230873,
          "cache_read_input_tokens": 4352523,
          "input_tokens": 33704,
          "kind": "main",
          "model": "claude-opus-4-8",
          "name": "main",
          "output_tokens": 38707,
          "total_context_tokens": 4655807,
          "turns": 43
        }
      ],
      "recorded_at": "2026-06-11T03:54:37Z",
      "sha": "0a5a83f522e442bf13f749d8474f51f0ffb54a70",
      "subject": "fix(agent-guard): narrow string tool_input normalization to object decodes (PR #60 review)",
      "totals": {
        "cache_creation_ephemeral_1h_input_tokens": 230873,
        "cache_creation_input_tokens": 230873,
        "cache_read_input_tokens": 4352523,
        "input_tokens": 33704,
        "output_tokens": 38707,
        "total_context_tokens": 4655807,
        "turns": 43
      }
    }
  ],
  "confidence": "best_effort",
  "metered_commits": 2,
  "pr": {
    "base": "main",
    "head": "chore/detection-followup",
    "number": 60
  },
  "schema": "code-flow-usage/1",
  "scope": "current_branch_pr",
  "source": "claude_code_hooks",
  "total_commits": 2,
  "totals": {
    "cache_creation_ephemeral_1h_input_tokens": 516297,
    "cache_creation_input_tokens": 516297,
    "cache_read_input_tokens": 10334934,
    "input_tokens": 72149,
    "output_tokens": 105530,
    "total_context_tokens": 11028910,
    "turns": 95
  },
  "totals_by_model": [
    {
      "cache_creation_ephemeral_1h_input_tokens": 516297,
      "cache_creation_input_tokens": 516297,
      "cache_read_input_tokens": 10334934,
      "input_tokens": 72149,
      "model": "claude-opus-4-8",
      "output_tokens": 105530,
      "total_context_tokens": 11028910,
      "turns": 95
    }
  ],
  "updated_at": "2026-06-11T03:58:00Z"
}
```

</details>
<!-- code-flow-usage-json:end -->
