### PR TITLE
feat(agent-guard): mask PII in tool output via mask mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - feat(agent-guard): mask secret-like values in tool output via PostToolUse `updatedToolOutput`, closing the gap where a command prints credentials the pre-tool check never sees (`cat memo.txt`, env-printing CLIs, `KEY=value` dumps). On by default; disable with `AGENT_GUARD_OUTPUT_REDACT=off`. Detection combines gitleaks with a `KEY=value` env-assignment heuristic; redaction preserves the tool result's shape and fails safe (never corrupts output).
+- feat(agent-guard): unseal `AGENT_GUARD_PII_HOOK_MODE=mask` — mask PII (email, phone incl. Korean mobile, IPv4, credit card, US SSN, Korean resident registration number) in tool output via the same PostToolUse path, composing with secret redaction into one rewrite. Tier policy: mask mode hard-blocks only Tier-2 PII (credit card / SSN / resident reg. no.) on inputs and lets Tier-1 (email/phone/IP) through to be masked on output; `block` mode (block all PII inputs) is unchanged. Adds Korean resident registration number and mobile patterns to the regex provider.
 
 ## v1.3.8 - 2026-06-16
 

--- a/README.md
+++ b/README.md
@@ -191,13 +191,19 @@ printf '%s\n' 'Customer jane@example.com' \
 
 Agent Guard does not install, import, run, or manage `pleno-anonymize`, Docker, Python, or any hosted service. If you use `pleno`, run pleno-anonymize separately or point `AGENT_GUARD_PII_REDACT_URL` at a hosted compatible endpoint.
 
-Masking is a CLI workflow. Agent hooks cannot safely rewrite pending tool payloads, so hook PII enforcement is off by default. To block tool inputs containing PII, opt in explicitly:
+PII handling in hooks is off by default. Two opt-in modes:
 
 ```sh
-AGENT_GUARD_PII_HOOK_MODE=block
+AGENT_GUARD_PII_HOOK_MODE=block   # block tool INPUTS that contain any PII
+# or
+AGENT_GUARD_PII_HOOK_MODE=mask    # mask PII in tool OUTPUTS; hard-block Tier-2 inputs
 ```
 
-In block mode, proposed `Write`, `Edit`, `MultiEdit`, `apply_patch`, `Bash`, `WebFetch`, `WebSearch`, and MCP inputs are blocked when PII is detected, with guidance to run `agent-guard pii-filter` first. `AGENT_GUARD_PII_HOOK_MODE=mask` is rejected because hooks cannot perform safe in-flight masking.
+In **block** mode, proposed `Write`, `Edit`, `MultiEdit`, `apply_patch`, `Bash`, `WebFetch`, `WebSearch`, and MCP inputs are blocked when any PII is detected, with guidance to run `agent-guard pii-filter` first.
+
+In **mask** mode, PII is masked in a tool's *output* (`PostToolUse`, the same path as secret redaction) so the model never sees it. On the *input* side, mask mode hard-blocks only **Tier-2** PII — credit card, US SSN, and Korean resident registration number, which must never reach a tool — and lets **Tier-1** PII (email, phone, IPv4) through to be masked on the way out. Hooks cannot rewrite a *pending* input payload, so Tier-1 input is allowed rather than masked in place; use `agent-guard pii-filter` for input-side masking.
+
+The regex provider recognizes email, phone (including Korean mobile), IPv4, credit card, US SSN, and Korean resident registration number.
 
 ## Native Git Hook
 
@@ -249,7 +255,7 @@ To enable it, add an Actions secret named `OPENAI_API_KEY` in the GitHub reposit
 - `Write`, `Edit`, `MultiEdit`, and Codex `apply_patch` content containing secret-like values
 - `WebFetch`, `WebSearch`, and MCP tool input JSON containing secret-like values
 - risky shell commands such as `printenv`, `op read`, `vault kv get`, `aws secretsmanager get-secret-value`, `cat .env`, and `git commit --no-verify`
-- PII in proposed write, shell, web, or MCP inputs only when `AGENT_GUARD_PII_HOOK_MODE=block`
+- PII in proposed write, shell, web, or MCP inputs — all PII when `AGENT_GUARD_PII_HOOK_MODE=block`, or only Tier-2 PII (credit card, US SSN, Korean resident registration number) when `AGENT_GUARD_PII_HOOK_MODE=mask`
 - staged added lines in the native pre-commit hook
 - working-tree added lines and untracked files after agent mutations
 
@@ -259,6 +265,8 @@ Patch and diff scans inspect added lines only. Removing an existing leaked value
 
 Beyond blocking, Agent Guard **masks** secret-like values in a tool's *output* before the model sees them. A `PostToolUse` redactor scans the result of `Bash` (stdout/stderr) and read-style tools (`Read`, `NotebookRead`, `Grep`, `Glob`, `WebFetch`, `WebSearch`, and `mcp__.*`) and rewrites any detected secret to `[REDACTED]` in place via `updatedToolOutput`, preserving the result's shape. This closes the gap where a command *prints* a credential the pre-tool check never saw — e.g. `cat memo.txt`, an env-printing CLI, or a tool that dumps `KEY=value` pairs. Detection combines gitleaks with a `KEY=value` env-assignment heuristic. It is on by default; disable with `AGENT_GUARD_OUTPUT_REDACT=off`.
 
+With `AGENT_GUARD_PII_HOOK_MODE=mask`, the same `PostToolUse` redactor also masks **PII** in tool output — email, phone (including Korean mobile), IPv4, credit card, US SSN, and Korean resident registration number become `[PII:TYPE]` placeholders in place. Secret redaction and PII masking compose into a single rewrite, so a result containing both is fully sanitized at once.
+
 ## Known Limitations
 
 Agent Guard is a deterministic, thin guardrail — not a DLP system, EDR, or vault. It scans tracked diffs, staged changes, and untracked files with gitleaks, and blocks a fixed list of sensitive paths and shell idioms. It deliberately does **not** inspect arbitrary file contents that a command reads, and it has these blind spots by design:
