### PR TITLE
feat(shell): resolve agent-guard without a PATH install for the bang guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,12 @@ To make this ergonomic, add the shell integration to your `~/.bashrc` / `~/.zshr
 eval "$(agent-guard shell-init)"
 ```
 
+Or let `setup-shell` write (and later update) that line for you — idempotently, and by absolute path when `agent-guard` isn't on your `$PATH` yet:
+
+```sh
+agent-guard setup-shell            # add `--experimental-bang-guard` to opt into the bang guard below
+```
+
 This defines `agx` (a thin wrapper for `agent-guard exec --`) so you can run `agx <cmd>` — in Claude Code, `!agx <cmd>` — and have the output masked before the model sees it. It also installs a **warn-only, non-blocking** nudge (a zsh `preexec` / bash `DEBUG` trap) that reminds you to use `agx` when you run a known secret-loading idiom without it. The nudge never blocks or modifies your command; pass `--bash` or `--zsh` to force a target shell.
 
 ### Experimental: auto-masking `!` reads (opt-in)
@@ -293,9 +299,11 @@ The nudge above relies on a `preexec` / `DEBUG` hook — but Claude Code runs `!
 eval "$(agent-guard shell-init --experimental-bang-guard)"
 ```
 
-This overrides `cat`, `head`, and `printenv` so that — **only inside Claude Code** (gated on `$CLAUDECODE`) **and only when `agent-guard` is resolvable on `$PATH`** — they route through `agent-guard exec`, masking their output before the transcript captures it. So `!cat config.txt` gets its secrets redacted automatically, without you remembering to type `agx`. In a normal terminal (`$CLAUDECODE` unset), or if `agent-guard` isn't on `$PATH`, the overrides fall back to plain `cat` / `head` / `printenv` behavior.
+This overrides `cat`, `head`, and `printenv` so that — **only inside Claude Code** (gated on `$CLAUDECODE`) — they route through `agent-guard exec`, masking their output before the transcript captures it. So `!cat config.txt` gets its secrets redacted automatically, without you remembering to type `agx`. In a normal terminal (`$CLAUDECODE` unset) the overrides stay inert and fall back to plain `cat` / `head` / `printenv` behavior.
 
