### PR TITLE
ci: add read-only HOL plugin scanner score-check workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  # GitHub Actions are agent-guard's only dependency surface (the tool itself is
+  # POSIX shell + gitleaks, with no package manifest). Keep third-party actions
+  # current so SHA pins are bumped deliberately rather than drifting silently.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Scan for secrets
         uses: ./
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Run tests
         run: tests/run.sh

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: Checkout
         if: env.HAS_OPENAI_API_KEY == 'true'
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
           persist-credentials: false
@@ -81,7 +81,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Comment on PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
           CODEX_FINAL_MESSAGE: ${{ needs.codex.outputs.final_message }}
         with:

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Run Codex review
         id: run_codex
         if: env.HAS_OPENAI_API_KEY == 'true'
-        uses: openai/codex-action@v1
+        uses: openai/codex-action@e0fdf01220eb9a88167c4898839d273e3f2609d1 # v1.8
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           sandbox: read-only

--- a/.github/workflows/hol-plugin-scanner.yml
+++ b/.github/workflows/hol-plugin-scanner.yml
@@ -1,19 +1,21 @@
 name: HOL Plugin Scanner
 
 # Self-scan against the HOL AI Plugin Scanner, the quality/security gate required
-# to list Agent Guard on awesome-codex-plugins.
+# to list Agent Guard on awesome-codex-plugins (needs score >= 80, no high/critical
+# findings, and the scanner running in CI on the main branch).
 #
-# Phase 1 (this file): score check only. Runs read-only and does NOT upload SARIF,
-# so the unvetted third-party scanner action executes with the minimum privileges
-# needed to print a score. If the score clears the gate (>= 80, no high findings)
-# and we decide to list, switch to the upstream-required workflow that adds
-# `upload_sarif: true` plus `security-events: write`.
+# Runs read-only and does NOT upload SARIF: the list only requires the scanner to
+# run with a passing score, so the unvetted third-party scanner action executes
+# with the minimum privileges needed to print a score. SARIF upload (which would
+# need `security-events: write`) is recommended-only upstream and deliberately
+# skipped to keep this surface minimal.
 #
-# The scanner action is pinned to a full commit SHA (not a floating tag) because it
-# is a new, low-adoption third-party action; first-party actions/checkout stays on
-# its major tag to match this repo's existing workflow convention.
+# Both third-party and first-party actions are pinned to full commit SHAs (mutable
+# tags can be moved even on first-party repos); the Dependabot config bumps them.
 
 on:
+  push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/hol-plugin-scanner.yml
+++ b/.github/workflows/hol-plugin-scanner.yml
@@ -1,0 +1,39 @@
+name: HOL Plugin Scanner
+
+# Self-scan against the HOL AI Plugin Scanner, the quality/security gate required
+# to list Agent Guard on awesome-codex-plugins.
+#
+# Phase 1 (this file): score check only. Runs read-only and does NOT upload SARIF,
+# so the unvetted third-party scanner action executes with the minimum privileges
+# needed to print a score. If the score clears the gate (>= 80, no high findings)
+# and we decide to list, switch to the upstream-required workflow that adds
+# `upload_sarif: true` plus `security-events: write`.
+#
+# The scanner action is pinned to a full commit SHA (not a floating tag) because it
+# is a new, low-adoption third-party action; first-party actions/checkout stays on
+# its major tag to match this repo's existing workflow convention.
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: HOL Plugin Scanner
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Run HOL AI Plugin Scanner
+        uses: hashgraph-online/ai-plugin-scanner-action@7efab6be3cc2e2b020492c77f769963070905d6e # v1.2.184
+        with:
+          mode: scan
+          min_score: 80
+          fail_on_severity: high
+          format: text
+          upload_sarif: false
+          write_step_summary: true

