### PR TITLE
chore(changelog): drop stale Unreleased block ahead of v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,3 @@
-## Unreleased
-
-- feat(agent-guard): mask secret-like values in tool output via PostToolUse `updatedToolOutput`, closing the gap where a command prints credentials the pre-tool check never sees (`cat memo.txt`, env-printing CLIs, `KEY=value` dumps). On by default; disable with `AGENT_GUARD_OUTPUT_REDACT=off`. Detection combines gitleaks with a `KEY=value` env-assignment heuristic; redaction preserves the tool result's shape and fails safe (never corrupts output).
-- feat(agent-guard): unseal `AGENT_GUARD_PII_HOOK_MODE=mask` — mask PII (email, phone incl. Korean mobile, IPv4, credit card, US SSN, Korean resident registration number) in tool output via the same PostToolUse path, composing with secret redaction into one rewrite. Tier policy: mask mode hard-blocks only Tier-2 PII (credit card / SSN / resident reg. no.) on inputs and lets Tier-1 (email/phone/IP) through to be masked on output; `block` mode (block all PII inputs) is unchanged. Adds Korean resident registration number and mobile patterns to the regex provider.
-- docs: document that commands run through the host's interactive shell escape (e.g. a `!`-prefixed command) bypass every Agent Guard hook, so they are neither blocked nor output-masked — recorded as a by-design blind spot in README Known Limitations and SECURITY.md Scope.
-
 ## v1.3.8 - 2026-06-16
 
 - docs: separate demo steps with blank lines for readability (#66)


### PR DESCRIPTION
## Summary

Removes the hand-written `## Unreleased` block from the top of `CHANGELOG.md` in preparation for the **v1.4.0** release.

The `release` workflow (`workflow_dispatch`) regenerates the changelog's version section from commit subjects (`git log <last-tag>..HEAD --pretty='- %s'`) and **prepends** it. It does not read or rename the manual `## Unreleased` block, so leaving it in place would strand it above the generated `## v1.4.0 - <date>` section. Dropping it now lets the automation produce a clean, consistent changelog.

No source or behavior change — changelog housekeeping only. The removed bullets (secret output masking, PII masking, shell-escape docs) are already captured as merged commits (#77, #78, #80) and will be regenerated into the v1.4.0 section by the release workflow.

## How to verify

- `CHANGELOG.md` now starts at `## v1.3.8 - 2026-06-16`.
- No other files changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- code-flow-usage-json:start -->
<details>
<summary>code-flow usage JSON</summary>

```json
{
  "commits": [
    {
      "confidence": "best_effort",
      "model_totals": [
        {
          "cache_creation_ephemeral_1h_input_tokens": 512554,
          "cache_creation_input_tokens": 512554,
          "cache_read_input_tokens": 19653204,
          "input_tokens": 47289,
          "model": "claude-opus-4-8",
          "output_tokens": 204296,
          "total_context_tokens": 20417343,
          "turns": 112
        }
      ],
      "participants": [
        {
          "attribution": "exact",
          "cache_creation_ephemeral_1h_input_tokens": 512554,
          "cache_creation_input_tokens": 512554,
          "cache_read_input_tokens": 19653204,
          "input_tokens": 47289,
          "kind": "main",
          "model": "claude-opus-4-8",
          "name": "main",
          "output_tokens": 204296,
          "total_context_tokens": 20417343,
          "turns": 112
        }
      ],
      "recorded_at": "2026-07-02T17:43:56Z",
      "sha": "8174992f2963b535412a3147f58338090e4b36f8",
      "subject": "chore(changelog): drop stale Unreleased block ahead of v1.4.0",
      "totals": {
        "cache_creation_ephemeral_1h_input_tokens": 512554,
        "cache_creation_input_tokens": 512554,
        "cache_read_input_tokens": 19653204,
        "input_tokens": 47289,
        "output_tokens": 204296,
        "total_context_tokens": 20417343,
        "turns": 112
      }
    }
  ],
  "confidence": "best_effort",
  "metered_commits": 1,
  "pr": {
    "base": "main",
    "head": "chore/changelog-unreleased-cleanup",
    "number": 81
  },
  "schema": "code-flow-usage/1",
  "scope": "current_branch_pr",
  "source": "claude_code_hooks",
  "total_commits": 1,
  "totals": {
    "cache_creation_ephemeral_1h_input_tokens": 512554,
    "cache_creation_input_tokens": 512554,
    "cache_read_input_tokens": 19653204,
    "input_tokens": 47289,
    "output_tokens": 204296,
    "total_context_tokens": 20417343,
    "turns": 112
  },
  "totals_by_model": [
    {
      "cache_creation_ephemeral_1h_input_tokens": 512554,
      "cache_creation_input_tokens": 512554,
      "cache_read_input_tokens": 19653204,
      "input_tokens": 47289,
      "model": "claude-opus-4-8",
      "output_tokens": 204296,
      "total_context_tokens": 20417343,
      "turns": 112
    }
  ],
  "updated_at": "2026-07-02T18:54:26Z"
}
```

</details>
<!-- code-flow-usage-json:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up the changelog by removing the top “Unreleased” section.
  * Versioned release notes remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->