### PR TITLE
feat(agent-guard): mask secret-like values in tool output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- feat(agent-guard): mask secret-like values in tool output via PostToolUse `updatedToolOutput`, closing the gap where a command prints credentials the pre-tool check never sees (`cat memo.txt`, env-printing CLIs, `KEY=value` dumps). On by default; disable with `AGENT_GUARD_OUTPUT_REDACT=off`. Detection combines gitleaks with a `KEY=value` env-assignment heuristic; redaction preserves the tool result's shape and fails safe (never corrupts output).
+
 ## v1.3.8 - 2026-06-16
 
 - docs: separate demo steps with blank lines for readability (#66)

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Patch and diff scans inspect added lines only. Removing an existing leaked value
 
 ## What Gets Masked
 
-Beyond blocking, Agent Guard **masks** secret-like values in a tool's *output* before the model sees them. A `PostToolUse` redactor scans the result of `Bash` (stdout/stderr) and read-style tools (`Read`, `NotebookRead`, `Grep`, `Glob`, `WebFetch`, `WebSearch`) and rewrites any detected secret to `[REDACTED]` in place via `updatedToolOutput`, preserving the result's shape. This closes the gap where a command *prints* a credential the pre-tool check never saw — e.g. `cat memo.txt`, an env-printing CLI, or a tool that dumps `KEY=value` pairs. Detection combines gitleaks with a `KEY=value` env-assignment heuristic. It is on by default; disable with `AGENT_GUARD_OUTPUT_REDACT=off`.
+Beyond blocking, Agent Guard **masks** secret-like values in a tool's *output* before the model sees them. A `PostToolUse` redactor scans the result of `Bash` (stdout/stderr) and read-style tools (`Read`, `NotebookRead`, `Grep`, `Glob`, `WebFetch`, `WebSearch`, and `mcp__.*`) and rewrites any detected secret to `[REDACTED]` in place via `updatedToolOutput`, preserving the result's shape. This closes the gap where a command *prints* a credential the pre-tool check never saw — e.g. `cat memo.txt`, an env-printing CLI, or a tool that dumps `KEY=value` pairs. Detection combines gitleaks with a `KEY=value` env-assignment heuristic. It is on by default; disable with `AGENT_GUARD_OUTPUT_REDACT=off`.
 
 ## Known Limitations
 

--- a/README.md
+++ b/README.md
@@ -255,6 +255,10 @@ To enable it, add an Actions secret named `OPENAI_API_KEY` in the GitHub reposit
 
 Patch and diff scans inspect added lines only. Removing an existing leaked value is allowed.
 
+## What Gets Masked
+
+Beyond blocking, Agent Guard **masks** secret-like values in a tool's *output* before the model sees them. A `PostToolUse` redactor scans the result of `Bash` (stdout/stderr) and read-style tools (`Read`, `NotebookRead`, `Grep`, `Glob`, `WebFetch`, `WebSearch`) and rewrites any detected secret to `[REDACTED]` in place via `updatedToolOutput`, preserving the result's shape. This closes the gap where a command *prints* a credential the pre-tool check never saw — e.g. `cat memo.txt`, an env-printing CLI, or a tool that dumps `KEY=value` pairs. Detection combines gitleaks with a `KEY=value` env-assignment heuristic. It is on by default; disable with `AGENT_GUARD_OUTPUT_REDACT=off`.
+
 ## Known Limitations
 
 Agent Guard is a deterministic, thin guardrail — not a DLP system, EDR, or vault. It scans tracked diffs, staged changes, and untracked files with gitleaks, and blocks a fixed list of sensitive paths and shell idioms. It deliberately does **not** inspect arbitrary file contents that a command reads, and it has these blind spots by design:
@@ -262,7 +266,7 @@ Agent Guard is a deterministic, thin guardrail — not a DLP system, EDR, or vau
 - **Gitignored files are not scanned.** The working-tree and post-tool/stop backstops use `git ls-files --others --exclude-standard` and `git diff`, both of which skip `.gitignore`d paths. A secret written to a gitignored file (e.g. `secrets/` or `*.local`) is not caught by the backstop. Keep real secrets out of the repo entirely.
 - **Only files inside the git work tree are covered.** The post-tool and stop hooks no-op outside a git repository, and scans are scoped to the current repo. Files outside the repo root, or written when no repo is present, get no backstop. Use `agent-guard scan-path <dir>` to scan an arbitrary tree on demand.
 - **Path and command blocking use fixed lists.** Read/Grep/Glob blocking matches the paths in `deny-read-paths.txt`; shell blocking matches the idioms in `deny-bash-patterns.txt`. A secret in an unlisted path, or read by an unlisted tool or flag, is not blocked. Extend the lists with `AGENT_GUARD_DENY_READ_PATHS` / `AGENT_GUARD_DENY_BASH_PATTERNS`.
-- **Command output is not inspected.** Blocking a `Read` or `Bash` invocation is based on the requested path and the command text, not on what the command prints. A command that reads an unlisted secret file or expands a variable at runtime (e.g. `echo "$TOKEN"`) can surface a secret the pre-tool check never sees.
+- **Output masking is best-effort.** Secret-like values in a tool's output (`Bash` stdout/stderr, file reads) are masked in place by the `PostToolUse` redactor (`AGENT_GUARD_OUTPUT_REDACT`, on by default), but detection is heuristic — gitleaks plus a `KEY=value` env-assignment rule. Unusual or custom secret formats can still slip through, and the redactor only sees results of the agent's *tool calls*. Treat output masking as defense in depth and keep real secrets out of agent sessions entirely.
 - **Bash detection is pattern-based.** The denylist targets common-accident and obvious-malicious idioms; an actively-evading agent can craft a command that matches none of them. Treat shell blocking as defense in depth, not a complete adversarial boundary.
 
 For defense in depth, pair Agent Guard with GitHub Secret Scanning / Push Protection and a secrets manager so credentials never reach the working tree.
@@ -278,7 +282,10 @@ AGENT_GUARD_DENY_BASH_PATTERNS=/path/to/deny-bash-patterns.txt
 AGENT_GUARD_PII_PROVIDER=regex
 AGENT_GUARD_PII_REDACT_URL=http://127.0.0.1:8080/api/redact
 AGENT_GUARD_PII_HOOK_MODE=off
+AGENT_GUARD_OUTPUT_REDACT=mask
 ```
+
+Set `AGENT_GUARD_OUTPUT_REDACT=off` to disable masking secret-like values in tool output (default `mask`).
 
 Project-local `.gitleaks.toml` files are not automatically trusted.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,7 +27,7 @@ Agent Guard is a deterministic, thin guardrail — not a DLP system, EDR, or
 vault. It has documented blind spots by design (see
 [Known Limitations](README.md#known-limitations)): gitignored files are not
 scanned, only the git work tree is covered, path/command blocking uses fixed
-lists, command output is not inspected, and Bash detection is pattern-based.
+lists, tool-output masking is best-effort, and Bash detection is pattern-based.
 
 Behavior that falls within those documented limitations is expected, not a
 vulnerability. Suggestions to narrow a blind spot are welcome as regular issues

--- a/examples/claude/settings.project.json
+++ b/examples/claude/settings.project.json
@@ -14,7 +14,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Write|Edit|MultiEdit|Bash|apply_patch|mcp__.*",
+        "matcher": "Write|Edit|MultiEdit|Bash|apply_patch|Read|NotebookRead|Grep|Glob|WebFetch|WebSearch|mcp__.*",
         "hooks": [
           {
             "type": "command",

--- a/examples/codex/hooks.json
+++ b/examples/codex/hooks.json
@@ -14,7 +14,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Write|Edit|MultiEdit|Bash|apply_patch|mcp__.*",
+        "matcher": "Write|Edit|MultiEdit|Bash|apply_patch|Read|NotebookRead|Grep|Glob|WebFetch|WebSearch|mcp__.*",
         "hooks": [
           {
             "type": "command",

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -1392,19 +1392,140 @@ is_mutation_tool() {
   esac
 }
 
+# --- Tool-output secret redaction (PostToolUse) ------------------------------
+# The pre-tool checks only ever see a command string or a file path; they never
+# see what a command PRINTS or what a file read RETURNS. A shell command that
+# dumps credentials to stdout (an env-printing CLI, `cat` of a secret-bearing
+# note) therefore leaks the secret into the model context unscanned. PostToolUse
+# can rewrite an already-produced result before the model sees it via
+# `hookSpecificOutput.updatedToolOutput` (Claude Code >= 2.1.121), so here we
+# scan the tool_response and mask any secret-like spans in place.
+#
+# Fail-safe: this path runs for (potentially) every tool result, so any error
+# emits NOTHING and lets the original output through unchanged. A redaction bug
+# must never corrupt a tool result.
+
+output_redact_enabled() {
+  case "${AGENT_GUARD_OUTPUT_REDACT:-mask}" in
+    off|'') return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+# Recall booster for the most common leak shape: `KEY=value`, `export KEY=value`
+# or `KEY: value` dumps whose key name looks secret-bearing. gitleaks misses most
+# of these (custom value formats), so emit the VALUE for literal redaction.
+secretish_env_values() {
+  awk '
+    {
+      low = tolower($0)
+      # Anchor the value to the delimiter that follows the matched key, not the
+      # first [=:] on the line — a log/timestamp prefix (e.g. "12:00:00") would
+      # otherwise hijack the split and mis-slice the value. tolower preserves
+      # byte offsets for ASCII, so RSTART/RLENGTH from `low` apply to $0.
+      if (match(low, /(password|passwd|secret|token|api[_-]?key|access[_-]?key|private[_-]?key|credential|client[_-]?secret|auth[_-]?token|webhook)[a-z0-9_]*[ \t]*[=:]/)) {
+        val = substr($0, RSTART + RLENGTH)
+        gsub(/^[ \t"'\''`]+/, "", val)
+        gsub(/[ \t"'\''`,;]+$/, "", val)
+        if (length(val) >= 4) print val
+      }
+    }
+  '
+}
+
+# Collect the literal secret strings present in $1 (the tool output text):
+# gitleaks findings (when gitleaks is available) plus the env-assignment
+# heuristic. Prints one secret per line; empty output means nothing to redact.
+detect_output_secrets() {
+  text=$1
+  {
+    # ponytail: forks gitleaks once per matched tool output. Acceptable because
+    # tool results reaching the hook are already harness-truncated; if a large
+    # WebFetch/MCP stream ever dominates latency, gate this on a size cap or an
+    # in-process pre-filter before the fork.
+    if command -v gitleaks >/dev/null 2>&1 && [ -f "$GITLEAKS_CONFIG" ]; then
+      report=$(mktemp_file) || report=''
+      if [ -n "$report" ]; then
+        printf '%s\n' "$text" \
+          | gitleaks stdin --report-format json --report-path "$report" \
+              --no-banner --config "$GITLEAKS_CONFIG" >/dev/null 2>&1
+        [ -s "$report" ] && jq -r '.[]?.Secret // empty' "$report" 2>/dev/null
+        rm -f "$report"
+      fi
+    fi
+    printf '%s\n' "$text" | secretish_env_values
+  } | awk 'NF' | sort -u
+}
+
+# Replace every detected secret literal with a placeholder inside ANY string leaf
+# of the tool_response JSON ($1), preserving the original shape exactly
+# (updatedToolOutput must match the tool's native output shape). $2 is the
+# newline-separated secret list. Prints the redacted JSON, or nothing on failure.
+redact_tool_response_json() {
+  resp=$1
+  secrets=$2
+  secrets_json=$(printf '%s' "$secrets" | jq -R . 2>/dev/null | jq -s . 2>/dev/null) || return 1
+  [ -n "$secrets_json" ] || return 1
+  printf '%s' "$resp" | jq -c --argjson secrets "$secrets_json" '
+    def walk(f): def w: if type == "object" then map_values(w)
+                        elif type == "array" then map(w)
+                        else . end | f; w;
+    def redact($s): reduce ($s | sort_by(length) | reverse)[] as $x (.;
+      if ($x | length) > 0 then ((. / $x) | join("[REDACTED]")) else . end);
+    walk(if type == "string" then redact($secrets) else . end)
+  ' 2>/dev/null
+}
+
+# PostToolUse output guard: scan this tool's result and, if any secret-like value
+# is present, emit updatedToolOutput with it masked, then exit 0 (a non-zero exit
+# makes Claude Code ignore the JSON). Never blocks; never corrupts on error.
+redact_tool_output() {
+  input=$1
+  output_redact_enabled || return 0
+
+  resp=$(printf '%s' "$input" | jq -c '.tool_response // empty' 2>/dev/null) || return 0
+  case "$resp" in
+    ''|null) return 0 ;;
+  esac
+
+  text=$(printf '%s' "$input" \
+    | jq -r '.tool_response | if type == "string" then . else [.. | strings] | join("\n") end' 2>/dev/null)
+  [ -n "$text" ] || return 0
+
+  secrets=$(detect_output_secrets "$text")
+  [ -n "$secrets" ] || return 0
+
+  redacted=$(redact_tool_response_json "$resp" "$secrets")
+  [ -n "$redacted" ] || return 0
+  [ "$redacted" != "$resp" ] || return 0
+
+  printf '%s' "$input" \
+    | jq -c --argjson ut "$redacted" \
+        '{hookSpecificOutput: {hookEventName: "PostToolUse", updatedToolOutput: $ut}}' 2>/dev/null \
+    || return 0
+  info "$PROGRAM: masked secret-like values in $(json_value '.tool_name // "tool"' "$input") output"
+  exit 0
+}
+
 hook_post_tool() {
   need_cmd jq
-  need_cmd git
   input=$(cat)
   [ -n "$input" ] || return 0
   tool=$(json_value '.tool_name // .tool // .name // empty' "$input")
-  is_mutation_tool "$tool" || return 0
 
-  # Best-effort: silently skip when the agent runs outside a git work tree.
-  inside_git_repo || return 0
+  # Mutation tools keep the working-tree backstop (may exit 2). It runs first so
+  # a secret written to disk is still surfaced even when redaction is enabled.
+  if is_mutation_tool "$tool"; then
+    need_cmd git
+    if inside_git_repo; then
+      scan_working_tree
+      block_on_scan_status "$?" "changed files contain secret-like values after tool execution"
+    fi
+  fi
 
-  scan_working_tree
-  block_on_scan_status "$?" "changed files contain secret-like values after tool execution"
+  # All matched tools: mask secret-like values in the tool's output before the
+  # model sees them (may emit updatedToolOutput and exit 0).
+  redact_tool_output "$input"
 }
 
 hook_stop() {

--- a/plugins/agent-guard/hooks.json
+++ b/plugins/agent-guard/hooks.json
@@ -14,7 +14,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Write|Edit|MultiEdit|Bash|apply_patch|mcp__.*",
+        "matcher": "Write|Edit|MultiEdit|Bash|apply_patch|Read|NotebookRead|Grep|Glob|WebFetch|WebSearch|mcp__.*",
         "hooks": [
           {
             "type": "command",

--- a/plugins/agent-guard/hooks/hooks.json
+++ b/plugins/agent-guard/hooks/hooks.json
@@ -14,7 +14,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Write|Edit|MultiEdit|Bash|apply_patch|mcp__.*",
+        "matcher": "Write|Edit|MultiEdit|Bash|apply_patch|Read|NotebookRead|Grep|Glob|WebFetch|WebSearch|mcp__.*",
         "hooks": [
           {
             "type": "command",

--- a/tests/fixtures/mock-gitleaks
+++ b/tests/fixtures/mock-gitleaks
@@ -4,13 +4,24 @@ set -u
 mode=${1:-}
 case "$mode" in
   stdin)
+    shift
+    report_path=''
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --report-path) shift; report_path=${1:-} ;;
+        --report-path=*) report_path=${1#--report-path=} ;;
+      esac
+      shift
+    done
     input=$(cat)
     case "$input" in
       *AGENT_GUARD_TEST_SECRET*)
+        [ -n "$report_path" ] && printf '%s\n' '[{"Secret":"AGENT_GUARD_TEST_SECRET"}]' >"$report_path"
         printf '%s\n' "Finding: REDACTED"
         exit 1
         ;;
       *)
+        [ -n "$report_path" ] && printf '%s\n' '[]' >"$report_path"
         exit 0
         ;;
     esac

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1938,6 +1938,98 @@ else
   sed 's/^/  /' /tmp/agent-guard-test.err
 fi
 
+# --- Tool-output secret redaction (PostToolUse updatedToolOutput) ----------
+# Masks secret-like values in a tool's RESULT before the model sees it. Run from
+# a non-git dir so the mutation-tool working-tree backstop stays inert and these
+# assertions isolate the redaction path. The harness mock gitleaks flags
+# AGENT_GUARD_TEST_SECRET; the env-assignment heuristic catches KEY=value dumps.
+post_tool_out() {
+  printf '%s' "$1" | (cd "$TMP_ROOT" && "$PLUGIN_ROOT/bin/agent-guard" hook-post-tool) \
+    >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+}
+
+post_tool_out '{"tool_name":"Bash","tool_input":{"command":"loadsecrets"},"tool_response":{"stdout":"token AGENT_GUARD_TEST_SECRET here\n","stderr":"","interrupted":false,"isImage":false}}'
+post_status=$?
+post_out=$(cat /tmp/agent-guard-test.out)
+if [ "$post_status" -eq 0 ] \
+   && printf '%s' "$post_out" | grep -q '\[REDACTED\]' \
+   && ! printf '%s' "$post_out" | grep -q 'AGENT_GUARD_TEST_SECRET' \
+   && printf '%s' "$post_out" | jq -e '.hookSpecificOutput.updatedToolOutput | has("stdout") and has("stderr") and has("interrupted") and has("isImage")' >/dev/null 2>&1; then
+  ok "post-tool masks a gitleaks-detected secret in Bash stdout (shape preserved)"
+else
+  not_ok "post-tool masks a gitleaks-detected secret in Bash stdout (status $post_status)"
+  printf '%s\n' "$post_out" | sed 's/^/  out: /'
+fi
+
+post_tool_out '{"tool_name":"Bash","tool_input":{"command":"printenv-like"},"tool_response":{"stdout":"DATABASE_PASSWORD=hunter2-long-value\n","stderr":"","interrupted":false,"isImage":false}}'
+post_out=$(cat /tmp/agent-guard-test.out)
+if printf '%s' "$post_out" | grep -q '\[REDACTED\]' \
+   && ! printf '%s' "$post_out" | grep -q 'hunter2-long-value'; then
+  ok "post-tool env-assignment heuristic masks KEY=value gitleaks misses"
+else
+  not_ok "post-tool env-assignment heuristic masks KEY=value gitleaks misses"
+  printf '%s\n' "$post_out" | sed 's/^/  out: /'
+fi
+
+post_tool_out '{"tool_name":"Read","tool_input":{"file_path":"memo.txt"},"tool_response":"API_KEY=supersecretvalue123\n"}'
+post_out=$(cat /tmp/agent-guard-test.out)
+if printf '%s' "$post_out" | jq -e '.hookSpecificOutput.updatedToolOutput | type == "string"' >/dev/null 2>&1 \
+   && ! printf '%s' "$post_out" | grep -q 'supersecretvalue123'; then
+  ok "post-tool masks secrets in Read string output (shape stays string)"
+else
+  not_ok "post-tool masks secrets in Read string output"
+  printf '%s\n' "$post_out" | sed 's/^/  out: /'
+fi
+
+post_tool_out '{"tool_name":"Bash","tool_input":{"command":"echo hi"},"tool_response":{"stdout":"hello world\n","stderr":"","interrupted":false,"isImage":false}}'
+post_status=$?
+post_out=$(cat /tmp/agent-guard-test.out)
+if [ "$post_status" -eq 0 ] && [ -z "$post_out" ]; then
+  ok "post-tool leaves clean output untouched (no rewrite emitted)"
+else
+  not_ok "post-tool leaves clean output untouched (status $post_status)"
+  printf '%s\n' "$post_out" | sed 's/^/  out: /'
+fi
+
+printf '%s' '{"tool_name":"Read","tool_input":{"file_path":"memo.txt"},"tool_response":"API_KEY=supersecretvalue123\n"}' \
+  | (cd "$TMP_ROOT" && AGENT_GUARD_OUTPUT_REDACT=off "$PLUGIN_ROOT/bin/agent-guard" hook-post-tool) \
+  >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+post_status=$?
+if [ "$post_status" -eq 0 ] && [ ! -s /tmp/agent-guard-test.out ]; then
+  ok "post-tool redaction disabled via AGENT_GUARD_OUTPUT_REDACT=off"
+else
+  not_ok "post-tool redaction disabled via AGENT_GUARD_OUTPUT_REDACT=off (status $post_status)"
+  sed 's/^/  out: /' /tmp/agent-guard-test.out
+fi
+
+# Overlapping secrets: when one detected value is a prefix of another, redaction
+# must scrub both. Lexicographic order would replace the prefix first and strand
+# the longer secret's suffix (UNIQUESUFFIX) — longest-first ordering prevents it.
+post_tool_out '{"tool_name":"Bash","tool_input":{"command":"x"},"tool_response":{"stdout":"AWS_SECRET=abcdwxyzcommonpart\nAWS_SECRET_KEY=abcdwxyzcommonpartUNIQUESUFFIX\n","stderr":"","interrupted":false,"isImage":false}}'
+post_out=$(cat /tmp/agent-guard-test.out)
+if printf '%s' "$post_out" | grep -q '\[REDACTED\]' \
+   && ! printf '%s' "$post_out" | grep -q 'abcdwxyzcommonpart' \
+   && ! printf '%s' "$post_out" | grep -q 'UNIQUESUFFIX'; then
+  ok "post-tool redacts overlapping secrets without leaking the longer suffix"
+else
+  not_ok "post-tool redacts overlapping secrets without leaking the longer suffix"
+  printf '%s\n' "$post_out" | sed 's/^/  out: /'
+fi
+
+# Log/timestamp prefix must not hijack the env-heuristic split: the value is
+# anchored to the matched key's delimiter, not the first ":" (here inside the
+# "12:00:00" timestamp). A clean copy in a SEPARATE leaf (stderr) only gets
+# masked if the extracted literal is the real value, so this catches a mis-slice.
+post_tool_out '{"tool_name":"Bash","tool_input":{"command":"x"},"tool_response":{"stdout":"2026-06-30T12:00:00Z level=info password=SuperSecretLogValue\n","stderr":"echoed SuperSecretLogValue\n","interrupted":false,"isImage":false}}'
+post_out=$(cat /tmp/agent-guard-test.out)
+if printf '%s' "$post_out" | grep -q '\[REDACTED\]' \
+   && ! printf '%s' "$post_out" | grep -q 'SuperSecretLogValue'; then
+  ok "post-tool anchors env value past a log prefix and masks it across leaves"
+else
+  not_ok "post-tool anchors env value past a log prefix and masks it across leaves"
+  printf '%s\n' "$post_out" | sed 's/^/  out: /'
+fi
+
 say "passed: $pass"
 say "failed: $fail"
 


### PR DESCRIPTION
## What & why

Agent Guard blocks secrets in tool **inputs** (paths, write content, shell command text), but never inspected tool **output**. So a command that *prints* a credential — `cat memo.txt`, an env-printing CLI, any `KEY=value` dump — surfaced the secret to the model untouched, even though nothing in the pre-tool path matched.

This adds a `PostToolUse` redactor that scans a tool's result and rewrites detected secret-like values to `[REDACTED]` in place via `updatedToolOutput`, preserving the result's shape. It **masks** rather than blocks, so the dev workflow keeps flowing.

## How it works

- Matched tools: `Bash` (stdout/stderr) + read-style tools (`Read`, `NotebookRead`, `Grep`, `Glob`, `WebFetch`, `WebSearch`, `mcp__.*`).
- Detection = gitleaks **plus** a `KEY=value` env-assignment heuristic (gitleaks misses most custom-format dumps). The heuristic anchors the value to the matched key's delimiter, so a log/timestamp prefix can't mis-slice it.
- Redaction is a shape-preserving jq `walk` over every string leaf, replacing the **longest** detected literals first so overlapping values can't strand a suffix.
- **Fail-safe:** any error (no jq, bad JSON, nothing detected, no change) emits nothing and the original output passes through unchanged — a redaction bug can never corrupt a tool result.
- On by default; `AGENT_GUARD_OUTPUT_REDACT=off` disables.

## Review-trio findings addressed

A parallel code-review / security / CodeRabbit pass ran on the diff. Resolved:

- 🟡 **Overlapping-secret suffix leak** (flagged by all three): `sort -u` + sequential reduce could leave a longer secret's tail while still claiming "masked". → longest-first redaction (`sort_by(length) | reverse`).
- 🟢 **env heuristic mis-slice / cross-leaf leak**: value was cut at the line's first `=`/`:`. → anchored to the matched key's delimiter.
- 🟢 **gitleaks fork per output (perf)**: documented as a deliberate tradeoff (tool results are harness-truncated) with a `ponytail:` upgrade path, rather than adding a size cap that would create a leak blind spot.

Cleared with no change: command/jq/argument injection (untrusted text reaches `gitleaks`/`awk` only via stdin, `jq` only via `--argjson`), ReDoS, temp-file race.

## Test plan

- `make test` → **280 passed / 0 failed**. 7 new tests cover: gitleaks-detected masking with shape preservation, env-heuristic masking, `Read` string-shape masking, clean-output passthrough, `AGENT_GUARD_OUTPUT_REDACT=off`, overlapping-secret suffix, and log-prefix anchoring across leaves.
- The new matcher is synced across both plugin manifests and both `examples/` manifests (enforced by existing sync tests).

## Manual verification (please check in a live Claude Code session)

Automated tests exercise the engine directly; what they can't fully prove is the hook firing end-to-end in a real agent and the `updatedToolOutput` reaching the model. Suggested checks:

1. Install/point Claude Code at this branch's plugin and restart so the `PostToolUse` hook reloads. Confirm `/hooks` shows the PostToolUse hook trusted.
2. In a scratch dir, create a throwaway file containing a fake `KEY=value` line (e.g. `API_KEY=not-a-real-value-1234`) and have the agent run `cat` on it. **Expected:** the value the agent sees is `[REDACTED]`, and a stderr note `masked secret-like values in ... output` appears.
3. Run a command that prints a gitleaks-detectable token. **Expected:** masked in the agent's view.
4. Set `AGENT_GUARD_OUTPUT_REDACT=off`, repeat step 2. **Expected:** no masking (passthrough).
5. Sanity: a clean command (`echo hello`) is untouched and adds no latency-visible stall.

> Note: this covers the agent **tool-call** path. A user-typed `!` shell-escape command runs outside the tool loop and fires no hooks — that limitation is tracked for a follow-up docs PR.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- code-flow-usage-json:start -->
<details>
<summary>code-flow usage JSON</summary>

```json
{
  "commits": [
    {
      "confidence": "best_effort",
      "model_totals": [],
      "participants": [],
      "sha": "e7fdf042d24bebf94ef4e2bf775532f36527b2c0",
      "status": "unmetered",
      "subject": "feat(agent-guard): mask secret-like values in tool output",
      "totals": {
        "cache_creation_input_tokens": 0,
        "cache_read_input_tokens": 0,
        "input_tokens": 0,
        "output_tokens": 0,
        "total_context_tokens": 0
      }
    }
  ],
  "confidence": "best_effort",
  "metered_commits": 0,
  "pr": {
    "base": "main",
    "head": "feat/redact-secrets-in-tool-output",
    "number": 77
  },
  "schema": "code-flow-usage/1",
  "scope": "current_branch_pr",
  "source": "claude_code_hooks",
  "total_commits": 1,
  "totals": {
    "cache_creation_input_tokens": 0,
    "cache_read_input_tokens": 0,
    "input_tokens": 0,
    "output_tokens": 0,
    "total_context_tokens": 0
  },
  "totals_by_model": [],
  "updated_at": "2026-06-30T15:47:35Z"
}
```

</details>
<!-- code-flow-usage-json:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool output can now be automatically masked to hide secret-like values, while preserving the original output format.
  * This masking is enabled by default and can be turned off with an environment setting.

* **Bug Fixes**
  * Improved coverage so more tool outputs are checked and sensitive values are less likely to appear in results.

* **Documentation**
  * Updated the README and security notes to explain what gets masked, known limitations, and how to disable masking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->