-> **Prerequisite — the `agent-guard` CLI must be on your `$PATH`.** This flag routes through the bare `agent-guard` command, so `command -v agent-guard` has to succeed in the same interactive shell. A plain `/plugin install` wires up the *hooks* (Claude Code invokes them by absolute path) but does **not** add `agent-guard` to your `$PATH` — so on a plugin-only install these overrides silently pass through **unmasked**. Install the CLI itself (e.g. the `bootstrap.sh` one-liner under [Pick an install path](#pick-an-install-path)) before enabling this flag.
+The binary is resolved at call time in this order: an explicit `$AGENT_GUARD_BIN`, then `agent-guard` on your `$PATH`, then the **absolute path baked into the snippet** at `shell-init` time. That last fallback means the guard works on a **plugin-only install** — where `agent-guard` is never added to `$PATH` — with no extra CLI install. If none of the three resolve (e.g. a plugin update moved the binary and left the baked path stale), the guard **fails open**: it runs your command but prints a loud `output is NOT masked` warning to stderr telling you to re-run `agent-guard setup-shell`. (`agx`, being an *explicit* mask request, instead fails **closed** — it refuses to run rather than leak.)
+
+> **Works without the CLI on `$PATH` — but a plugin can't edit your rc.** The one manual step for a plugin-only install is getting the `shell-init` line into your shell rc so it loads in every shell (hence every Claude Code snapshot). Run `agent-guard setup-shell --experimental-bang-guard` once — invoke it by the plugin binary's absolute path if `agent-guard` isn't on your `$PATH`; it bakes that same absolute path into the line it writes — then restart your shell and any Claude Code session.
 
 **This is best-effort, not a security control.** It covers only those command names and is trivially bypassed by an absolute path (`/bin/cat`), `source` / `.`, `python -c 'open(...)'`, or a redirection (`< file`). Because `agent-guard exec` buffers the whole output before masking it, **streaming / follow commands would hang** — so `tail` is deliberately *not* wrapped, and you should not `agx` a `tail -f`, a pager, or any long-running program (wrap only terminating dump commands). Output is captured via shell substitution, so wrapping is **text-only** — a binary or NUL-containing read loses embedded NULs and its trailing newline, so use `command cat` / `\cat` for faithful binary output. Each wrapped call also pays a gitleaks scan. Treat it as a convenience nudge for the common cases, not a boundary — the only channel-agnostic fix remains an egress redaction proxy or an upstream `!`-command hook.
 

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -35,6 +35,18 @@ script_dir() {
 
 BIN_DIR=$(script_dir)
 ROOT_DIR=$(CDPATH= cd -- "$BIN_DIR/.." && pwd -P)
+# Absolute path of THIS binary. Baked into the shell-init snippet so the wrappers
+# can find agent-guard even when it is NOT on $PATH (e.g. a plugin-only install,
+# where the binary lives in the plugin cache and is never symlinked onto PATH).
+SELF_BIN="$BIN_DIR/agent-guard"
+
+# Emit $1 as a safely single-quoted POSIX shell word, so a path with spaces (or,
+# rarely, an embedded quote) survives being baked into an emitted snippet.
+sh_squote() {
+  printf "'"
+  printf '%s' "$1" | sed "s/'/'\\\\''/g"
+  printf "'"
+}
 
 GITLEAKS_CONFIG=${AGENT_GUARD_GITLEAKS_CONFIG:-"$ROOT_DIR/config/gitleaks.toml"}
 DENY_READ_PATHS=${AGENT_GUARD_DENY_READ_PATHS:-"$ROOT_DIR/config/deny-read-paths.txt"}
@@ -47,7 +59,8 @@ Usage:
   agent-guard hook-post-tool
   agent-guard hook-stop
   agent-guard exec [--] <cmd> [args...]
-  agent-guard shell-init [--bash|--zsh]
+  agent-guard shell-init [--bash|--zsh] [--experimental-bang-guard]
+  agent-guard setup-shell [--bash|--zsh|--rc FILE] [--experimental-bang-guard]
   agent-guard pii-filter [--check]
   agent-guard scan-staged
   agent-guard scan-working-tree
@@ -1878,15 +1891,23 @@ shell_init_bang_guard() {
 # terminating dump commands.
 __agentguard_guard() {  # $1 = real command name, remaining args forwarded
   __ag_cmd=$1; shift
-  if [ -n "${CLAUDECODE:-}" ] && command -v agent-guard >/dev/null 2>&1; then
-    # `exec` runs the wrapped command in agent-guard's OWN child process, where
-    # these override functions do not exist — so the real binary runs and there
-    # is no re-entry (no inner `command` needed).
-    command agent-guard exec -- "$__ag_cmd" "$@"
-  else
-    # `command` bypasses this override so the real binary runs (no recursion).
-    command "$__ag_cmd" "$@"
+  if [ -n "${CLAUDECODE:-}" ]; then
+    # Route through `agent-guard exec` (resolved via $PATH or the baked path) so
+    # the output is masked. `exec` runs the command in agent-guard's OWN child
+    # process, where these overrides do not exist, so the real binary runs with
+    # no re-entry (no inner `command` needed).
+    if __ag_exe=$(__agentguard_exe); then
+      command "$__ag_exe" exec -- "$__ag_cmd" "$@"
+      return
+    fi
+    # Unlike agx, this is a TRANSPARENT override (the user just typed `cat`), so
+    # fail OPEN — run the command — but WARN loudly that the output is unmasked
+    # rather than leaking silently. A stale baked path after a plugin update
+    # lands here; `agent-guard setup-shell` re-bakes it.
+    printf 'agent-guard: bang-guard cannot locate the agent-guard binary; %s output is NOT masked. Re-run: agent-guard setup-shell\n' "$__ag_cmd" >&2
   fi
+  # `command` bypasses this override so the real binary runs (no recursion).
+  command "$__ag_cmd" "$@"
 }
 # A user alias for one of these (e.g. `alias cat='cat -n'`) would otherwise
 # alias-expand the `${name}()` token while this eval is PARSED, so the function
@@ -1925,6 +1946,11 @@ shell_init() {
   # leaves the other stream transcript-bound, so those must NOT skip), and only
   # fires on a small curated set of secret-loading idioms. The match is a
   # pure-shell `case` glob (no subprocess per command, so it is fast).
+  #
+  # Bake this binary's absolute path so the wrappers resolve agent-guard even when
+  # it is not on $PATH (plugin-only install). Emitted as its own assignment (the
+  # heredoc below is single-quoted, so it cannot expand a shell variable itself).
+  printf '__agentguard_bin=%s\n' "$(sh_squote "$SELF_BIN")"
   cat <<'EOF'
 # --- agent-guard shell integration (managed by: agent-guard shell-init) -------
 # Threat: a `!`-prefixed command in Claude Code runs in your shell and its OUTPUT
@@ -1932,7 +1958,32 @@ shell_init() {
 # for `!`. Run secret-printing commands as `agx <cmd>` (in Claude Code: `!agx
 # <cmd>`) so their output is masked BEFORE the model sees it. The nudge below is a
 # warn-only reminder; it never blocks or changes your command.
-agx() { command agent-guard exec -- "$@"; }
+#
+# Resolve the agent-guard binary at call time: an explicit $AGENT_GUARD_BIN wins,
+# then $PATH (the durable path for a CLI install, unaffected by version bumps),
+# then the absolute path baked in above (lets a plugin-only install work without
+# putting agent-guard on $PATH). Prints the resolved command; non-zero if none.
+__agentguard_exe() {
+  if [ -n "${AGENT_GUARD_BIN:-}" ] && [ -x "$AGENT_GUARD_BIN" ]; then
+    printf '%s' "$AGENT_GUARD_BIN"; return 0
+  fi
+  if command -v agent-guard >/dev/null 2>&1; then printf '%s' agent-guard; return 0; fi
+  if [ -n "${__agentguard_bin:-}" ] && [ -x "$__agentguard_bin" ]; then
+    printf '%s' "$__agentguard_bin"; return 0
+  fi
+  return 1
+}
+# `agx <cmd>` masks a command's output. It is an EXPLICIT mask request, so if the
+# binary cannot be found it FAILS CLOSED (loud error, does not run the command
+# unmasked) — running it raw would leak exactly what you asked to mask.
+agx() {
+  if __ag_exe=$(__agentguard_exe); then
+    command "$__ag_exe" exec -- "$@"
+  else
+    printf 'agent-guard: agx cannot locate the agent-guard binary; NOT running (output would be unmasked). Re-run: agent-guard setup-shell\n' >&2
+    return 127
+  fi
+}
 __agentguard_nudge() {
   [ -n "$1" ] || return 0
   case "$1" in
@@ -1971,6 +2022,94 @@ EOF
   [ "$bang_guard" = 1 ] && shell_init_bang_guard
 }
 
+# `setup-shell` — write the `eval "$(... shell-init ...)"` line into the user's
+# shell rc so the wrappers load in every new shell (hence every Claude Code shell
+# snapshot). This is the one manual step a plugin-only install needs: a plugin
+# cannot edit your rc, so run this once (by absolute path if agent-guard is not
+# yet on $PATH). Idempotent — re-running replaces the managed block in place.
+do_setup_shell() {
+  sh_target= rc= bang=
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --bash) sh_target=bash ;;
+      --zsh) sh_target=zsh ;;
+      --rc) shift; rc=${1:-}; [ -n "$rc" ] || die "setup-shell: --rc requires a path" ;;
+      --experimental-bang-guard) bang=' --experimental-bang-guard' ;;
+      -h|--help)
+        {
+          printf '%s\n' "Usage: $PROGRAM setup-shell [--bash|--zsh|--rc FILE] [--experimental-bang-guard]"
+          printf '%s\n' "Adds the shell-init line to your shell rc (idempotent). Restart your"
+          printf '%s\n' "shell and any Claude Code session afterwards to apply."
+        } >&2
+        return 0 ;;
+      *) die "setup-shell: unknown option: $1 (see: $PROGRAM setup-shell --help)" ;;
+    esac
+    shift
+  done
+
+  # Pick the rc file: explicit --rc wins, else derive from the chosen/detected shell.
+  if [ -z "$rc" ]; then
+    if [ -z "$sh_target" ]; then
+      case "${SHELL:-}" in */bash) sh_target=bash ;; *) sh_target=zsh ;; esac
+    fi
+    case "$sh_target" in bash) rc=$HOME/.bashrc ;; *) rc=$HOME/.zshrc ;; esac
+  fi
+
+  # Invocation baked into the rc line: prefer the bare name when agent-guard is on
+  # $PATH (durable — unaffected by version bumps), else the absolute path of THIS
+  # binary so a plugin-only install still resolves. The emitted snippet keeps its
+  # `auto` shell detection, so the same line works in bash and zsh.
+  if command -v agent-guard >/dev/null 2>&1; then inv=agent-guard; else inv=$SELF_BIN; fi
+  q=$(sh_squote "$inv")
+  line="eval \"\$($q shell-init${bang})\""
+
+  begin='# >>> agent-guard shell-init >>>'
+  end='# <<< agent-guard shell-init <<<'
+
+  # If the rc is a symlink (e.g. into a dotfiles repo), edit the file it points
+  # at rather than replacing the link with a regular file. Walk the chain by hand
+  # (BSD readlink lacks -f), matching script_path() above.
+  rc_real=$rc hops=0
+  while [ -L "$rc_real" ]; do
+    hops=$((hops + 1)); [ "$hops" -le 40 ] || die "setup-shell: too many symlink hops resolving $rc"
+    t=$(readlink -- "$rc_real")
+    case "$t" in /*) rc_real=$t ;; *) rc_real=$(dirname -- "$rc_real")/$t ;; esac
+  done
+  rc_dir=$(dirname -- "$rc_real")
+  [ -d "$rc_dir" ] || die "setup-shell: directory does not exist: $rc_dir"
+
+  # Build the new content in a temp file in the SAME directory as the target, so
+  # the final `mv` is an atomic same-filesystem rename: the rc is never left
+  # half-written, even if this process is killed mid-run.
+  tmp=$(mktemp "$rc_dir/.agent-guard-rc.XXXXXX" 2>/dev/null) \
+    || die "setup-shell: failed to create temp file in $rc_dir"
+  if [ -f "$rc_real" ]; then
+    # Seed perms/owner from the existing rc (a plain `>` below keeps the inode's
+    # mode while rewriting content); a brand-new rc keeps mktemp's private 0600.
+    cp -p "$rc_real" "$tmp" 2>/dev/null || :
+    # Strip any existing managed block, then REFUSE if we hit a begin marker with
+    # no matching end (`END{exit skip}`): silently dropping everything after an
+    # unbalanced marker would eat unrelated rc content.
+    if ! awk -v b="$begin" -v e="$end" \
+      '$0==b{skip=1} skip==0{print} $0==e{skip=0} END{exit skip}' "$rc_real" >"$tmp"; then
+      rm -f "$tmp"
+      die "setup-shell: $rc_real has '$begin' with no matching '$end'; refusing to overwrite. Fix or remove that block, then re-run."
+    fi
+  else
+    : >"$tmp"
+  fi
+  {
+    printf '%s\n' "$begin"
+    printf '%s\n' "# Managed by 'agent-guard setup-shell' — remove this block to disable."
+    printf '%s\n' "$line"
+    printf '%s\n' "$end"
+  } >>"$tmp"
+  mv "$tmp" "$rc_real" || { rm -f "$tmp"; die "setup-shell: failed to write $rc_real"; }
+
+  info "$PROGRAM: shell integration written to $rc_real"
+  info "$PROGRAM: restart your shell (and any Claude Code session) to apply"
+}
+
 cmd=${1:-}
 case "$cmd" in
   hook-pre-tool) hook_pre_tool ;;
@@ -1984,6 +2123,7 @@ case "$cmd" in
   scan-path) shift; scan_path "$@" ;;
   check) check_deps ;;
   setup) shift; do_setup "$@" ;;
+  setup-shell) shift; do_setup_shell "$@" ;;
   smoke-test) smoke_test ;;
   checksum) shift; exec sh "$ROOT_DIR/scripts/gitleaks-checksum.sh" "$@" ;;
   version) printf '%s %s\n' "$PROGRAM" "$VERSION" ;;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -2566,6 +2566,144 @@ for bg_sh in bash zsh; do
   fi
 done
 
+# --- CLI-less operation: baked path + resolver (no agent-guard on $PATH) ------
+# A plugin-only install never symlinks agent-guard onto $PATH, so the wrappers
+# must resolve it via the absolute path baked into the snippet. These tests strip
+# $PATH down to a minimal set (no agent-guard) to prove that fallback.
+if printf '%s' "$shellinit_bg" | grep -q '^__agentguard_bin='; then
+  ok "shell-init bakes the absolute binary path (__agentguard_bin)"
+else
+  not_ok "shell-init bakes the absolute binary path (__agentguard_bin)"
+fi
+if printf '%s' "$shellinit_bg" | grep -q '__agentguard_exe()'; then
+  ok "shell-init emits the __agentguard_exe resolver"
+else
+  not_ok "shell-init emits the __agentguard_exe resolver"
+fi
+
+# Route via the BAKED path when agent-guard is not on $PATH: point the baked line
+# at the stub and drop $PATH so `command -v agent-guard` cannot find anything.
+bg_baked="$bg_dir/guard-baked.sh"
+sed "s#^__agentguard_bin=.*#__agentguard_bin='$bg_dir/bin/agent-guard'#" "$bg_dir/guard.sh" >"$bg_baked"
+bg_nopath=$(PATH=/usr/bin:/bin CLAUDECODE=1 sh -c '. "$1"; cat "$2"' _ "$bg_baked" "$bg_dir/file.txt" 2>/dev/null)
+if [ "$bg_nopath" = ROUTED ]; then
+  ok "bang guard routes via the baked path when agent-guard is off \$PATH"
+else
+  not_ok "bang guard routes via baked path off \$PATH (got: $bg_nopath)"
+fi
+
+# $AGENT_GUARD_BIN wins over both $PATH and the baked path.
+cat >"$bg_dir/bin/ag-override" <<'STUB'
+#!/bin/sh
+[ "$1" = exec ] && { printf 'ENVROUTED\n'; exit 0; }
+exit 0
+STUB
+chmod +x "$bg_dir/bin/ag-override"
+bg_env=$(PATH="$bg_dir/bin:$PATH" CLAUDECODE=1 AGENT_GUARD_BIN="$bg_dir/bin/ag-override" \
+  sh -c '. "$1"; cat "$2"' _ "$bg_dir/guard.sh" "$bg_dir/file.txt" 2>/dev/null)
+if [ "$bg_env" = ENVROUTED ]; then
+  ok "\$AGENT_GUARD_BIN takes priority in the resolver"
+else
+  not_ok "\$AGENT_GUARD_BIN priority in the resolver (got: $bg_env)"
+fi
+
+# When NO binary resolves (stale baked path, nothing on $PATH), the TRANSPARENT
+# bang guard fails OPEN — it still runs the command — but warns loudly on stderr.
+bg_none="$bg_dir/guard-none.sh"
+sed "s#^__agentguard_bin=.*#__agentguard_bin='/nonexistent/agent-guard'#" "$bg_dir/guard.sh" >"$bg_none"
+bg_open=$(PATH=/usr/bin:/bin CLAUDECODE=1 sh -c '. "$1"; cat "$2"' _ "$bg_none" "$bg_dir/file.txt" 2>"$ERR")
+if [ "$bg_open" = hello-plain ]; then
+  ok "bang guard fails OPEN (runs the command) when no binary resolves"
+else
+  not_ok "bang guard fail-open passthrough when no binary resolves (got: $bg_open)"
+fi
+if grep -q 'NOT masked' "$ERR"; then
+  ok "bang guard warns loudly on stderr when it cannot mask"
+else
+  not_ok "bang guard warns loudly on stderr when it cannot mask"
+fi
+
+# agx is an EXPLICIT mask request, so it fails CLOSED — it must NOT run the
+# command unmasked when the binary is missing; it returns 127 instead.
+agx_out=$(PATH=/usr/bin:/bin sh -c '. "$1"; agx cat "$2"; printf "rc=%s" "$?"' _ "$bg_none" "$bg_dir/file.txt" 2>/dev/null)
+case "$agx_out" in
+  *hello-plain*) not_ok "agx fails CLOSED when no binary resolves (leaked: $agx_out)" ;;
+  *rc=127*)      ok "agx fails CLOSED (rc=127, does not run) when no binary resolves" ;;
+  *)             not_ok "agx fail-closed return code (got: $agx_out)" ;;
+esac
+
+# --- setup-shell: write the shell-init line into an rc, idempotently ----------
+ss_rc="$TESTTMP/setup.rc"
+"$PLUGIN_ROOT/bin/agent-guard" setup-shell --rc "$ss_rc" >/dev/null 2>&1
+if grep -q '>>> agent-guard shell-init >>>' "$ss_rc" 2>/dev/null; then
+  ok "setup-shell writes a managed shell-init block into the rc"
+else
+  not_ok "setup-shell writes a managed shell-init block into the rc"
+fi
+"$PLUGIN_ROOT/bin/agent-guard" setup-shell --rc "$ss_rc" >/dev/null 2>&1
+ss_markers=$(grep -c '>>> agent-guard shell-init >>>' "$ss_rc" 2>/dev/null)
+if [ "$ss_markers" = 1 ]; then
+  ok "setup-shell is idempotent (one managed block after two runs)"
+else
+  not_ok "setup-shell idempotent (begin-marker count: $ss_markers)"
+fi
+printf 'export AG_TEST_KEEP=1\n' >>"$ss_rc"
+"$PLUGIN_ROOT/bin/agent-guard" setup-shell --rc "$ss_rc" >/dev/null 2>&1
+if grep -q 'export AG_TEST_KEEP=1' "$ss_rc" 2>/dev/null; then
+  ok "setup-shell preserves unrelated rc lines"
+else
+  not_ok "setup-shell preserves unrelated rc lines"
+fi
+"$PLUGIN_ROOT/bin/agent-guard" setup-shell --rc "$ss_rc" --experimental-bang-guard >/dev/null 2>&1
+if grep -q 'shell-init --experimental-bang-guard' "$ss_rc" 2>/dev/null; then
+  ok "setup-shell threads --experimental-bang-guard into the rc line"
+else
+  not_ok "setup-shell threads --experimental-bang-guard into the rc line"
+fi
+if "$PLUGIN_ROOT/bin/agent-guard" setup-shell --bogus >/dev/null 2>&1; then
+  not_ok "setup-shell rejects an unknown option"
+else
+  ok "setup-shell rejects an unknown option"
+fi
+# An unbalanced managed block (begin marker, no matching end) must make
+# setup-shell REFUSE and leave the rc untouched — never silently drop the
+# user content that follows the orphaned marker.
+ss_bad="$TESTTMP/setup-bad.rc"
+{
+  printf '%s\n' 'export AG_BEFORE=1'
+  printf '%s\n' '# >>> agent-guard shell-init >>>'
+  printf '%s\n' 'export AG_ORPHAN_KEEP=1'
+} >"$ss_bad"
+ss_bad_before=$(cat "$ss_bad")
+if "$PLUGIN_ROOT/bin/agent-guard" setup-shell --rc "$ss_bad" >/dev/null 2>&1; then
+  not_ok "setup-shell refuses an rc with an unbalanced managed-block marker"
+else
+  ok "setup-shell refuses an rc with an unbalanced managed-block marker"
+fi
+if [ "$(cat "$ss_bad")" = "$ss_bad_before" ]; then
+  ok "setup-shell leaves the rc untouched when it refuses"
+else
+  not_ok "setup-shell leaves the rc untouched when it refuses"
+fi
+# A symlinked rc is written THROUGH to its target (dotfiles workflow): the link
+# stays a link and the real file gets the managed block + keeps its content.
+if ln -s "$TESTTMP/real-rc" "$TESTTMP/link-rc" 2>/dev/null; then
+  printf 'export AG_DOTFILES=1\n' >"$TESTTMP/real-rc"
+  "$PLUGIN_ROOT/bin/agent-guard" setup-shell --rc "$TESTTMP/link-rc" >/dev/null 2>&1
+  if [ -L "$TESTTMP/link-rc" ] && grep -q '>>> agent-guard shell-init >>>' "$TESTTMP/real-rc" 2>/dev/null; then
+    ok "setup-shell writes through a symlinked rc (link preserved, target updated)"
+  else
+    not_ok "setup-shell writes through a symlinked rc (link preserved, target updated)"
+  fi
+  if grep -q 'export AG_DOTFILES=1' "$TESTTMP/real-rc" 2>/dev/null; then
+    ok "setup-shell preserves target content when writing through a symlink"
+  else
+    not_ok "setup-shell preserves target content when writing through a symlink"
+  fi
+else
+  say "symlinks not supported here; skipped setup-shell symlink test"
+fi
+
 say "passed: $pass"
 say "failed: $fail"
 


### PR DESCRIPTION
## What & why

The experimental **bang guard** (`shell-init --experimental-bang-guard`) and the `agx`
wrapper previously routed through the bare `agent-guard` command. On a **plugin-only
install** — where the plugin invokes hooks by absolute path but never adds `agent-guard`
to your `$PATH` — that meant the transparent `cat`/`head`/`printenv` overrides silently
passed reads through **unmasked**. This PR removes the CLI-on-`$PATH` prerequisite.

- **Baked absolute path + resolver.** `shell-init` now bakes this binary's absolute path
  into the emitted snippet and resolves it at call time in order: `$AGENT_GUARD_BIN` →
  `agent-guard` on `$PATH` → the baked path. A plugin-only install now works with no
  extra CLI install; a CLI install still prefers the durable `$PATH` name (unaffected by
  version bumps).
- **Asymmetric failure.** When nothing resolves, the *transparent* overrides fail **open**
  with a loud `output is NOT masked` stderr warning — a stale baked path after a plugin
  update must not break `cat`/`head`/`printenv` in every shell. `agx`, an *explicit* mask
  request, fails **closed** (`rc 127`) rather than run the command unmasked.
- **`agent-guard setup-shell`.** A plugin can't edit your rc, so this new command writes
  the `shell-init` line into your `~/.zshrc` / `~/.bashrc` idempotently (by absolute path
  when `agent-guard` isn't on `$PATH` yet).

## Review findings addressed (code-review-trio)

- 🟡 **rc data-loss on an unbalanced managed-block marker** (flagged by all three
  reviewers, reproduced): the block stripper now uses `awk … END{exit skip}` and
  **refuses** (leaves the rc untouched) when it finds a begin marker with no matching end,
  instead of dropping everything after it.
- 🟡 **Non-atomic / truncate-before-write rc write** (code-review + security): now writes
  to a same-directory temp and `mv`s atomically, so an interrupted run never leaves a
  half-written rc. A **symlinked rc is written through to its target** (dotfiles repos keep
  working, link preserved), and the file's mode is seeded from the existing rc.

Non-blocking, documented rather than changed:

- **`$PATH` resolver tier can run an attacker-planted `agent-guard`** — pre-existing (the
  old bang guard already did `command -v agent-guard`); this PR *reduces* `$PATH` reliance
  by adding the `$AGENT_GUARD_BIN` and baked absolute-path tiers. Reduces to the user's own
  `$PATH` hygiene.
- **Transparent fail-open** is deliberate and consistent with the feature being documented
  as "best-effort, not a security control." A future `AGENT_GUARD_STRICT` opt-in could make
  it fail closed too.

## How to verify

Automated:

```sh
make -C plugins/agent-guard test    # or: sh tests/run.sh   → 340 pass, 0 fail
```

Manual — CLI-less (plugin-only) masking, redactor-proof:

1. Emit the guard by absolute path (no `agent-guard` on `$PATH`):
   `BIN=plugins/agent-guard/bin/agent-guard; "$BIN" shell-init --experimental-bang-guard > /tmp/guard.sh`
2. Put a fake token in a file: `printf 'GITHUB_TOKEN=ghp_%s\n' "$(head -c 36 /dev/urandom | base64 | tr -dc a-zA-Z0-9 | head -c 36)" > /tmp/cfg.txt`
3. Source with `$PATH` stripped and `$CLAUDECODE` set, then read the file:
   `PATH=/usr/bin:/bin CLAUDECODE=1 sh -c '. /tmp/guard.sh; cat /tmp/cfg.txt'`
   → the token is `[REDACTED]` (routed through the baked path), **not** printed raw.
4. `agent-guard setup-shell --rc /tmp/rc --experimental-bang-guard` twice → exactly one
   managed block; `grep -c '>>> agent-guard shell-init >>>' /tmp/rc` is `1`.

## Scope

`plugins/agent-guard/bin/agent-guard` (resolver + fail-open/closed + `setup-shell`),
`tests/run.sh` (+16 tests), `README.md` (CLI-less docs + `setup-shell`). No behavior change
to hooks, scanning, or `exec`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shell setup command that can write or update integration settings automatically.
  * Improved shell support for installs where the binary is not on the system path.

* **Bug Fixes**
  * Added safer command resolution for shell helpers, with clear fallback behavior when the binary cannot be found.
  * Made the optional masking workflow more robust, including warnings when masking cannot be guaranteed.
  * Improved handling of shell config files, including repeated runs and symlinked files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->