@@ -266,7 +274,7 @@ Agent Guard is a deterministic, thin guardrail — not a DLP system, EDR, or vau
 - **Gitignored files are not scanned.** The working-tree and post-tool/stop backstops use `git ls-files --others --exclude-standard` and `git diff`, both of which skip `.gitignore`d paths. A secret written to a gitignored file (e.g. `secrets/` or `*.local`) is not caught by the backstop. Keep real secrets out of the repo entirely.
 - **Only files inside the git work tree are covered.** The post-tool and stop hooks no-op outside a git repository, and scans are scoped to the current repo. Files outside the repo root, or written when no repo is present, get no backstop. Use `agent-guard scan-path <dir>` to scan an arbitrary tree on demand.
 - **Path and command blocking use fixed lists.** Read/Grep/Glob blocking matches the paths in `deny-read-paths.txt`; shell blocking matches the idioms in `deny-bash-patterns.txt`. A secret in an unlisted path, or read by an unlisted tool or flag, is not blocked. Extend the lists with `AGENT_GUARD_DENY_READ_PATHS` / `AGENT_GUARD_DENY_BASH_PATTERNS`.
-- **Output masking is best-effort.** Secret-like values in a tool's output (`Bash` stdout/stderr, file reads) are masked in place by the `PostToolUse` redactor (`AGENT_GUARD_OUTPUT_REDACT`, on by default), but detection is heuristic — gitleaks plus a `KEY=value` env-assignment rule. Unusual or custom secret formats can still slip through, and the redactor only sees results of the agent's *tool calls*. Treat output masking as defense in depth and keep real secrets out of agent sessions entirely.
+- **Output masking is best-effort.** Secret-like values in a tool's output (`Bash` stdout/stderr, file reads) are masked in place by the `PostToolUse` redactor (`AGENT_GUARD_OUTPUT_REDACT`, on by default), but detection is heuristic — gitleaks plus a `KEY=value` env-assignment rule. Unusual or custom secret formats can still slip through, and the redactor only sees results of the agent's *tool calls*. PII masking (`AGENT_GUARD_PII_HOOK_MODE=mask`) is likewise regex-based: it can over-match (a version string read as an IPv4) or miss locale formats it has no rule for. Both the secret redactor and the PII masker walk JSON string *values* only — a secret or PII string that appears as an object *key* is left unmasked, because rewriting keys could collapse two distinct keys onto one placeholder and drop an entry. Treat output masking as defense in depth and keep real secrets and personal data out of agent sessions entirely.
 - **Bash detection is pattern-based.** The denylist targets common-accident and obvious-malicious idioms; an actively-evading agent can craft a command that matches none of them. Treat shell blocking as defense in depth, not a complete adversarial boundary.
 
 For defense in depth, pair Agent Guard with GitHub Secret Scanning / Push Protection and a secrets manager so credentials never reach the working tree.