--- a/.github/workflows/hol-plugin-scanner.yml
+++ b/.github/workflows/hol-plugin-scanner.yml
@@ -26,7 +26,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          # The scanner only reads the working tree, and the unvetted third-party
+          # scanner step runs right after. Don't leave GITHUB_TOKEN persisted in
+          # .git/config where that action could read it.
+          persist-credentials: false
 
       - name: Run HOL AI Plugin Scanner
         uses: hashgraph-online/ai-plugin-scanner-action@7efab6be3cc2e2b020492c77f769963070905d6e # v1.2.184

--- a/.github/workflows/plugin-validation.yml
+++ b/.github/workflows/plugin-validation.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Run tests
         run: make test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary

Adds a read-only **HOL Plugin Scanner** workflow (`.github/workflows/hol-plugin-scanner.yml`) that runs the HOL AI Plugin Scanner against this repo on pull requests and `workflow_dispatch`.

The immediate goal is to obtain Agent Guard's scanner **score**, which is the listing gate for [awesome-codex-plugins](https://github.com/hashgraph-online/awesome-codex-plugins) (requires ≥ 80, no high/critical findings). It doubles as a free security/quality self-audit.

## Design / safety

This is a **Phase 1 score check** — deliberately minimal-privilege:

- `permissions: contents: read` only; **no SARIF upload** (so the third-party action runs read-only — no `security-events: write`).
- The third-party scanner action is pinned to a **full commit SHA** (`…7efab6b`, = v1.2.184), not a floating tag, because it is a new, low-adoption action.
- First-party `actions/checkout` stays on `@v5` to match this repo's existing workflow convention (trusted first-party ⇒ tag; unvetted third-party ⇒ SHA-pin).
- Runs only on PRs / manual dispatch — **not** on `push: main` — so nothing lands on `main` until we decide to list. If we don't list, just close this PR.
- Score prints to the job summary (`write_step_summary: true`).

If the score clears the gate and we proceed to list, a follow-up will switch to the upstream-required form (`upload_sarif: true` + scoped `security-events: write`).

## Heads-up

