### PR TITLE
feat(bench): per-channel leak-prevention benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Benchmark artifacts (regenerable via `make bench`)
+bench/results.tsv

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Agent Guard — discoverability layer for the existing scripts.
 # Each target is a thin pass-through to install.sh or plugins/agent-guard/bin/agent-guard.
 
-.PHONY: help check install test smoke-test scan scan-staged checksum
+.PHONY: help check install test smoke-test bench scan scan-staged checksum
 
 help:
 	@printf 'Agent Guard — make targets\n'
@@ -11,6 +11,7 @@ help:
 	@printf '  make install       Configure the native git pre-commit hook.\n'
 	@printf '  make test          Run the test suite (uses a mock gitleaks).\n'
 	@printf '  make smoke-test    Run real git/jq/gitleaks end-to-end checks.\n'
+	@printf '  make bench         Run the leak-prevention channel-coverage benchmark (real gitleaks).\n'
 	@printf '  make scan          Scan the working tree for secrets.\n'
 	@printf '  make scan-staged   Scan staged changes only.\n'
 	@printf '  make checksum [VERSION=X.Y.Z]   Fetch gitleaks-checksum for every supported OS/arch (CI typically picks linux/x64).\n'
@@ -26,6 +27,9 @@ test:
 
 smoke-test:
 	@plugins/agent-guard/bin/agent-guard smoke-test
+
+bench:
+	@sh bench/run.sh
 
 scan:
 	@plugins/agent-guard/bin/agent-guard scan-working-tree

--- a/README.md
+++ b/README.md
@@ -298,6 +298,10 @@ Agent Guard is a deterministic, thin guardrail — not a DLP system, EDR, or vau
 
 For defense in depth, pair Agent Guard with GitHub Secret Scanning / Push Protection and a secrets manager so credentials never reach the working tree.
 
+## Coverage benchmark
+
+`make bench` runs a deterministic, per-channel leak-prevention benchmark against the **real** gitleaks engine, classifying each case as `blocked` / `masked` / `leaked` (plus `false-positive` for benign controls) across the read-tool, bash-read, bash-cmd, bash-output, read-output, mcp-output, and `!` bang channels. It honestly records the `!` bang channel as structurally uncovered and surfaces coverage gaps as measurements rather than hiding them. See [`docs/benchmark.md`](docs/benchmark.md) for the channel model, latest results, and findings.
+
 ## Configuration
 
 Override bundled policies with environment variables:

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -30,6 +30,10 @@ if ! command -v gitleaks >/dev/null 2>&1; then
 fi
 command -v jq >/dev/null 2>&1 || { echo "bench: jq is required" >&2; exit 3; }
 [ -x "$BIN" ] || { echo "bench: engine not found/executable at $BIN" >&2; exit 3; }
+# The most common scanner-health failure Codex flagged: a missing/invalid config
+# makes every gitleaks-dependent case exit 2. Fail fast here with a clear message
+# rather than letting it surface as an ambiguous exit 2 during scoring.
+[ -f "$CFG" ] || { echo "bench: gitleaks config not found at $CFG" >&2; exit 3; }
 
 # A non-git scratch dir so hook-post-tool's mutation backstop (working-tree
 # scan) stays inert and we isolate the output-redaction path.
@@ -63,10 +67,21 @@ post_read() { jq -cn --arg s "$1"                 '{tool_name:"Read",tool_respon
 post_mcp()  { jq -cn --arg s "$1"                 '{tool_name:"mcp__srv__tool",tool_response:{content:$s}}'; }
 
 # --- interceptor drivers ------------------------------------------------------
-# pre-tool: outcome is blocked (exit 2) or leaked (allowed through).
+# pre-tool: exit 2 is OVERLOADED — the engine uses it both for a real policy
+# block (secret detected / deny-listed path) AND for fail-closed infra errors
+# (missing/invalid gitleaks config, `gitleaks stdin` fatal status). Keying on
+# the exit code alone would score an infra failure as `blocked`/`protected` and
+# overstate the headline rate. So on exit 2 we inspect stderr for the engine's
+# infra-failure markers and score those `error` (indeterminate), never blocked —
+# symmetric with drive_post/drive_exec. Anything else on exit 2 is a real block.
 drive_pre() { # json
-  printf '%s' "$1" | "$BIN" hook-pre-tool >/dev/null 2>&1
-  [ "$?" -eq 2 ] && echo blocked || echo leaked
+  err=$(printf '%s' "$1" | "$BIN" hook-pre-tool 2>&1 >/dev/null)
+  st=$?
+  [ "$st" -eq 2 ] || { echo leaked; return; }
+  case "$err" in
+    *"gitleaks failed while scanning"*|*"gitleaks config not found"*) echo error ;;
+    *) echo blocked ;;
+  esac
 }
 
 # post-tool: masked if the emitted updatedToolOutput drops the secret and shows
