### PR TITLE
docs(readme): lead with a Claude Code quick start to lift install conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agent Guard
 
-[![Release](https://img.shields.io/github/v/release/JeongJaeSoon/agent-guard)](https://github.com/JeongJaeSoon/agent-guard/releases) [![CI](https://github.com/JeongJaeSoon/agent-guard/actions/workflows/ci.yml/badge.svg)](https://github.com/JeongJaeSoon/agent-guard/actions/workflows/ci.yml) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Release](https://img.shields.io/github/v/release/JeongJaeSoon/agent-guard)](https://github.com/JeongJaeSoon/agent-guard/releases) [![GitHub Marketplace](https://img.shields.io/badge/Marketplace-Agent%20Guard-2EA44F?logo=github)](https://github.com/marketplace/actions/agent-guard-secret-guardrails) [![CI](https://github.com/JeongJaeSoon/agent-guard/actions/workflows/ci.yml/badge.svg)](https://github.com/JeongJaeSoon/agent-guard/actions/workflows/ci.yml) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 **Stop your AI coding agent from leaking secrets — in real time, before the tool call runs.**
 
@@ -12,11 +12,35 @@ Unlike commit- or CI-time scanners that catch a leak *after* it lands, Agent Gua
 
 It is not a vault, credential rotator, or replacement for GitHub Secret Scanning / Push Protection.
 
+## Quick start (Claude Code)
+
+Install from the marketplace:
+
+```text
+/plugin marketplace add JeongJaeSoon/agent-guard
+/plugin install agent-guard@agent-guard
+/reload-plugins
+```
+
+Verify it's live — ask the agent to read your `.env`:
+
+```text
+Please read .env
+```
+
+It should refuse:
+
+```text
+agent-guard: blocked sensitive file access: .env
+```
+
+Detection needs `jq` and `gitleaks` on your machine (`brew install jq gitleaks`; see [Requirements](#requirements) for Linux). Using Codex, Git hooks, or CI instead? Pick your path below.
+
 ## Pick an install path
 
 | Use case | Install path | Best first check |
 |---|---|---|
-| Claude Code agent guardrails | [Claude Code plugin](#claude-code-plugin) | Ask the agent to read `.env`; it should be blocked. |
+| Claude Code agent guardrails | [Quick start (Claude Code)](#quick-start-claude-code) | Ask the agent to read `.env`; it should be blocked. |
 | Codex stable guardrails | [Codex direct CLI + Git hook](#codex-plugin) | Run `agent-guard smoke-test`; commit a staged fixture secret, and it should fail. |
 | Codex experimental plugin hooks | [Codex plugin](#codex-plugin) | Enable `plugin_hooks`, trust hooks in `/hooks`, then ask Codex to read `.env`; it should be blocked. |
 | Local commits | [Native Git hook](#native-git-hook) | Commit a staged fixture secret; commit should fail. |
@@ -62,27 +86,7 @@ On Debian / Ubuntu or Fedora, install `jq` with the system package manager and d
 
 ## Claude Code Plugin
 
-Install from the marketplace:
-
-```text
-/plugin marketplace add JeongJaeSoon/agent-guard
-/plugin install agent-guard@agent-guard
-/reload-plugins
-```
-
-Smoke test:
-
-```text
-Please read .env
-```
-
-Expected result:
-
-```text
-agent-guard: blocked sensitive file access: .env
-```
-
-Useful Claude Code slash commands:
+Install and verify in [Quick start (Claude Code)](#quick-start-claude-code). Useful slash commands once installed:
 
 ```text
 /agent-guard:verify


### PR DESCRIPTION
## What

Restructure the top of the README to reduce install friction for first-time visitors (timely with the launch posts + listing traffic).

- **Quick start (Claude Code)** above the fold: marketplace install → sensitive-file block verification → one-line dependency note. The most common audience can install and confirm a block in seconds without first reading Requirements and a six-row table.
- The install-path table's Claude Code row now points to the quick start; the detailed **Claude Code Plugin** section is trimmed to its unique slash commands (no duplicated install/smoke steps).
- **GitHub Marketplace badge** added to the badge row (discovery/trust signal).

## Why

Pre-traction; the bottleneck is distribution + conversion. Leading with the fastest path-to-value (install → verify) is the highest-leverage README change as listing/HN traffic arrives.

## Verification

- All 8 internal anchor links resolve (validated programmatically).
- Badges remain on a single line (the Marketplace README renderer stacks multi-line badge rows).
- No test/CI asserts README content; `release.yml`'s semver-rewrite `sed` targets `agent-guard@X.Y.Z` only (our snippets use `@agent-guard` / `@v1`), so it stays a no-op.
- Pure docs change, no behavior impact.


<!-- code-flow-usage-json:start -->
<details>
<summary>code-flow usage JSON</summary>

```json
{
  "commits": [
    {
      "confidence": "best_effort",
      "model_totals": [],
      "participants": [],
      "sha": "d3ad414b942372dd8e1749e89cc7d776eeadd5f9",
      "status": "unmetered",
      "subject": "docs(readme): lead with a Claude Code quick start to lift install conversion",
      "totals": {
        "cache_creation_input_tokens": 0,
        "cache_read_input_tokens": 0,
        "input_tokens": 0,
        "output_tokens": 0,
        "total_context_tokens": 0
      }
    }
  ],
  "confidence": "best_effort",
  "metered_commits": 0,
  "pr": {
    "base": "main",
    "head": "docs/readme-conversion",
    "number": 73
  },
  "schema": "code-flow-usage/1",
  "scope": "current_branch_pr",
  "source": "claude_code_hooks",
  "total_commits": 1,
  "totals": {
    "cache_creation_input_tokens": 0,
    "cache_read_input_tokens": 0,
    "input_tokens": 0,
    "output_tokens": 0,
    "total_context_tokens": 0
  },
  "totals_by_model": [],
  "updated_at": "2026-06-18T08:40:42Z"
}
```

</details>
<!-- code-flow-usage-json:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added GitHub Marketplace badge to project.
  * Reworked Quick start section with improved installation and verification guidance.
  * Simplified installation path selection with updated cross-references.
  * Consolidated Claude Code Plugin documentation for easier navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->