Agent Guard intentionally ships **secret-shaped test fixtures and detection-pattern strings** (it is a secret scanner). The HOL scanner may flag these as "hardcoded secrets," which could lower the score or raise findings. That is expected; this PR exists precisely to measure it. We will triage findings into real issues (fix) vs. false positives on our own fixtures (suppress via scanner config, or decide listing isn't worth it).

## Functional verification

- YAML validated locally: `ruby -ryaml -e 'YAML.load_file(...)'` → OK; parsed `jobs: [scan]`, `permissions: {contents: read}`.
- Structure mirrors the existing `ci.yml` (same `permissions` scoping, `runs-on: ubuntu-latest`).
- The scanner's actual score and findings will appear on **this PR's `HOL Plugin Scanner` check** — that run is the real verification of behavior.
- Single new file; no change to any shipped hook, plugin, Action, or existing workflow.


<!-- code-flow-usage-json:start -->
<details>
<summary>code-flow usage JSON</summary>

```json
{
  "commits": [
    {
      "confidence": "best_effort",
      "model_totals": [],
      "participants": [],
      "sha": "35f82df0087dc81623ed54e98768becaa4ae765a",
      "status": "unmetered",
      "subject": "ci: add read-only HOL plugin scanner score-check workflow",
      "totals": {
        "cache_creation_input_tokens": 0,
        "cache_read_input_tokens": 0,
        "input_tokens": 0,
        "output_tokens": 0,
        "total_context_tokens": 0
      }
    },
    {
      "confidence": "best_effort",
      "model_totals": [
        {
          "cache_creation_input_tokens": 0,
          "cache_read_input_tokens": 0,
          "input_tokens": 0,
          "model": "<synthetic>",
          "output_tokens": 0,
          "total_context_tokens": 0,
          "turns": 2
        },
        {
          "cache_creation_ephemeral_1h_input_tokens": 430758,
          "cache_creation_input_tokens": 430758,
          "cache_read_input_tokens": 7919534,
          "input_tokens": 28648,
          "model": "claude-opus-4-8",
          "output_tokens": 76863,
          "total_context_tokens": 8455803,
          "turns": 48
        }
      ],
      "participants": [
        {
          "attribution": "exact",
          "cache_creation_input_tokens": 0,
          "cache_read_input_tokens": 0,
          "input_tokens": 0,
          "kind": "main",
          "model": "<synthetic>",
          "name": "main",
          "output_tokens": 0,
          "total_context_tokens": 0,
          "turns": 2
        },
        {
          "attribution": "exact",
          "cache_creation_ephemeral_1h_input_tokens": 430758,
          "cache_creation_input_tokens": 430758,
          "cache_read_input_tokens": 7919534,
          "input_tokens": 28648,
          "kind": "main",
          "model": "claude-opus-4-8",
          "name": "main",
          "output_tokens": 76863,
          "total_context_tokens": 8455803,
          "turns": 48
        }
      ],
      "recorded_at": "2026-06-17T10:16:39Z",
      "sha": "e31aa8109cc2f7a5660acc1036661fd1692aa380",
      "subject": "ci: SHA-pin codex-action and add Dependabot for actions",
      "totals": {
        "cache_creation_ephemeral_1h_input_tokens": 430758,
        "cache_creation_input_tokens": 430758,
        "cache_read_input_tokens": 7919534,
        "input_tokens": 28648,
        "output_tokens": 76863,
        "total_context_tokens": 8455803,
        "turns": 50
      }
    },
    {
      "confidence": "best_effort",
      "model_totals": [],
      "participants": [],
      "sha": "5c768940f2b6b1350a8b09dd2a6c4ddca9bd500b",
      "status": "unmetered",
      "subject": "ci: SHA-pin all GitHub Actions and harden scanner checkout",
      "totals": {
        "cache_creation_input_tokens": 0,
        "cache_read_input_tokens": 0,
        "input_tokens": 0,
        "output_tokens": 0,
        "total_context_tokens": 0
      }
    },
    {
      "confidence": "best_effort",
      "model_totals": [],
      "participants": [],
      "sha": "19f4752b9fb27169f679936a09ad9f4f9ab564a7",
      "status": "unmetered",
      "subject": "ci: run HOL scanner on main and document read-only rationale",
      "totals": {
        "cache_creation_input_tokens": 0,
        "cache_read_input_tokens": 0,
        "input_tokens": 0,
        "output_tokens": 0,
        "total_context_tokens": 0
      }
    }
  ],
  "confidence": "best_effort",
  "metered_commits": 1,
  "pr": {
    "base": "main",
    "head": "chore/hol-scanner-score-check",
    "number": 68
  },
  "schema": "code-flow-usage/1",
  "scope": "current_branch_pr",
  "source": "claude_code_hooks",
  "total_commits": 4,
  "totals": {
    "cache_creation_ephemeral_1h_input_tokens": 430758,
    "cache_creation_input_tokens": 430758,
    "cache_read_input_tokens": 7919534,
    "input_tokens": 28648,
    "output_tokens": 76863,
    "total_context_tokens": 8455803,
    "turns": 50
  },
  "totals_by_model": [
    {
      "cache_creation_input_tokens": 0,
      "cache_read_input_tokens": 0,
      "input_tokens": 0,
      "model": "<synthetic>",
      "output_tokens": 0,
      "total_context_tokens": 0,
      "turns": 2
    },
    {
      "cache_creation_ephemeral_1h_input_tokens": 430758,
      "cache_creation_input_tokens": 430758,
      "cache_read_input_tokens": 7919534,
      "input_tokens": 28648,
      "model": "claude-opus-4-8",
      "output_tokens": 76863,
      "total_context_tokens": 8455803,
      "turns": 48
    }
  ],
  "updated_at": "2026-06-17T14:38:38Z"
}
```

</details>
<!-- code-flow-usage-json:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated security scanning workflow with severity thresholds and step summary output.
  * Introduced Dependabot updates for GitHub Actions on a weekly cadence.
  * Pinned GitHub Actions versions (including checkout) to specific commit SHAs across CI, plugin validation, Codex review, and release workflows for more consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->