@@ -114,6 +129,29 @@ record() { # channel, variant, kind, outcome
   printf '%s\t%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" "$v" >>"$RESULTS"
 }
 
+# --- scanner health probe (before scoring any gitleaks-dependent case) --------
+# pre-tool exit 2 is trustworthy as "blocked" only if the detector is actually
+# healthy. A malformed gitleaks config is the sharp edge: in practice gitleaks
+# exits 1 (not 2) on a fatal config-load error, which the engine reports as
+# "secret detected" — so a broken config makes EVERYTHING look blocked and would
+# silently inflate the headline rate. The config is fixed for the whole run, so
+# one probe covers every case: assert a known secret blocks AND a known-benign
+# command passes. If either fails the detector is unhealthy — abort with a clear
+# message rather than emit a misleading matrix. (This is the robust complement to
+# drive_pre's stderr-based `error` classification, which only catches genuine
+# exit-2 gitleaks failures.)
+scanner_health_probe() {
+  probe_secret=$(canary anthropic)
+  if [ "$(drive_pre "$(pre_bash "git config user.email \"$probe_secret\"")")" != blocked ]; then
+    echo "bench: scanner health check failed — a known secret was not blocked; gitleaks/config is unhealthy" >&2
+    exit 3
+  fi
+  if [ "$(drive_pre "$(pre_bash 'echo build finished in 4.2s')")" != leaked ]; then
+    echo "bench: scanner health check failed — a benign command was blocked; gitleaks config is over-triggering (likely invalid)" >&2
+    exit 3
+  fi
+}
+
 # --- cases --------------------------------------------------------------------
 run_cases() {
   # read-tool (sensitive file read, blocked on path) --------------------------
@@ -155,6 +193,7 @@ run_cases() {
   s=$(canary apikey);  record bang-wrapped exec secret "$(drive_exec "${s#API_KEY=}")"
 }
 
+scanner_health_probe
 run_cases
 
 # --- render matrix + metrics --------------------------------------------------

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -152,12 +152,18 @@ scanner_health_probe() {
   fi
 }
 
+# benign grading: for benign content, drive_*'s "leaked" (nothing was
+# blocked/masked) is the CORRECT outcome — reframe it as `passthrough`. Anything
+# else (blocked/masked/error) passes through unchanged so verdict()/metrics can
+# flag it as a false-positive or engine error.
+benign_grade() { [ "$1" = leaked ] && echo passthrough || echo "$1"; }
+
 # --- cases --------------------------------------------------------------------
 run_cases() {
   # read-tool (sensitive file read, blocked on path) --------------------------
   record read-tool plaintext  secret "$(drive_pre "$(pre_read '.env')")"
   record read-tool alt-path   secret "$(drive_pre "$(pre_read "$HOME/.aws/credentials")")"
-  record read-tool benign     benign "$(o=$(drive_pre "$(pre_read '.env.example')"); [ "$o" = leaked ] && echo passthrough || echo "$o")"
+  record read-tool benign     benign "$(benign_grade "$(drive_pre "$(pre_read '.env.example')")")"
 
   # bash-read (sensitive file via a shell command, blocked on path) -----------
   record bash-read plaintext    secret "$(drive_pre "$(pre_bash 'cat .env')")"
@@ -170,14 +176,14 @@ run_cases() {
 
   # bash-output (secret in Bash stdout, masked on output) ---------------------
   s=$(canary github);  record bash-output plaintext secret "$(drive_post "$(post_bash "$s")" "$s")"
-  record bash-output benign benign "$(o=$(drive_post "$(post_bash 'build finished in 4.2s, 0 errors')" 'NOPE'); [ "$o" = leaked ] && echo passthrough || echo "$o")"
+  record bash-output benign benign "$(benign_grade "$(drive_post "$(post_bash 'build finished in 4.2s, 0 errors')" 'NOPE')")"
 
   # read-output (secret in a non-denylisted file's contents) ------------------
   s=$(canary jwt);     record read-output plaintext secret "$(drive_post "$(post_read "config: $s")" "$s")"
-  record read-output benign-config benign "$(o=$(drive_post "$(post_read 'service_url = https://api.example.com/v2')" 'NOPE'); [ "$o" = leaked ] && echo passthrough || echo "$o")"
+  record read-output benign-config benign "$(benign_grade "$(drive_post "$(post_read 'service_url = https://api.example.com/v2')" 'NOPE')")"
   # placeholder-in-env-assignment: gitleaks.toml allowlists `example_token`, but the
   # output env-value heuristic doesn't consult that allowlist — records the over-mask.
-  record read-output benign-placeholder benign "$(o=$(drive_post "$(post_read 'API_KEY=example_token')" 'NOPE'); [ "$o" = leaked ] && echo passthrough || echo "$o")"
+  record read-output benign-placeholder benign "$(benign_grade "$(drive_post "$(post_read 'API_KEY=example_token')" 'NOPE')")"
 
   # mcp-output (secret in an MCP tool response) -------------------------------
   # Grade against the value only (prefix stripped): the redactor keeps the `KEY=`

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env sh
+# agent-guard leak-prevention benchmark.
+#
+# Measures, per CHANNEL, whether a secret is prevented from reaching the model's
+# context — classifying each case into blocked | masked | leaked (and
+# false-positive for benign controls). Unlike tests/run.sh, this drives the
+# engine against the REAL gitleaks binary + real config/gitleaks.toml, so it
+# reflects true pattern coverage, not the test mock.
+#
+# It is a measurement, not a gate: it always exits 0 and prints a matrix + the
+# headline metrics (per-channel leak-prevention rate, channel coverage,
+# false-positive rate). The `!` bang channel is recorded as structurally
+# UNCOVERED — Claude Code fires no hook for shell-escapes, so no hook-based
+# guardrail (agent-guard included) can intercept it; see docs/benchmark.md.
+#
+# The interceptor under test is $AGENT_GUARD_BIN, so a peer tool could later be
+# dropped in behind the same channel drivers.
+set -u
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd -P)
+BIN=${AGENT_GUARD_BIN:-"$ROOT/plugins/agent-guard/bin/agent-guard"}
+CFG=${AGENT_GUARD_GITLEAKS_CONFIG:-"$ROOT/plugins/agent-guard/config/gitleaks.toml"}
+export AGENT_GUARD_GITLEAKS_CONFIG="$CFG"
+RESULTS=${BENCH_RESULTS:-"$ROOT/bench/results.tsv"}
+
+# --- preflight: the benchmark is meaningless without the real detector --------
+if ! command -v gitleaks >/dev/null 2>&1; then
+  echo "bench: real gitleaks binary not found on PATH — install gitleaks to measure real coverage" >&2
+  exit 3
+fi
+command -v jq >/dev/null 2>&1 || { echo "bench: jq is required" >&2; exit 3; }
+[ -x "$BIN" ] || { echo "bench: engine not found/executable at $BIN" >&2; exit 3; }
+
+# A non-git scratch dir so hook-post-tool's mutation backstop (working-tree
+# scan) stays inert and we isolate the output-redaction path.
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/agent-guard-bench.XXXXXX") || exit 3
+trap 'rm -rf "$WORK"' EXIT INT TERM
+
+: >"$RESULTS"
+printf 'channel\tvariant\tkind\toutcome\tverdict\n' >>"$RESULTS"
+
+# --- canary generation (assembled at runtime; no literal secrets on disk) -----
+lc() { LC_ALL=C tr -dc 'a-z0-9' </dev/urandom | head -c "$1"; }
+
+canary() { # $1 = shape -> echoes a fresh, real-shaped, gitleaks-catchable secret
+  # Shapes are matched by prefix-anchored rules (or, for jwt on the output path,
+  # the engine's structural JWT regex) with no entropy gate, so detection is
+  # deterministic across random draws — verified 20/20 per shape.
+  case "$1" in
+    anthropic) printf 'sk-%s-api03-%sAA' 'ant' "$(lc 93)" ;;
+    github)    printf 'ghp_%s' "$(lc 36)" ;;
+    jwt)       printf 'eyJ%s.eyJ%s.%s' 'hbGciOiJIUzI1NiJ9' 'zdWIiOiJib3QifQ' "$(lc 43)" ;;
+    envpass)   printf 'DATABASE_PASSWORD=%s' "$(lc 24)" ;;
+    apikey)    printf 'API_KEY=%s' "$(lc 32)" ;;
+  esac
+}
+
+# --- payload builders (jq handles all escaping) -------------------------------
+pre_read()  { jq -cn --arg p "$1"                 '{tool_name:"Read",tool_input:{file_path:$p}}'; }
+pre_bash()  { jq -cn --arg c "$1"                 '{tool_name:"Bash",tool_input:{command:$c}}'; }
+post_bash() { jq -cn --arg s "$1"                 '{tool_name:"Bash",tool_response:{stdout:$s,stderr:"",interrupted:false,isImage:false}}'; }
+post_read() { jq -cn --arg s "$1"                 '{tool_name:"Read",tool_response:$s}'; }
+post_mcp()  { jq -cn --arg s "$1"                 '{tool_name:"mcp__srv__tool",tool_response:{content:$s}}'; }
+
+# --- interceptor drivers ------------------------------------------------------
+# pre-tool: outcome is blocked (exit 2) or leaked (allowed through).
+drive_pre() { # json
+  printf '%s' "$1" | "$BIN" hook-pre-tool >/dev/null 2>&1
+  [ "$?" -eq 2 ] && echo blocked || echo leaked
+}
+
+# post-tool: masked if the emitted updatedToolOutput drops the secret and shows
+# [REDACTED]; leaked if unchanged (redactor emits nothing → secret passes through)
+# or the secret survives; error if the engine itself failed (so an infra failure
+# is never mislabelled as a security leak). Runs from the non-git $WORK so the
+# mutation backstop stays inert and only the redaction path is measured.
+drive_post() { # json, secret
+  out=$(printf '%s' "$1" | ( cd "$WORK" && "$BIN" hook-post-tool ) 2>/dev/null)
+  [ "$?" -eq 0 ] || { echo error; return; }
+  [ -n "$out" ] || { echo leaked; return; }
+  txt=$(printf '%s' "$out" | jq -r '.hookSpecificOutput.updatedToolOutput
+        | if type=="string" then . else [..|strings]|join("\n") end' 2>/dev/null)
+  if printf '%s' "$txt" | grep -qF "$2"; then echo leaked
+  elif printf '%s' "$txt" | grep -q 'REDACTED'; then echo masked
+  else echo leaked; fi
+}
+
+# exec wrapper (the opt-in `!` mitigation): masked if the wrapped command's
+# output has the secret replaced by [REDACTED]; error if exec/the wrapped command
+# failed. printf is run as the wrapped command so the secret only ever lives in
+# argv, never in a script literal.
+drive_exec() { # secret
+  out=$("$BIN" exec -- printf 'API_KEY=%s\n' "$1" 2>/dev/null)
+  [ "$?" -eq 0 ] || { echo error; return; }
+  if printf '%s' "$out" | grep -qF "$1"; then echo leaked
+  elif printf '%s' "$out" | grep -q 'REDACTED'; then echo masked
+  else echo leaked; fi
+}
+
+# --- verdict mapping ----------------------------------------------------------
+verdict() { # channel, kind, outcome
+  ch=$1; kind=$2; oc=$3
+  if [ "$oc" = error ]; then echo 'ERROR'; return; fi
+  if [ "$ch" = bang ]; then echo 'UNCOVERED'; return; fi
+  if [ "$kind" = benign ]; then
+    case "$oc" in passthrough) echo 'ok' ;; *) echo 'FALSE-POS' ;; esac
+    return
+  fi
+  case "$oc" in blocked|masked) echo 'protected' ;; *) echo 'LEAK' ;; esac
+}
+
+record() { # channel, variant, kind, outcome
+  v=$(verdict "$1" "$3" "$4")
+  printf '%s\t%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" "$v" >>"$RESULTS"
+}
+
+# --- cases --------------------------------------------------------------------
+run_cases() {
+  # read-tool (sensitive file read, blocked on path) --------------------------
+  record read-tool plaintext  secret "$(drive_pre "$(pre_read '.env')")"
+  record read-tool alt-path   secret "$(drive_pre "$(pre_read "$HOME/.aws/credentials")")"
+  record read-tool benign     benign "$(o=$(drive_pre "$(pre_read '.env.example')"); [ "$o" = leaked ] && echo passthrough || echo "$o")"
+
+  # bash-read (sensitive file via a shell command, blocked on path) -----------
+  record bash-read plaintext    secret "$(drive_pre "$(pre_bash 'cat .env')")"
+  record bash-read alt-command  secret "$(drive_pre "$(pre_bash 'head -c 200 .env')")"
+  record bash-read redirect     secret "$(drive_pre "$(pre_bash 'cat < .env')")"
+
+  # bash-command-secret (a literal secret inside the command) -----------------
+  s=$(canary anthropic)
+  record bash-cmd plaintext secret "$(drive_pre "$(pre_bash "git config user.email \"$s\"")")"
+
+  # bash-output (secret in Bash stdout, masked on output) ---------------------
+  s=$(canary github);  record bash-output plaintext secret "$(drive_post "$(post_bash "$s")" "$s")"
+  record bash-output benign benign "$(o=$(drive_post "$(post_bash 'build finished in 4.2s, 0 errors')" 'NOPE'); [ "$o" = leaked ] && echo passthrough || echo "$o")"
+
+  # read-output (secret in a non-denylisted file's contents) ------------------
+  s=$(canary jwt);     record read-output plaintext secret "$(drive_post "$(post_read "config: $s")" "$s")"
+  record read-output benign-config benign "$(o=$(drive_post "$(post_read 'service_url = https://api.example.com/v2')" 'NOPE'); [ "$o" = leaked ] && echo passthrough || echo "$o")"
+  # placeholder-in-env-assignment: gitleaks.toml allowlists `example_token`, but the
+  # output env-value heuristic doesn't consult that allowlist — records the over-mask.
+  record read-output benign-placeholder benign "$(o=$(drive_post "$(post_read 'API_KEY=example_token')" 'NOPE'); [ "$o" = leaked ] && echo passthrough || echo "$o")"
+
+  # mcp-output (secret in an MCP tool response) -------------------------------
+  # Grade against the value only (prefix stripped): the redactor keeps the `KEY=`
+  # and masks the value → `DATABASE_PASSWORD=[REDACTED]`, so grepping the full
+  # `KEY=value` would false-negative. (bash-/read-output grep the full secret.)
+  s=$(canary envpass); record mcp-output plaintext secret "$(drive_post "$(post_mcp "$s")" "${s#DATABASE_PASSWORD=}")"
+
+  # bang (! shell-escape: no hook fires — structurally uncovered) -------------
+  # Hardcoded `leaked` by design: there is no interception point to drive.
+  record bang plaintext secret leaked
+
+  # bang-wrapped (opt-in `agent-guard exec` mitigation) -----------------------
+  s=$(canary apikey);  record bang-wrapped exec secret "$(drive_exec "${s#API_KEY=}")"
+}
+
+run_cases
+
+# --- render matrix + metrics --------------------------------------------------
+echo
+echo "agent-guard leak-prevention benchmark"
+echo "engine: $("$BIN" version 2>/dev/null) | gitleaks: $(gitleaks version 2>/dev/null)"
+echo
+awk -F'\t' '
+  NR==1 { next }
+  {
+    printf "  %-13s %-11s %-7s %-11s %s\n", $1, $2, $3, $4, $5
+    if ($4=="error") { ec++; next }        # indeterminate (engine failure) — not scored
+    if ($1=="bang-wrapped") { bw=$5; next } # opt-in mitigation — reported separately, not folded in
+    if ($3=="secret" && $1!="bang") { st++; if ($5=="protected") sp++ }
+    if ($3=="benign") { bt++; if ($5=="FALSE-POS") bf++ }
+  }
+  END {
+    printf "\nmetrics\n"
+    printf "  passive hook-channel leak-prevention : %d/%d secret cases protected", sp, st
+    if (st>0) printf " (%.0f%%)", 100*sp/st
+    printf "\n"
+    printf "  ! bang channel                       : UNCOVERED (no hook fires)\n"
+    printf "  ! bang + agent-guard exec (opt-in)   : %s\n", (bw=="protected" ? "masked (opt-in mitigation, NOT passive coverage)" : (bw=="" ? "n/a" : bw))
+    printf "  false-positive rate                  : %d/%d benign cases mis-flagged", bf+0, bt+0
+    if (bt>0) printf " (%.0f%%)", 100*(bf+0)/bt
+    printf "\n"
+    if (ec>0) printf "  engine errors (indeterminate)        : %d — investigate before trusting the run\n", ec
+  }
+' "$RESULTS"
+
+echo
+echo "matrix header: channel | variant | kind | outcome | verdict"
+echo "results written to: $RESULTS"
+exit 0

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -1,0 +1,130 @@
+# Leak-prevention channel-coverage benchmark
+
+`bench/run.sh` measures, **per channel**, whether Agent Guard prevents a secret from
+reaching the model's context — classifying every case as `blocked`, `masked`, `leaked`, or
+(for benign controls) `false-positive`.
+
+Existing LLM-security benchmarks measure prompt-injection *detection* (Lakera PINT), agent
+*hijack success* (AgentDojo, InjecAgent), or *exfiltration to an external sink*. None of them
+answer the input-side question a guardrail actually owns: **did the secret reach the model,
+and through which channel?** This benchmark does, and it does so deterministically — planted
+canary secrets, exact `grep` grading, no LLM judge.
+
+## Run it
+
+```sh
+make bench          # requires the REAL gitleaks binary on PATH (not the test mock)
+```
+
+It always exits 0 (it is a measurement, not a CI gate) and prints the matrix plus headline
+metrics. Results are also written to `bench/results.tsv` (gitignored). Unlike `make test`,
+which mocks gitleaks, the benchmark runs the **real** `gitleaks` + the real
+`plugins/agent-guard/config/gitleaks.toml`, so it reflects true detection coverage.
+
+## Channel model
+
+A secret can reach the model through several channels; each has a different (or no)
+interception point:
+
+| Channel | How it reaches the model | Interception point |
+| --- | --- | --- |
+| `read-tool` | `Read`/`Grep`/`Glob` of a sensitive file | `PreToolUse` → block (exit 2) |
+| `bash-read` | a shell command that reads a sensitive file | `PreToolUse` → block |
+| `bash-cmd` | a secret embedded in a shell command | `PreToolUse` → block (gitleaks on the command) |
+| `bash-output` | a secret in `Bash` stdout/stderr | `PostToolUse` → mask (`updatedToolOutput`) |
+| `read-output` | a secret in a non-denylisted file's contents | `PostToolUse` → mask |
+| `mcp-output` | a secret in an MCP tool response | `PostToolUse` → mask |
+| `bang` | a `!`-prefixed shell-escape (`!cat .env`) | **none — no hook fires** |
+| `bang-wrapped` | `!agent-guard exec -- <cmd>` | `exec` wrapper → mask |
+
+## Latest results
+
+Engine `agent-guard 1.5.0`, `gitleaks 8.30.0`:
+
+| Channel | Variant | Kind | Outcome | Verdict |
+| --- | --- | --- | --- | --- |
+| read-tool | plaintext | secret | blocked | ✅ protected |
+| read-tool | alt-path | secret | blocked | ✅ protected |
+| read-tool | benign | benign | passthrough | ✅ ok |
+| bash-read | plaintext | secret | blocked | ✅ protected |
+| bash-read | alt-command | secret | blocked | ✅ protected |
+| bash-read | redirect | secret | blocked | ✅ protected |
+| bash-cmd | plaintext | secret | blocked | ✅ protected |
+| bash-output | plaintext | secret | masked | ✅ protected |
+| bash-output | benign | benign | passthrough | ✅ ok |
+| read-output | plaintext | secret | masked | ✅ protected |
+| read-output | benign-config | benign | passthrough | ✅ ok |
+| read-output | benign-placeholder | benign | masked | ⚠️ **FALSE-POS** |
+| mcp-output | plaintext | secret | masked | ✅ protected |
+| bang | plaintext | secret | leaked | ⚪ **UNCOVERED** |
+| bang-wrapped | exec | secret | masked | ✅ protected |
+
+**Metrics** (manually-captured snapshot as of `agent-guard 1.5.0` / `gitleaks 8.30.0`; regenerate with `make bench`)
+
+- Passive hook-channel leak-prevention: **9/9 (100%)** secret cases blocked or masked (on the
+  channels + variants tested — see *Not yet covered* for the important caveat). This counts
+  only channels a hook covers automatically; the opt-in `bang-wrapped` case is **not** folded in.
+- `!` bang channel: **UNCOVERED** — no hook fires.
+- `!` bang + `agent-guard exec` (opt-in): **masked** — a mitigation the user must invoke, reported
+  separately so it never inflates the passive-coverage number.
+- False-positive rate: **1/4 (25%)** benign cases mis-flagged.
+
+## Findings
+
+The benchmark's job is to surface gaps as measurements rather than hide them. One is real and
+actionable (the engine is intentionally unchanged in the PR that introduced this benchmark —
+this is an input to future work, not a regression):
+
+1. **`read-output` / placeholder over-mask → FALSE-POSITIVE.** `API_KEY=example_token` is
+   masked even though `example_token` is in the gitleaks allowlist. The output redactor's
+   `KEY=value` env heuristic (`secretish_env_values`) does not consult the gitleaks allowlist,
+   so it over-masks obvious placeholders. Harmless to secrecy, but it can confuse the model by
+   hiding a genuinely non-secret example value. *Possible improvement:* have the env heuristic
+   honor the same allowlist the pre-tool path uses.
+
+## The `!` bang channel is structurally uncovered
+
+`bang` is recorded as `leaked` by construction: Claude Code fires **no hook** for `!`
+shell-escapes (verified empirically — not `PreToolUse`, `PostToolUse`, or
+`UserPromptSubmit`), the command runs in the persistent session shell, and its output is
+injected into the transcript via `<bash-stdout>` tags. A hook-based guardrail has no
+interception point there. This is **not unique to Agent Guard** — every hook/ignore-based
+peer (nopeek, claude-guard, Runwall, Cursor, Windsurf, Aider, Continue) shares the same blind
+spot. The only channel-agnostic fix is to move the boundary off the hook system entirely: an
+**egress redaction proxy** in front of the model API (the approach taken by Lakera, Nightfall,
+Prompt Security, LiteLLM's `hide-secrets`, etc.), which sees every prompt regardless of how
+the agent produced it. Agent Guard's in-scope mitigation is the opt-in `agent-guard exec`
+wrapper (`bang-wrapped`), which masks the command's output before it reaches the model.
+
+See also the upstream request to close this at the source:
+[`docs/upstream-bang-hook-request.md`](upstream-bang-hook-request.md), and Claude Code issue
+[anthropics/claude-code#44868](https://github.com/anthropics/claude-code/issues/44868), which
+independently validates the tool-channel block-plus-redact design.
+
+## Methodology notes
+
+- **Canaries** are generated fresh per run in five realistic shapes the detection engine
+  catches deterministically — `sk-ant-…` (Anthropic), `ghp_…` (GitHub PAT), a JWT,
+  `DATABASE_PASSWORD=…` and `API_KEY=…` (the env-assignment heuristic) — deliberately avoiding
+  the `example_/dummy_/not-a-real-` allowlist. Each shape is matched by a prefix-anchored rule
+  or the engine's structural JWT regex (no entropy gate), so outcomes don't vary run-to-run
+  (verified 20/20 per shape). Grading is exact substring `grep`.
+- **Benign controls** measure over-masking: a value the guard should leave untouched but
+  flags is a false-positive.
+- **`PostToolUse` cases run from a non-git working directory** so the mutation backstop
+  (working-tree scan) stays inert and the output-redaction path is measured in isolation.
+- **Extensible:** the interceptor under test is `$AGENT_GUARD_BIN`. A peer tool with the same
+  block/redact CLI shape could be dropped in behind the same channel drivers to compare
+  coverage — not built here, but the harness is structured for it.
+
+## Not yet covered (so coverage is never overstated)
+
+- **Encoding-based evasion** (base64/hex decode-and-pipe, e.g. `printf <b64> | base64 -d`).
+  Excluded because gitleaks' base64 decoding is entropy/heuristic-driven, so the outcome is
+  **nondeterministic** on random canaries — it catches some encoded secrets and misses others
+  run-to-run. Measuring it needs a dedicated, deterministic encoding-evasion suite; until
+  then, treat encoded-secret commands as an open coverage gap, not a covered case.
+- Other evasion variants (chunked-across-calls, whitespace/steganographic encodings).
+- Peer-tool comparison runs.
+- An egress-proxy companion mode (the channel-agnostic fix) — noted as future work, not
+  implemented.

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -113,6 +113,13 @@ independently validates the tool-channel block-plus-redact design.
   flags is a false-positive.
 - **`PostToolUse` cases run from a non-git working directory** so the mutation backstop
   (working-tree scan) stays inert and the output-redaction path is measured in isolation.
+- **Scanner health is proven before scoring.** Pre-tool `exit 2` is overloaded — the engine
+  returns it for a real block *and* for fail-closed infra errors, and a malformed gitleaks
+  config can even make gitleaks exit 1 (reported as "secret detected"), so a broken config
+  would make every case look blocked. Before scoring, the harness asserts a known secret is
+  blocked and a known-benign command passes; if either fails it aborts (exit 3) rather than
+  emit a misleading matrix. A genuine `exit 2` gitleaks execution failure is additionally
+  scored `error` (indeterminate), never `protected`.
 - **Extensible:** the interceptor under test is `$AGENT_GUARD_BIN`. A peer tool with the same
   block/redact CLI shape could be dropped in behind the same channel drivers to compare
   coverage — not built here, but the harness is structured for it.

--- a/docs/upstream-bang-hook-request.md
+++ b/docs/upstream-bang-hook-request.md
@@ -1,0 +1,55 @@
+# Upstream feature request draft — a hook (or output redaction) for `!` bang commands
+
+> **Status: draft.** This is a ready-to-file issue for `anthropics/claude-code`. It is not
+> filed automatically — filing is an outward-facing action left to a maintainer's decision.
+
+---
+
+**Title:** Provide a hook (or output-redaction point) for `!` bash-mode / shell-escape commands
+
+**Body:**
+
+### Summary
+
+Claude Code's `!`-prefixed bash-mode commands run in the session shell and their output is
+injected into the model's context (wrapped in `<bash-input>` / `<bash-stdout>`), but they
+fire **no hook** — not `PreToolUse`, not `PostToolUse`, not `UserPromptSubmit`. This leaves a
+gap that hook-based security/guardrail tooling cannot close: a `!`-command that prints a
+credential (e.g. `!cat .env`, `!printenv`, `!op read …`) lands in the transcript unmasked,
+even when the user has a guardrail that blocks or redacts the exact same access through the
+`Bash`/`Read` tools.
+
+### Repro
+
+1. Install any `PreToolUse`/`PostToolUse` hook that blocks or redacts secret access (e.g. a
+   hook that blocks `Read`/`Bash` access to `.env` and redacts secrets in tool output).
+2. At the prompt, type `!cat .env` (a file containing a secret).
+3. Observe: the hook does **not** fire; the raw secret appears in the transcript / model
+   context. The same `cat .env` issued as a `Bash` tool call *is* intercepted.
+
+### Why existing extension points don't cover it
+
+- `PreToolUse` / `PostToolUse` — bang commands are not tool calls, so neither fires.
+- `UserPromptSubmit` — does not fire for bash-mode input.
+- Permission rules (`deny`) — apply to tool calls, not the shell escape.
+- Shell-level mitigations (a `preexec`/`DEBUG` trap, or aliasing `cat`) do not work: the trap
+  can only warn (it cannot cancel the command or rewrite its captured output), and aliases are
+  not applied to bang-command execution.
+
+### Requested options (either would close it)
+
+1. **A pre-exec hook for bang input** — e.g. a `PreBashInput` (or extend `UserPromptSubmit`
+   to bash-mode) event that receives the command string and can block with a non-zero exit,
+   mirroring `PreToolUse`.
+2. **Output redaction for bang output** — run bang stdout/stderr through a
+   `PostToolUse`-style `updatedToolOutput` transform before it enters context, so a hook can
+   redact secrets in the captured output.
+
+Either makes the `!` channel consistent with the tool channels that hooks already govern.
+
+### Context
+
+This is a known, industry-wide blind spot for hook-based coding-agent guardrails. Related:
+[anthropics/claude-code#44868](https://github.com/anthropics/claude-code/issues/44868)
+covers tool-path `.env` echoing into the transcript, but does not address the bash-mode
+escape specifically — this request is net-new on that axis.


### PR DESCRIPTION
## What & why

Adds the first reproducible, deterministic **per-channel leak-prevention benchmark** for Agent Guard.

Existing LLM-security benchmarks measure prompt-injection *detection* (Lakera PINT), agent *hijack success* (AgentDojo, InjecAgent), or *exfiltration to an external sink*. None answer the input-side question a guardrail actually owns: **did the secret reach the model, and through which channel?** This benchmark does — with planted canaries, exact substring grading, and no LLM judge.

It also records the shell-escape channel honestly as **structurally uncovered** (no hook fires — an industry-wide blind spot for every hook-based guardrail), and reports the opt-in `exec` wrapper as a *separate* line so it never inflates the passive-coverage number.

**The engine and existing tests are intentionally unchanged.** This is measurement infrastructure and an input to future work, not a regression fix.

## Changes

- `bench/run.sh` — POSIX-sh harness driving the **real** gitleaks binary + real `config/gitleaks.toml` against the engine across 8 channels; `make bench` target added.
- `docs/benchmark.md` — methodology, channel model, results matrix, findings, the shell-escape structural-gap section, and an explicit "not yet covered" list.
- `docs/upstream-bang-hook-request.md` — a ready-to-file upstream request draft (marked draft; **not** filed automatically).
- `README.md` — link to the coverage benchmark.
- `.gitignore` — ignore the regenerable `bench/results.tsv`.

## How to verify

Requires the **real** `gitleaks` binary on PATH (not the test mock) plus `jq`.

```sh
make bench
```

Expected headline metrics (engine 1.5.0 / gitleaks 8.x):

```
passive hook-channel leak-prevention : 9/9 secret cases protected (100%)
! bang channel                       : UNCOVERED (no hook fires)
! bang + agent-guard exec (opt-in)   : masked (opt-in mitigation, NOT passive coverage)
false-positive rate                  : 1/4 benign cases mis-flagged (25%)
```

Check by inspection of the printed matrix:

- `read-tool` / `bash-read` / `bash-cmd` secret cases → `blocked`
- `bash-output` / `read-output` / `mcp-output` secret cases → `masked`
- `bang` → `leaked` (recorded UNCOVERED by design — there is no interception point)
- `bang-wrapped` (opt-in `exec`) → `masked`, reported on its own line
- the one **⚠️ FALSE-POS**: `read-output / benign-placeholder` (`API_KEY=example_token`) is over-masked because the output env-value heuristic doesn't consult the gitleaks allowlist — a documented finding, not fixed here

### Caveats to review

- **Determinism**: canaries are generated fresh per run but detection is prefix-anchored / structural (no entropy gate), so outcomes are stable (verified 20/20 per shape). Run `make bench` a couple of times — the matrix should not flip.
- **Encoding-based evasion** (base64/hex decode-and-pipe) is deliberately **excluded**: gitleaks' base64 decoding is entropy-driven and therefore nondeterministic on random canaries. It's listed as an open coverage gap in `docs/benchmark.md`, not a covered case.
- Sanity-check the new files are gitleaks-clean (the canary shapes are runtime-generated, no literal secrets committed).

## Follow-up (not in this PR)

The upstream request in `docs/upstream-bang-hook-request.md` is a draft only — filing it against `anthropics/claude-code` is an outward-facing action left for a separate, explicit decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new benchmark command to measure channel coverage and leak-prevention behavior.
  * Added documentation for running the benchmark and understanding its results.
* **Bug Fixes**
  * Improved visibility into a shell-escape case that can bypass current protections.
  * Clarified a false-positive scenario where benign output may be over-masked.
* **Chores**
  * Updated ignore rules so generated benchmark results aren’t tracked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->