### PR TITLE
docs: render README badges in a single row

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Agent Guard
 
-[![Release](https://img.shields.io/github/v/release/JeongJaeSoon/agent-guard)](https://github.com/JeongJaeSoon/agent-guard/releases)
-[![CI](https://github.com/JeongJaeSoon/agent-guard/actions/workflows/ci.yml/badge.svg)](https://github.com/JeongJaeSoon/agent-guard/actions/workflows/ci.yml)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Release](https://img.shields.io/github/v/release/JeongJaeSoon/agent-guard)](https://github.com/JeongJaeSoon/agent-guard/releases) [![CI](https://github.com/JeongJaeSoon/agent-guard/actions/workflows/ci.yml/badge.svg)](https://github.com/JeongJaeSoon/agent-guard/actions/workflows/ci.yml) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 **Stop your AI coding agent from leaking secrets — in real time, before the tool call runs.**
 


### PR DESCRIPTION
## Summary

Render the three README status badges (release, CI, license) as a single horizontal row.

The badges were authored on three separate lines. GitHub's **repository README** renderer collapses soft line breaks into spaces, so they already appear in one row there. But the **GitHub Marketplace listing** renderer treats each newline as a hard break, so on the freshly published Marketplace page the badges stacked vertically.

This puts the three badge links on one line separated by spaces — which renders as a single horizontal row in both renderers. Badge URLs and link targets are unchanged.

## Functional verification

- `git diff origin/main` → 1 file, `README.md`, 1 insertion / 3 deletions (only the badge line is joined).
- Confirmed via browser that the repository README already renders the badges horizontally; the vertical stack only appears on the Marketplace listing (https://github.com/marketplace/actions/agent-guard-secret-guardrails).
- No behavior, script, or metadata change — documentation only.


<!-- code-flow-usage-json:start -->
<details>
<summary>code-flow usage JSON</summary>

```json
{
  "commits": [
    {
      "confidence": "best_effort",
      "model_totals": [
        {
          "cache_creation_ephemeral_1h_input_tokens": 801735,
          "cache_creation_ephemeral_5m_input_tokens": 58,
          "cache_creation_input_tokens": 801793,
          "cache_read_input_tokens": 17386813,
          "input_tokens": 29651,
          "model": "claude-opus-4-8",
          "output_tokens": 100568,
          "total_context_tokens": 18318825,
          "turns": 89
        }
      ],
      "participants": [
        {
          "attribution": "exact",
          "cache_creation_ephemeral_1h_input_tokens": 801735,
          "cache_creation_ephemeral_5m_input_tokens": 58,
          "cache_creation_input_tokens": 801793,
          "cache_read_input_tokens": 17386813,
          "input_tokens": 29651,
          "kind": "main",
          "model": "claude-opus-4-8",
          "name": "main",
          "output_tokens": 100568,
          "total_context_tokens": 18318825,
          "turns": 89
        }
      ],
      "recorded_at": "2026-06-16T08:16:38Z",
      "sha": "80a3cb22ac72ff866f334f96ffa5e781a4833191",
      "subject": "docs: render README badges in a single row",
      "totals": {
        "cache_creation_ephemeral_1h_input_tokens": 801735,
        "cache_creation_ephemeral_5m_input_tokens": 58,
        "cache_creation_input_tokens": 801793,
        "cache_read_input_tokens": 17386813,
        "input_tokens": 29651,
        "output_tokens": 100568,
        "total_context_tokens": 18318825,
        "turns": 89
      }
    }
  ],
  "confidence": "best_effort",
  "metered_commits": 1,
  "pr": {
    "base": "main",
    "head": "fix/readme-badge-row",
    "number": 65
  },
  "schema": "code-flow-usage/1",
  "scope": "current_branch_pr",
  "source": "claude_code_hooks",
  "total_commits": 1,
  "totals": {
    "cache_creation_ephemeral_1h_input_tokens": 801735,
    "cache_creation_ephemeral_5m_input_tokens": 58,
    "cache_creation_input_tokens": 801793,
    "cache_read_input_tokens": 17386813,
    "input_tokens": 29651,
    "output_tokens": 100568,
    "total_context_tokens": 18318825,
    "turns": 89
  },
  "totals_by_model": [
    {
      "cache_creation_ephemeral_1h_input_tokens": 801735,
      "cache_creation_ephemeral_5m_input_tokens": 58,
      "cache_creation_input_tokens": 801793,
      "cache_read_input_tokens": 17386813,
      "input_tokens": 29651,
      "model": "claude-opus-4-8",
      "output_tokens": 100568,
      "total_context_tokens": 18318825,
      "turns": 89
    }
  ],
  "updated_at": "2026-06-16T08:17:18Z"
}
```

</details>
<!-- code-flow-usage-json:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reformatted release badges in README for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->