@@ -285,7 +293,7 @@ AGENT_GUARD_PII_HOOK_MODE=off
 AGENT_GUARD_OUTPUT_REDACT=mask
 ```
 
-Set `AGENT_GUARD_OUTPUT_REDACT=off` to disable masking secret-like values in tool output (default `mask`).
+Set `AGENT_GUARD_OUTPUT_REDACT=off` to disable masking secret-like values in tool output (default `mask`). Set `AGENT_GUARD_PII_HOOK_MODE` to `block` (block PII in tool inputs), `mask` (mask PII in tool outputs + hard-block Tier-2 PII inputs), or `off` (default).
 
 Project-local `.gitleaks.toml` files are not automatically trusted.
 

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -357,9 +357,11 @@ pii_regex_adapter_filter() {
   awk '
     BEGIN {
       credit_card = "[0-9][0-9][0-9][0-9][ -]?[0-9][0-9][0-9][0-9][ -]?[0-9][0-9][0-9][0-9][ -]?[0-9][0-9][0-9][0-9]([ -]?[0-9][0-9][0-9])?"
+      kr_rrn = "[0-9][0-9][0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9][0-9][0-9][0-9]"
       ssn = "[0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9][0-9][0-9]"
       ip_addr = "[0-9][0-9]?[0-9]?[.][0-9][0-9]?[0-9]?[.][0-9][0-9]?[0-9]?[.][0-9][0-9]?[0-9]?"
       email = "[[:alnum:]_%+.-]+@[[:alnum:].-]+[.][[:alpha:]][[:alpha:]][[:alpha:]]*"
+      kr_mobile = "01[0-9][ -]?[0-9][0-9][0-9][0-9][ -]?[0-9][0-9][0-9][0-9]"
       phone = "([+]?[0-9][ .-]?)?([(][0-9][0-9][0-9][)]|[0-9][0-9][0-9])[ .-]?[0-9][0-9][0-9][ .-]?[0-9][0-9][0-9][0-9]"
     }
     {
@@ -367,9 +369,11 @@ pii_regex_adapter_filter() {
         printf "%s", ORS
       }
       gsub(credit_card, "[PII:CREDIT_CARD]")
+      gsub(kr_rrn, "[PII:KR_RRN]")
       gsub(ssn, "[PII:SSN]")
       gsub(ip_addr, "[PII:IP_ADDRESS]")
       gsub(email, "[PII:EMAIL]")
+      gsub(kr_mobile, "[PII:PHONE]")
       gsub(phone, "[PII:PHONE]")
       printf "%s", $0
     }
@@ -461,31 +465,61 @@ pii_text_has_match() {
   [ "$masked" != "$text" ]
 }
 
-pii_hook_block_enabled() {
+pii_hook_mode() {
   mode=${AGENT_GUARD_PII_HOOK_MODE:-off}
   case "$mode" in
-    off|'') return 1 ;;
-    block) return 0 ;;
-    mask)
-      die "PII hook mode mask is not supported; hooks cannot rewrite pending tool payloads. Use agent-guard pii-filter before invoking tools, or set AGENT_GUARD_PII_HOOK_MODE=block."
-      ;;
-    *) die "unsupported PII hook mode: $mode (expected off or block)" ;;
+    off|'') printf 'off' ;;
+    block) printf 'block' ;;
+    mask) printf 'mask' ;;
+    *) die "unsupported PII hook mode: $mode (expected off, block, or mask)" ;;
   esac
 }
 
+# High-sensitivity ("Tier 2") PII that must never reach a tool input even in
+# mask mode: SSN, credit card, and Korean resident registration number. Detected
+# directly (provider-independent) so the input gate works for any provider, since
+# only the regex adapter exposes typed markers. These patterns mirror the Tier-2
+# rules in pii_regex_adapter_filter (CLI) and mask_pii_response_json (output); if
+# you change one, change all three. tests/run.sh drives a credit card, SSN, and
+# resident reg. no. through this gate (expect exit 2) and through the masker.
+pii_tier2_present() {
+  text=$1
+  [ -n "$text" ] || return 1
+  printf '%s' "$text" | awk '
+    BEGIN {
+      cc = "[0-9][0-9][0-9][0-9][ -]?[0-9][0-9][0-9][0-9][ -]?[0-9][0-9][0-9][0-9][ -]?[0-9][0-9][0-9][0-9]([ -]?[0-9][0-9][0-9])?"
+      ssn = "[0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9][0-9][0-9]"
+      rrn = "[0-9][0-9][0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9][0-9][0-9][0-9]"
+    }
+    $0 ~ cc || $0 ~ ssn || $0 ~ rrn { found = 1 }
+    END { exit (found ? 0 : 1) }
+  '
+}
+
+# Input gate. block mode blocks ANY PII (run pii-filter first); mask mode only
+# hard-blocks Tier-2 PII on the way in (Tier-1 — email/phone/IP — is allowed in
+# and masked on the way out instead). off never reaches here.
 block_on_pii_text() {
   label=$1
   text=$2
-  if pii_text_has_match "$text"; then
-    info "$PROGRAM: blocked PII in $label; run agent-guard pii-filter before using this tool"
-    exit 2
-  fi
+  case "$(pii_hook_mode)" in
+    block)
+      pii_text_has_match "$text" || return 0
+      info "$PROGRAM: blocked PII in $label; run agent-guard pii-filter before using this tool"
+      exit 2
+      ;;
+    mask)
+      pii_tier2_present "$text" || return 0
+      info "$PROGRAM: blocked high-sensitivity PII (SSN/credit card/resident reg. no.) in $label"
+      exit 2
+      ;;
+  esac
 }
 
 check_pii_hook_input() {
   input=$1
   tool=$2
-  pii_hook_block_enabled || return 0
+  [ "$(pii_hook_mode)" = off ] && return 0
   need_cmd jq
 
   case "$tool" in
@@ -1466,6 +1500,9 @@ redact_tool_response_json() {
   secrets=$2
   secrets_json=$(printf '%s' "$secrets" | jq -R . 2>/dev/null | jq -s . 2>/dev/null) || return 1
   [ -n "$secrets_json" ] || return 1
+  # Redacts string VALUES only; object KEYS are left untouched. Transforming keys
+  # could collide two distinct keys onto one placeholder and silently drop an
+  # entry; a secret appearing as a JSON key is a documented limitation (README).
   printf '%s' "$resp" | jq -c --argjson secrets "$secrets_json" '
     def walk(f): def w: if type == "object" then map_values(w)
                         elif type == "array" then map(w)
@@ -1479,31 +1516,86 @@ redact_tool_response_json() {
 # PostToolUse output guard: scan this tool's result and, if any secret-like value
 # is present, emit updatedToolOutput with it masked, then exit 0 (a non-zero exit
 # makes Claude Code ignore the JSON). Never blocks; never corrupts on error.
+# Mask PII inside ANY string leaf of the tool_response JSON ($1), preserving the
+# original shape. The regex patterns mirror pii_regex_adapter_filter (the CLI
+# adapter) so the hook and `agent-guard pii-filter` mask the same things; Tier-2
+# (credit card / KR resident reg. no. / SSN) is masked first so a Tier-1 pattern
+# can't shadow it, and KR mobile before the generic phone pattern. Like the
+# secret redactor, this masks string VALUES only — object KEYS are left as-is
+# (masking keys risks collapsing distinct keys onto one placeholder); PII in a
+# JSON key is a documented limitation (README). Prints the masked JSON, or
+# nothing on failure (e.g. a jq build without Oniguruma gsub).
+mask_pii_response_json() {
+  resp=$1
+  printf '%s' "$resp" | jq -c '
+    def mask_pii:
+      gsub("[0-9]{4}[ -]?[0-9]{4}[ -]?[0-9]{4}[ -]?[0-9]{4}([ -]?[0-9]{3})?"; "[PII:CREDIT_CARD]")
+      | gsub("[0-9]{6}-[0-9]{7}"; "[PII:KR_RRN]")
+      | gsub("[0-9]{3}-[0-9]{2}-[0-9]{4}"; "[PII:SSN]")
+      | gsub("[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}"; "[PII:IP_ADDRESS]")
+      | gsub("[A-Za-z0-9_%+.-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}"; "[PII:EMAIL]")
+      | gsub("01[0-9][ -]?[0-9]{4}[ -]?[0-9]{4}"; "[PII:PHONE]")
+      | gsub("(\\+?[0-9][ .-]?)?(\\([0-9]{3}\\)|[0-9]{3})[ .-]?[0-9]{3}[ .-]?[0-9]{4}"; "[PII:PHONE]");
+    def walk(f): def w: if type == "object" then map_values(w)
+                        elif type == "array" then map(w)
+                        else . end | f; w;
+    walk(if type == "string" then mask_pii else . end)
+  ' 2>/dev/null
+}
+
+# PostToolUse output guard. Applies, in one rewrite: secret-literal redaction
+# (AGENT_GUARD_OUTPUT_REDACT, on by default) and PII masking
+# (AGENT_GUARD_PII_HOOK_MODE=mask). Both transform the same tool_response and are
+# emitted as a single updatedToolOutput, so they compose instead of racing for
+# the one rewrite slot. Never blocks; never corrupts on error (fail-safe: any
+# step that fails leaves the value unchanged and the original passes through).
 redact_tool_output() {
   input=$1
-  output_redact_enabled || return 0
+  secrets_on=0; pii_on=0
+  output_redact_enabled && secrets_on=1
+  [ "$(pii_hook_mode)" = mask ] && pii_on=1
+  [ "$secrets_on" -eq 1 ] || [ "$pii_on" -eq 1 ] || return 0
 
   resp=$(printf '%s' "$input" | jq -c '.tool_response // empty' 2>/dev/null) || return 0
   case "$resp" in
     ''|null) return 0 ;;
   esac
 
-  text=$(printf '%s' "$input" \
-    | jq -r '.tool_response | if type == "string" then . else [.. | strings] | join("\n") end' 2>/dev/null)
-  [ -n "$text" ] || return 0
+  out=$resp
+  did_secret=0; did_pii=0
 
-  secrets=$(detect_output_secrets "$text")
-  [ -n "$secrets" ] || return 0
+  if [ "$secrets_on" -eq 1 ]; then
+    text=$(printf '%s' "$out" \
+      | jq -r 'if type == "string" then . else [.. | strings] | join("\n") end' 2>/dev/null)
+    if [ -n "$text" ]; then
+      secrets=$(detect_output_secrets "$text")
+      if [ -n "$secrets" ]; then
+        r=$(redact_tool_response_json "$out" "$secrets")
+        if [ -n "$r" ] && [ "$r" != "$out" ]; then out=$r; did_secret=1; fi
+      fi
+    fi
+  fi
 
-  redacted=$(redact_tool_response_json "$resp" "$secrets")
-  [ -n "$redacted" ] || return 0
-  [ "$redacted" != "$resp" ] || return 0
+  if [ "$pii_on" -eq 1 ]; then
+    r=$(mask_pii_response_json "$out")
+    if [ -n "$r" ] && [ "$r" != "$out" ]; then out=$r; did_pii=1; fi
+  fi
+
+  [ "$out" != "$resp" ] || return 0
 
   printf '%s' "$input" \
-    | jq -c --argjson ut "$redacted" \
+    | jq -c --argjson ut "$out" \
         '{hookSpecificOutput: {hookEventName: "PostToolUse", updatedToolOutput: $ut}}' 2>/dev/null \
     || return 0
-  info "$PROGRAM: masked secret-like values in $(json_value '.tool_name // "tool"' "$input") output"
+
+  tool=$(json_value '.tool_name // "tool"' "$input")
+  if [ "$did_secret" -eq 1 ] && [ "$did_pii" -eq 1 ]; then
+    info "$PROGRAM: masked secret-like values and PII in $tool output"
+  elif [ "$did_pii" -eq 1 ]; then
+    info "$PROGRAM: masked PII in $tool output"
+  else
+    info "$PROGRAM: masked secret-like values in $tool output"
+  fi
   exit 0
 }
 
@@ -1523,8 +1615,9 @@ hook_post_tool() {
     fi
   fi
 
-  # All matched tools: mask secret-like values in the tool's output before the
-  # model sees them (may emit updatedToolOutput and exit 0).
+  # All matched tools: mask secret-like values (and PII, when
+  # AGENT_GUARD_PII_HOOK_MODE=mask) in the tool's output before the model sees
+  # them (may emit updatedToolOutput and exit 0).
   redact_tool_output "$input"
 }
 

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -357,6 +357,7 @@ pii_regex_adapter_filter() {
   awk '
     BEGIN {
       credit_card = "[0-9][0-9][0-9][0-9][ -]?[0-9][0-9][0-9][0-9][ -]?[0-9][0-9][0-9][0-9][ -]?[0-9][0-9][0-9][0-9]([ -]?[0-9][0-9][0-9])?"
+      amex = "3[47][0-9][0-9][ -]?[0-9][0-9][0-9][0-9][0-9][0-9][ -]?[0-9][0-9][0-9][0-9][0-9]"
       kr_rrn = "[0-9][0-9][0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9][0-9][0-9][0-9]"
       ssn = "[0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9][0-9][0-9]"
       ip_addr = "[0-9][0-9]?[0-9]?[.][0-9][0-9]?[0-9]?[.][0-9][0-9]?[0-9]?[.][0-9][0-9]?[0-9]?"
@@ -369,6 +370,7 @@ pii_regex_adapter_filter() {
         printf "%s", ORS
       }
       gsub(credit_card, "[PII:CREDIT_CARD]")
+      gsub(amex, "[PII:CREDIT_CARD]")
       gsub(kr_rrn, "[PII:KR_RRN]")
       gsub(ssn, "[PII:SSN]")
       gsub(ip_addr, "[PII:IP_ADDRESS]")
@@ -485,13 +487,15 @@ pii_hook_mode() {
 pii_tier2_present() {
   text=$1
   [ -n "$text" ] || return 1
+  need_cmd awk
   printf '%s' "$text" | awk '
     BEGIN {
       cc = "[0-9][0-9][0-9][0-9][ -]?[0-9][0-9][0-9][0-9][ -]?[0-9][0-9][0-9][0-9][ -]?[0-9][0-9][0-9][0-9]([ -]?[0-9][0-9][0-9])?"
+      amex = "3[47][0-9][0-9][ -]?[0-9][0-9][0-9][0-9][0-9][0-9][ -]?[0-9][0-9][0-9][0-9][0-9]"
       ssn = "[0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9][0-9][0-9]"
       rrn = "[0-9][0-9][0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9][0-9][0-9][0-9]"
     }
-    $0 ~ cc || $0 ~ ssn || $0 ~ rrn { found = 1 }
+    $0 ~ cc || $0 ~ amex || $0 ~ ssn || $0 ~ rrn { found = 1 }
     END { exit (found ? 0 : 1) }
   '
 }
@@ -509,8 +513,16 @@ block_on_pii_text() {
       exit 2
       ;;
     mask)
-      pii_tier2_present "$text" || return 0
-      info "$PROGRAM: blocked high-sensitivity PII (SSN/credit card/resident reg. no.) in $label"
+      # Fail closed: only a definitive "no Tier-2 PII" (status 1) lets input
+      # through; a detector error (awk missing/failed) blocks rather than
+      # silently allowing high-sensitivity PII into the tool.
+      pii_tier2_present "$text"
+      status=$?
+      case "$status" in
+        1) return 0 ;;
+        0) info "$PROGRAM: blocked high-sensitivity PII (SSN/credit card/resident reg. no.) in $label" ;;
+        *) info "$PROGRAM: blocked input: Tier-2 PII detector failed (status $status) in $label" ;;
+      esac
       exit 2
       ;;
   esac
@@ -519,6 +531,10 @@ block_on_pii_text() {
 check_pii_hook_input() {
   input=$1
   tool=$2
+  # Validate the mode in the main shell first: pii_hook_mode dies on an
+  # unsupported value, but the $(...) reads below would swallow that exit and
+  # silently disable the gate. Running it here (no subshell) fails closed.
+  pii_hook_mode >/dev/null
   [ "$(pii_hook_mode)" = off ] && return 0
   need_cmd jq
 
@@ -1530,6 +1546,7 @@ mask_pii_response_json() {
   printf '%s' "$resp" | jq -c '
     def mask_pii:
       gsub("[0-9]{4}[ -]?[0-9]{4}[ -]?[0-9]{4}[ -]?[0-9]{4}([ -]?[0-9]{3})?"; "[PII:CREDIT_CARD]")
+      | gsub("3[47][0-9]{2}[ -]?[0-9]{6}[ -]?[0-9]{5}"; "[PII:CREDIT_CARD]")
       | gsub("[0-9]{6}-[0-9]{7}"; "[PII:KR_RRN]")
       | gsub("[0-9]{3}-[0-9]{2}-[0-9]{4}"; "[PII:SSN]")
       | gsub("[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}"; "[PII:IP_ADDRESS]")
@@ -1551,6 +1568,10 @@ mask_pii_response_json() {
 # step that fails leaves the value unchanged and the original passes through).
 redact_tool_output() {
   input=$1
+  # Validate the mode in the main shell (pii_hook_mode dies on an unsupported
+  # value; the $(...) read below would otherwise swallow the exit and silently
+  # leave PII unmasked). A misconfigured mode fails loud instead of fail-open.
+  pii_hook_mode >/dev/null
   secrets_on=0; pii_on=0
   output_redact_enabled && secrets_on=1
   [ "$(pii_hook_mode)" = mask ] && pii_on=1

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -730,14 +730,65 @@ else
   sed 's/^/  stderr: /' /tmp/agent-guard-test.err
 fi
 
+# mask mode: clean input passes through (nothing to block on the way in).
 printf '%s' '{"tool_name":"Write","tool_input":{"file_path":"note.txt","content":"clean"}}' \
   | AGENT_GUARD_PII_HOOK_MODE=mask "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool \
     >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
 status=$?
-if [ "$status" -eq 2 ] && grep -q 'mask is not supported' /tmp/agent-guard-test.err; then
-  ok "PII hook mask mode is rejected"
+if [ "$status" -eq 0 ]; then
+  ok "PII mask mode allows clean input"
 else
-  not_ok "PII hook mask mode is rejected (expected 2, got $status)"
+  not_ok "PII mask mode allows clean input (expected 0, got $status)"
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+
+# mask mode: Tier-1 PII (email) is allowed IN — it gets masked on output instead.
+printf '%s' '{"tool_name":"Write","tool_input":{"file_path":"note.txt","content":"contact jane@example.com"}}' \
+  | AGENT_GUARD_PII_HOOK_MODE=mask "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool \
+    >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+status=$?
+if [ "$status" -eq 0 ]; then
+  ok "PII mask mode allows Tier-1 PII (email) input"
+else
+  not_ok "PII mask mode allows Tier-1 PII (email) input (expected 0, got $status)"
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+
+# mask mode: Tier-2 PII (KR resident registration number) is hard-blocked on input.
+printf '%s' '{"tool_name":"Write","tool_input":{"file_path":"note.txt","content":"id 900101-1234567"}}' \
+  | AGENT_GUARD_PII_HOOK_MODE=mask "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool \
+    >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+status=$?
+if [ "$status" -eq 2 ] && grep -q 'high-sensitivity PII' /tmp/agent-guard-test.err; then
+  ok "PII mask mode blocks Tier-2 PII (resident reg. no.) input"
+else
+  not_ok "PII mask mode blocks Tier-2 PII input (expected 2, got $status)"
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+
+# mask mode: Tier-2 credit card is hard-blocked on input.
+# (Card number assembled at runtime so this test file holds no contiguous PAN.)
+cc="4111 1111 ""1111 1111"
+printf '%s' "{\"tool_name\":\"Write\",\"tool_input\":{\"file_path\":\"note.txt\",\"content\":\"card $cc\"}}" \
+  | AGENT_GUARD_PII_HOOK_MODE=mask "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool \
+    >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+status=$?
+if [ "$status" -eq 2 ] && grep -q 'high-sensitivity PII' /tmp/agent-guard-test.err; then
+  ok "PII mask mode blocks Tier-2 PII (credit card) input"
+else
+  not_ok "PII mask mode blocks Tier-2 PII (credit card) input (expected 2, got $status)"
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+
+# mask mode: Tier-2 US SSN is hard-blocked on input.
+printf '%s' '{"tool_name":"Write","tool_input":{"file_path":"note.txt","content":"ssn 123-45-6789"}}' \
+  | AGENT_GUARD_PII_HOOK_MODE=mask "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool \
+    >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+status=$?
+if [ "$status" -eq 2 ] && grep -q 'high-sensitivity PII' /tmp/agent-guard-test.err; then
+  ok "PII mask mode blocks Tier-2 PII (US SSN) input"
+else
+  not_ok "PII mask mode blocks Tier-2 PII (US SSN) input (expected 2, got $status)"
   sed 's/^/  stderr: /' /tmp/agent-guard-test.err
 fi
 
@@ -2028,6 +2079,80 @@ if printf '%s' "$post_out" | grep -q '\[REDACTED\]' \
 else
   not_ok "post-tool anchors env value past a log prefix and masks it across leaves"
   printf '%s\n' "$post_out" | sed 's/^/  out: /'
+fi
+
+# --- PII output masking (PostToolUse, AGENT_GUARD_PII_HOOK_MODE=mask) ---------
+# Masks PII in a tool's RESULT (parallel to secret redaction). Run from the
+# non-git TMP_ROOT so the mutation backstop stays inert.
+post_tool_pii() {
+  printf '%s' "$1" | (cd "$TMP_ROOT" && AGENT_GUARD_PII_HOOK_MODE=mask "$PLUGIN_ROOT/bin/agent-guard" hook-post-tool) \
+    >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+}
+
+post_tool_pii '{"tool_name":"Bash","tool_input":{"command":"x"},"tool_response":{"stdout":"user jane@example.com ip 10.1.2.3 id 900101-1234567\n","stderr":"","interrupted":false,"isImage":false}}'
+post_status=$?
+post_out=$(cat /tmp/agent-guard-test.out)
+if [ "$post_status" -eq 0 ] \
+   && printf '%s' "$post_out" | grep -q '\[PII:EMAIL\]' \
+   && printf '%s' "$post_out" | grep -q '\[PII:IP_ADDRESS\]' \
+   && printf '%s' "$post_out" | grep -q '\[PII:KR_RRN\]' \
+   && ! printf '%s' "$post_out" | grep -q 'jane@example.com' \
+   && printf '%s' "$post_out" | jq -e '.hookSpecificOutput.updatedToolOutput | has("stdout") and has("stderr")' >/dev/null 2>&1; then
+  ok "post-tool mask mode masks email/IP/KR-RRN in output (shape preserved)"
+else
+  not_ok "post-tool mask mode masks PII in output"
+  printf '%s\n' "$post_out" | sed 's/^/  out: /'
+fi
+
+# Without mask mode, PII in output is left untouched (no rewrite emitted).
+post_tool_out '{"tool_name":"Bash","tool_input":{"command":"x"},"tool_response":{"stdout":"user jane@example.com\n","stderr":"","interrupted":false,"isImage":false}}'
+post_out=$(cat /tmp/agent-guard-test.out)
+if [ -z "$post_out" ]; then
+  ok "post-tool leaves PII untouched without mask mode (default)"
+else
+  not_ok "post-tool leaves PII untouched without mask mode (default)"
+  printf '%s\n' "$post_out" | sed 's/^/  out: /'
+fi
+
+# Secret redaction and PII masking compose into one updatedToolOutput across leaves.
+post_tool_pii '{"tool_name":"Bash","tool_input":{"command":"x"},"tool_response":{"stdout":"DATABASE_PASSWORD=hunter2longvalue\n","stderr":"notified jane@example.com\n","interrupted":false,"isImage":false}}'
+post_out=$(cat /tmp/agent-guard-test.out)
+if printf '%s' "$post_out" | grep -q '\[REDACTED\]' \
+   && printf '%s' "$post_out" | grep -q '\[PII:EMAIL\]' \
+   && ! printf '%s' "$post_out" | grep -q 'jane@example.com'; then
+  ok "post-tool composes secret redaction and PII masking in one rewrite"
+else
+  not_ok "post-tool composes secret redaction and PII masking in one rewrite"
+  printf '%s\n' "$post_out" | sed 's/^/  out: /'
+fi
+
+# CLI pii-filter (regex adapter) masks Korean PII: resident reg. no. and mobile.
+pii_cli=$(printf 'rrn 900101-1234567 mob 010-1234-5678\n' | "$PLUGIN_ROOT/bin/agent-guard" pii-filter 2>/dev/null)
+if printf '%s' "$pii_cli" | grep -q '\[PII:KR_RRN\]' \
+   && printf '%s' "$pii_cli" | grep -q '\[PII:PHONE\]' \
+   && ! printf '%s' "$pii_cli" | grep -q '900101-1234567'; then
+  ok "pii-filter masks Korean resident reg. no. and mobile"
+else
+  not_ok "pii-filter masks Korean resident reg. no. and mobile"
+  printf '%s\n' "$pii_cli" | sed 's/^/  out: /'
+fi
+
+# The CLI regex adapter and the hook output masker must mask the SAME sample
+# identically — credit card and SSN are included so a drift in either Tier-2 rule
+# (pii_regex_adapter_filter vs mask_pii_response_json vs pii_tier2_present) is caught.
+# Card assembled at runtime so this test file holds no contiguous PAN.
+sync_cc="4111 1111 ""1111 1111"
+sync_sample="card $sync_cc ssn 123-45-6789 ip 8.8.8.8 mail x@y.io rrn 900101-1234567 mob 010-1234-5678"
+sync_cli=$(printf '%s\n' "$sync_sample" | "$PLUGIN_ROOT/bin/agent-guard" pii-filter 2>/dev/null)
+sync_hin=$(printf '{"tool_name":"Read","tool_input":{"file_path":"m"},"tool_response":%s}' "$(printf '%s' "$sync_sample" | jq -Rs .)")
+sync_hook=$(printf '%s' "$sync_hin" | (cd "$TMP_ROOT" && AGENT_GUARD_PII_HOOK_MODE=mask "$PLUGIN_ROOT/bin/agent-guard" hook-post-tool 2>/dev/null) | jq -r '.hookSpecificOutput.updatedToolOutput')
+if [ -n "$sync_hook" ] && [ "$sync_cli" = "$sync_hook" ] \
+   && printf '%s' "$sync_hook" | grep -q '\[PII:CREDIT_CARD\]' \
+   && printf '%s' "$sync_hook" | grep -q '\[PII:SSN\]'; then
+  ok "CLI pii-filter and hook output masker mask identically (incl. card + SSN)"
+else
+  not_ok "CLI pii-filter and hook output masker mask identically"
+  printf '%s\n' "  cli : $sync_cli" "  hook: $sync_hook"
 fi
 
 say "passed: $pass"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -780,6 +780,20 @@ else
   sed 's/^/  stderr: /' /tmp/agent-guard-test.err
 fi
 
+# mask mode: a 15-digit Amex card is hard-blocked on input (not just 16-digit).
+# (Assembled at runtime so this test file holds no contiguous PAN.)
+amex="3782 ""822463 ""10005"
+printf '%s' "{\"tool_name\":\"Write\",\"tool_input\":{\"file_path\":\"note.txt\",\"content\":\"card $amex\"}}" \
+  | AGENT_GUARD_PII_HOOK_MODE=mask "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool \
+    >/tmp/agent-guard-test.out 2>/tmp/agent-guard-test.err
+status=$?
+if [ "$status" -eq 2 ] && grep -q 'high-sensitivity PII' /tmp/agent-guard-test.err; then
+  ok "PII mask mode blocks Tier-2 PII (15-digit Amex) input"
+else
+  not_ok "PII mask mode blocks Tier-2 PII (15-digit Amex) input (expected 2, got $status)"
+  sed 's/^/  stderr: /' /tmp/agent-guard-test.err
+fi
+
 # mask mode: Tier-2 US SSN is hard-blocked on input.
 printf '%s' '{"tool_name":"Write","tool_input":{"file_path":"note.txt","content":"ssn 123-45-6789"}}' \
   | AGENT_GUARD_PII_HOOK_MODE=mask "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool \
@@ -2106,8 +2120,9 @@ fi
 
 # Without mask mode, PII in output is left untouched (no rewrite emitted).
 post_tool_out '{"tool_name":"Bash","tool_input":{"command":"x"},"tool_response":{"stdout":"user jane@example.com\n","stderr":"","interrupted":false,"isImage":false}}'
+post_status=$?
 post_out=$(cat /tmp/agent-guard-test.out)
-if [ -z "$post_out" ]; then
+if [ "$post_status" -eq 0 ] && [ -z "$post_out" ]; then
   ok "post-tool leaves PII untouched without mask mode (default)"
 else
   not_ok "post-tool leaves PII untouched without mask mode (default)"
@@ -2142,7 +2157,8 @@ fi
 # (pii_regex_adapter_filter vs mask_pii_response_json vs pii_tier2_present) is caught.
 # Card assembled at runtime so this test file holds no contiguous PAN.
 sync_cc="4111 1111 ""1111 1111"
-sync_sample="card $sync_cc ssn 123-45-6789 ip 8.8.8.8 mail x@y.io rrn 900101-1234567 mob 010-1234-5678"
+sync_amex="3782 ""822463 ""10005"
+sync_sample="card $sync_cc amex $sync_amex ssn 123-45-6789 ip 8.8.8.8 mail x@y.io rrn 900101-1234567 mob 010-1234-5678"
 sync_cli=$(printf '%s\n' "$sync_sample" | "$PLUGIN_ROOT/bin/agent-guard" pii-filter 2>/dev/null)
 sync_hin=$(printf '{"tool_name":"Read","tool_input":{"file_path":"m"},"tool_response":%s}' "$(printf '%s' "$sync_sample" | jq -Rs .)")
 sync_hook=$(printf '%s' "$sync_hin" | (cd "$TMP_ROOT" && AGENT_GUARD_PII_HOOK_MODE=mask "$PLUGIN_ROOT/bin/agent-guard" hook-post-tool 2>/dev/null) | jq -r '.hookSpecificOutput.updatedToolOutput')


### PR DESCRIPTION
## What

Unseals `AGENT_GUARD_PII_HOOK_MODE=mask`. In mask mode the `PostToolUse` redactor that already masks secrets (#77) also masks **PII in a tool's output** — email, phone (incl. Korean mobile), IPv4, credit card, US SSN, and Korean resident registration number — rewriting each to a `[PII:TYPE]` placeholder via `updatedToolOutput`, preserving the result's shape.

Secret redaction and PII masking **compose into a single rewrite**, so a result containing both is fully sanitized at once.

### Tier policy (inputs)

mask mode treats the two PII tiers differently on the **input** side:

| Tier | Examples | mask mode (input) | mask mode (output) |
| --- | --- | --- | --- |
| Tier-1 | email, phone, IPv4 | allowed through | masked |
| Tier-2 | credit card, US SSN, KR resident reg. no. | **hard-blocked** | masked |

Tier-2 PII must never reach a tool, so it is blocked at the pre-tool gate even in mask mode. Tier-1 is let through and masked on the way out. `block` mode (block **all** PII inputs) is unchanged.

## Why

Before this, agent-guard could mask secrets in tool output but had no safe in-flight PII handling — `mask` mode was sealed off. This closes that gap with the same `PostToolUse` mechanism, and adds Korean-locale rules (resident registration number, mobile) the regex provider was missing.

## How it's verified (automated)

- `make test` → **289/0** (3 new: Tier-2 credit-card and SSN input hard-block; CLI `pii-filter` ↔ hook output masker mask identically, incl. card + SSN).
- The CLI regex adapter and the hook jq masker are pinned to produce identical output by a sync test, so a drift in any Tier-2 rule is caught.

## Manual QA (please verify in a live session)

Automated tests exercise the engine directly; the live hook integration is what a human should confirm:

1. **Output masking** — in a session with `AGENT_GUARD_PII_HOOK_MODE=mask`, run a `Bash` command that prints PII, e.g.:
   - `printf 'contact me at jane@example.com or 010-1234-5678\n'`
   - Expected: the model sees `[PII:EMAIL]` and `[PII:PHONE]`, not the raw values. Confirm an `agent-guard: masked PII in Bash output` info line appears.
2. **Compose** — a command that prints both a secret and an email in one result should come back with `[REDACTED]` **and** `[PII:EMAIL]` in a single rewrite.
3. **Tier-2 input block** — ask the agent to `Write` a file whose content contains a US SSN (`123-45-6789`) with mask mode on. Expected: blocked with `blocked high-sensitivity PII (SSN/credit card/resident reg. no.)`.
4. **Tier-1 input passes** — the same with an email should **not** be blocked (it gets masked on output instead).
5. **Default off** — with the env var unset, no PII masking occurs (only secret redaction, which is on by default).

## Known limitation

Both the secret redactor and the PII masker walk JSON string **values** only — PII/secret appearing as an object **key** is left unmasked, because rewriting keys could collapse two distinct keys onto one placeholder and drop an entry. Documented in README and in code comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- code-flow-usage-json:start -->
<details>
<summary>code-flow usage JSON</summary>

```json
{
  "commits": [
    {
      "confidence": "best_effort",
      "model_totals": [
        {
          "cache_creation_ephemeral_1h_input_tokens": 562163,
          "cache_creation_input_tokens": 562163,
          "cache_read_input_tokens": 22524848,
          "input_tokens": 44855,
          "model": "claude-opus-4-8",
          "output_tokens": 156282,
          "total_context_tokens": 23288148,
          "turns": 114
        }
      ],
      "participants": [
        {
          "attribution": "exact",
          "cache_creation_ephemeral_1h_input_tokens": 562163,
          "cache_creation_input_tokens": 562163,
          "cache_read_input_tokens": 22524848,
          "input_tokens": 44855,
          "kind": "main",
          "model": "claude-opus-4-8",
          "name": "main",
          "output_tokens": 156282,
          "total_context_tokens": 23288148,
          "turns": 114
        }
      ],
      "recorded_at": "2026-06-30T17:52:14Z",
      "sha": "962889439d7e6fe1029d14d90ec4f97838ef33fd",
      "subject": "feat(agent-guard): mask PII in tool output via mask mode",
      "totals": {
        "cache_creation_ephemeral_1h_input_tokens": 562163,
        "cache_creation_input_tokens": 562163,
        "cache_read_input_tokens": 22524848,
        "input_tokens": 44855,
        "output_tokens": 156282,
        "total_context_tokens": 23288148,
        "turns": 114
      }
    },
    {
      "confidence": "best_effort",
      "model_totals": [
        {
          "cache_creation_ephemeral_1h_input_tokens": 174602,
          "cache_creation_input_tokens": 174602,
          "cache_read_input_tokens": 6270020,
          "input_tokens": 3194,
          "model": "claude-opus-4-8",
          "output_tokens": 33017,
          "total_context_tokens": 6480833,
          "turns": 39
        }
      ],
      "participants": [
        {
          "attribution": "exact",
          "cache_creation_ephemeral_1h_input_tokens": 174602,
          "cache_creation_input_tokens": 174602,
          "cache_read_input_tokens": 6270020,
          "input_tokens": 3194,
          "kind": "main",
          "model": "claude-opus-4-8",
          "name": "main",
          "output_tokens": 33017,
          "total_context_tokens": 6480833,
          "turns": 39
        }
      ],
      "recorded_at": "2026-06-30T18:07:09Z",
      "sha": "bf355df42d47905d9ac7963c3b8343a41842bd27",
      "subject": "fix(agent-guard): harden Tier-2 PII gate per review",
      "totals": {
        "cache_creation_ephemeral_1h_input_tokens": 174602,
        "cache_creation_input_tokens": 174602,
        "cache_read_input_tokens": 6270020,
        "input_tokens": 3194,
        "output_tokens": 33017,
        "total_context_tokens": 6480833,
        "turns": 39
      }
    }
  ],
  "confidence": "best_effort",
  "metered_commits": 2,
  "pr": {
    "base": "main",
    "head": "feat/pii-output-masking",
    "number": 78
  },
  "schema": "code-flow-usage/1",
  "scope": "current_branch_pr",
  "source": "claude_code_hooks",
  "total_commits": 2,
  "totals": {
    "cache_creation_ephemeral_1h_input_tokens": 736765,
    "cache_creation_input_tokens": 736765,
    "cache_read_input_tokens": 28794868,
    "input_tokens": 48049,
    "output_tokens": 189299,
    "total_context_tokens": 29768981,
    "turns": 153
  },
  "totals_by_model": [
    {
      "cache_creation_ephemeral_1h_input_tokens": 736765,
      "cache_creation_input_tokens": 736765,
      "cache_read_input_tokens": 28794868,
      "input_tokens": 48049,
      "model": "claude-opus-4-8",
      "output_tokens": 189299,
      "total_context_tokens": 29768981,
      "turns": 153
    }
  ],
  "updated_at": "2026-06-30T18:07:22Z"
}
```

</details>
<!-- code-flow-usage-json:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new PII handling mode that can either block sensitive input or mask it in tool output.
  * Expanded masking support to include Korean mobile numbers and Korean resident registration numbers.

* **Bug Fixes**
  * Improved PII detection so high-sensitivity data is blocked more consistently.
  * Updated output rewriting to preserve JSON structure while hiding sensitive values.

* **Documentation**
  * Updated the README and changelog to explain the new PII modes and their behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->