### PR TITLE
feat(detection): allow dotenv-style template files via suffix rule

### DIFF
--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -836,14 +836,16 @@ resolve_path() {
 }
 
 # Allowlist short-circuit consulted before any deny-path check (both the Read and
-# Bash paths). It currently exempts committed `.env` placeholder templates that
-# the `.env*` deny glob would otherwise block. Matched on the exact basename so a
-# real secret file is never exempted by a crafted name. NOTE: a match here exempts
-# the candidate from ALL deny patterns, so only add names that never hold secrets.
+# Bash paths). It exempts committed dotenv-style placeholder templates that the
+# `.env*` deny glob would otherwise block: any basename starting with `.env` and
+# ending with a template suffix (`.envrc.sample`, `.env.local.example`, ...).
+# Matched on the basename only, with the suffix anchored at the end, so a real
+# secret file (`.env`, `.envrc`, `.env.production`, `.env.example.bak`) is never
+# exempted by a crafted path. NOTE: a match here exempts the candidate from ALL
+# deny patterns, so the rule must only admit shapes that never hold secrets.
 candidate_is_allowed() {
-  case "$1" in
-    .env.example|.env.sample|.env.template|.env.dist) return 0 ;;
-    */.env.example|*/.env.sample|*/.env.template|*/.env.dist) return 0 ;;
+  case "${1##*/}" in
+    .env*.example|.env*.sample|.env*.template|.env*.dist) return 0 ;;
     *) return 1 ;;
   esac
 }
@@ -1042,7 +1044,9 @@ shell_dequote_for_policy() {
 # the whole-command deny regex runs, so `cat .env.example` is allowed while
 # `cat .env.example .env` still blocks on the bare `.env` token. Globbing is
 # disabled inside a subshell so a stray `*` in the command is not expanded
-# against the real filesystem during word splitting.
+# against the real filesystem during word splitting. Caveat: tokens are stripped
+# textually, without symlink resolution — a template-named symlink to a real
+# secret passes this gate (the Read path re-checks the resolved target instead).
 bash_strip_allowed_tokens() {
   (
     set -f

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -835,19 +835,43 @@ resolve_path() {
   fi
 }
 
+# A template basename never exempts a file inside a deny-listed directory: walk
+# the deny patterns against the candidate's parent path so `.env.production/x`
+# stays denied regardless of what x is called. Uses its own variable names —
+# candidate_matches_deny calls into this while holding candidate/pattern.
+candidate_parent_matches_deny() {
+  parent_path=$1
+  [ -f "$DENY_READ_PATHS" ] || return 1
+  while IFS= read -r parent_pattern || [ -n "$parent_pattern" ]; do
+    case "$parent_pattern" in
+      ''|\#*) continue ;;
+    esac
+    case "$parent_path" in
+      $parent_pattern|*/$parent_pattern) return 0 ;;
+    esac
+  done <"$DENY_READ_PATHS"
+  return 1
+}
+
 # Allowlist short-circuit consulted before any deny-path check (both the Read and
 # Bash paths). It exempts committed dotenv-style placeholder templates that the
 # `.env*` deny glob would otherwise block: any basename starting with `.env` and
 # ending with a template suffix (`.envrc.sample`, `.env.local.example`, ...).
 # Matched on the basename only, with the suffix anchored at the end, so a real
 # secret file (`.env`, `.envrc`, `.env.production`, `.env.example.bak`) is never
-# exempted by a crafted path. NOTE: a match here exempts the candidate from ALL
-# deny patterns, so the rule must only admit shapes that never hold secrets.
+# exempted by a crafted path — and only when no parent path component is itself
+# deny-listed (`.env.production/.envrc.sample` stays blocked). NOTE: a match here
+# exempts the candidate from ALL deny patterns, so the rule must only admit
+# shapes that never hold secrets.
 candidate_is_allowed() {
   case "${1##*/}" in
-    .env*.example|.env*.sample|.env*.template|.env*.dist) return 0 ;;
+    .env*.example|.env*.sample|.env*.template|.env*.dist) ;;
     *) return 1 ;;
   esac
+  case "$1" in
+    */*) candidate_parent_matches_deny "${1%/*}" && return 1 ;;
+  esac
+  return 0
 }
 
 candidate_matches_deny() {

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -694,6 +694,19 @@ expect_json_status 2 "Read config/.env.local (path-prefixed, not a template) is 
   '{"tool_name":"Read","tool_input":{"file_path":"config/.env.local"}}' \
   hook-pre-tool
 
+# A template basename never exempts a file inside a deny-listed directory.
+expect_json_status 2 "Read template inside a deny-listed directory is blocked" \
+  '{"tool_name":"Read","tool_input":{"file_path":".env.production/.envrc.sample"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Read template under a deny-listed mid-path component is blocked" \
+  '{"tool_name":"Read","tool_input":{"file_path":"app/.env/.env.local.example"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Bash cat of a template inside a deny-listed directory is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"cat .env.production/.envrc.sample"}}' \
+  hook-pre-tool
+
 # Rank 8: shell builtins that print the whole environment.
 expect_json_status 2 "export -p is blocked" \
   '{"tool_name":"Bash","tool_input":{"command":"export -p"}}' \

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -647,6 +647,53 @@ expect_json_status 2 "Bash cat of .env.local (not a template) is blocked" \
   '{"tool_name":"Bash","tool_input":{"command":"cat .env.local"}}' \
   hook-pre-tool
 
+# Suffix rule: any `.env*` basename ending with a template suffix is allowed,
+# but the suffix must be final and the bare names stay blocked.
+expect_json_status 0 "Read .envrc.sample template is allowed" \
+  '{"tool_name":"Read","tool_input":{"file_path":".envrc.sample"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "Read .env.local.example template is allowed" \
+  '{"tool_name":"Read","tool_input":{"file_path":".env.local.example"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Read bare .envrc is blocked" \
+  '{"tool_name":"Read","tool_input":{"file_path":".envrc"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Read .env.example.bak (suffix not final) is blocked" \
+  '{"tool_name":"Read","tool_input":{"file_path":".env.example.bak"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "Bash cat .envrc.sample is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"cat .envrc.sample"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "Bash cat .env.local.example is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"cat .env.local.example"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Bash cat .envrc is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"cat .envrc"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Bash cat .env.example.bak (suffix not final) is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"cat .env.example.bak"}}' \
+  hook-pre-tool
+
+# Path-prefixed candidates go through basename stripping before the suffix match.
+expect_json_status 0 "Read config/.env.local.example (path-prefixed template) is allowed" \
+  '{"tool_name":"Read","tool_input":{"file_path":"config/.env.local.example"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "Bash cat config/.envrc.sample (path-prefixed template) is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"cat config/.envrc.sample"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Read config/.env.local (path-prefixed, not a template) is blocked" \
+  '{"tool_name":"Read","tool_input":{"file_path":"config/.env.local"}}' \
+  hook-pre-tool
+
 # Rank 8: shell builtins that print the whole environment.
 expect_json_status 2 "export -p is blocked" \
   '{"tool_name":"Bash","tool_input":{"command":"export -p"}}' \


### PR DESCRIPTION
## Summary

Extends the dotenv-template allowlist in `plugins/agent-guard/bin/agent-guard` (`candidate_is_allowed()`) from four exact basenames (`.env.example`, `.env.sample`, `.env.template`, `.env.dist`) to a suffix rule: any basename that starts with `.env` **and ends with** `.example`, `.sample`, `.template`, or `.dist` is exempt from the deny-read gate.

Closes #99

## What changed

- `candidate_is_allowed()` now strips the directory part first and matches the basename against anchored suffix globs (`.env*.example` etc.). Basename-only matching means the wildcard can never span a `/`, and the anchored suffix keeps the security property from the function's comment: only shapes that never hold secrets are exempted.
- Newly allowed (previously false positives): `.envrc.sample`, `.envrc.example`, `.env.local.example`, `.env.production.sample`, and similar committed templates.
- Still blocked: `.env`, `.envrc`, `.env.production` (no template suffix) and `.env.example.bak` (suffix not final).
- Both consumers of the allowlist are covered by the single edit: the Read-path gate (`candidate_matches_deny`) and the Bash token gate (`bash_strip_allowed_tokens`).
- Documented a pre-existing caveat on `bash_strip_allowed_tokens`: tokens are stripped textually without symlink resolution (the Read path re-checks the resolved target); the suffix rule widens the set of names that shape admits, so the comment now states it explicitly.
- 11 new test cases in `tests/run.sh` covering both gates: allow (`.envrc.sample`, `.env.local.example`, path-prefixed `config/.env.local.example`, `config/.envrc.sample`) and block (`.envrc`, `.env.example.bak`, `config/.env.local`) directions.

## Manual verification guide

Automated coverage: `make test` runs the full suite (354 tests, including the 11 new cases) with a mock gitleaks. What a human should spot-check by hand — live hook behavior with the real installed plugin:

1. Run the suite in the repo root:

   ```sh
   make test
   ```

   Expected: `passed: 354`, `failed: 0` (includes the new suffix-rule cases; grep the output for `envrc.sample`).

2. Exercise the hook binary directly — a newly allowed template (expect exit 0, no output):

   ```sh
   printf '%s' '{"tool_name":"Read","tool_input":{"file_path":".envrc.sample"}}' \
     | plugins/agent-guard/bin/agent-guard hook-pre-tool; echo "exit=$?"
   ```

3. A per-environment template through the Bash token gate (expect exit 0):

   ```sh
   printf '%s' '{"tool_name":"Bash","tool_input":{"command":"cat .env.local.example"}}' \
     | plugins/agent-guard/bin/agent-guard hook-pre-tool; echo "exit=$?"
   ```

4. Still-blocked names (expect exit 2 and a deny message on stderr for each):

   ```sh
   printf '%s' '{"tool_name":"Read","tool_input":{"file_path":".envrc"}}' \
     | plugins/agent-guard/bin/agent-guard hook-pre-tool; echo "exit=$?"
   printf '%s' '{"tool_name":"Read","tool_input":{"file_path":".env.example.bak"}}' \
     | plugins/agent-guard/bin/agent-guard hook-pre-tool; echo "exit=$?"
   printf '%s' '{"tool_name":"Bash","tool_input":{"command":"cat .env.example .env"}}' \
     | plugins/agent-guard/bin/agent-guard hook-pre-tool; echo "exit=$?"
   ```

5. In a live Claude Code session with the plugin installed (what automation can't cover): ask the agent to read a committed `.envrc.sample` in a real project — it should now succeed — and confirm reading a real `.env` is still denied.

## Notes

- No lint/shellcheck target exists in the Makefile or CI; the script's strict POSIX-sh style was preserved (case globs, no `local`).
- Renaming a real secrets file to earn the suffix (`cp .env .env.example`) was already possible with the exact-name allowlist and remains out of scope for this path gate; content-level scanning still applies elsewhere (see issue #99).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- code-flow-usage-json:start -->
<details>
<summary>code-flow usage JSON</summary>

```json
{
  "commits": [
    {
      "confidence": "best_effort",
      "model_totals": [
        {
          "cache_creation_ephemeral_1h_input_tokens": 209901,
          "cache_creation_input_tokens": 209901,
          "cache_read_input_tokens": 7191267,
          "input_tokens": 32722,
          "model": "claude-fable-5",
          "output_tokens": 67966,
          "total_context_tokens": 7501856,
          "turns": 52
        }
      ],
      "participants": [
        {
          "attribution": "exact",
          "cache_creation_ephemeral_1h_input_tokens": 209901,
          "cache_creation_input_tokens": 209901,
          "cache_read_input_tokens": 7191267,
          "input_tokens": 32722,
          "kind": "main",
          "model": "claude-fable-5",
          "name": "main",
          "output_tokens": 67966,
          "total_context_tokens": 7501856,
          "turns": 52
        }
      ],
      "recorded_at": "2026-07-06T18:19:52Z",
      "sha": "3c7b130d4f548619ac8fff9b04c0b2630122b73c",
      "subject": "feat(detection): allow dotenv-style template files via suffix rule",
      "totals": {
        "cache_creation_ephemeral_1h_input_tokens": 209901,
        "cache_creation_input_tokens": 209901,
        "cache_read_input_tokens": 7191267,
        "input_tokens": 32722,
        "output_tokens": 67966,
        "total_context_tokens": 7501856,
        "turns": 52
      }
    },
    {
      "confidence": "best_effort",
      "model_totals": [],
      "participants": [],
      "sha": "0c7daf0551573cb971f93f1121f196cfda7aa7b7",
      "status": "unmetered",
      "subject": "fix(detection): keep templates under deny-listed directories blocked",
      "totals": {
        "cache_creation_input_tokens": 0,
        "cache_read_input_tokens": 0,
        "input_tokens": 0,
        "output_tokens": 0,
        "total_context_tokens": 0
      }
    }
  ],
  "confidence": "best_effort",
  "metered_commits": 1,
  "pr": {
    "base": "main",
    "head": "feat/dotenv-template-suffix-allowlist",
    "number": 100
  },
  "schema": "code-flow-usage/1",
  "scope": "current_branch_pr",
  "source": "claude_code_hooks",
  "total_commits": 2,
  "totals": {
    "cache_creation_ephemeral_1h_input_tokens": 209901,
    "cache_creation_input_tokens": 209901,
    "cache_read_input_tokens": 7191267,
    "input_tokens": 32722,
    "output_tokens": 67966,
    "total_context_tokens": 7501856,
    "turns": 52
  },
  "totals_by_model": [
    {
      "cache_creation_ephemeral_1h_input_tokens": 209901,
      "cache_creation_input_tokens": 209901,
      "cache_read_input_tokens": 7191267,
      "input_tokens": 32722,
      "model": "claude-fable-5",
      "output_tokens": 67966,
      "total_context_tokens": 7501856,
      "turns": 52
    }
  ],
  "updated_at": "2026-07-06T18:45:52Z"
}
```

</details>
<!-- code-flow-usage-json:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of `.env*` file patterns so template-style filenames are recognized more consistently, including in nested paths.
  * Tightened blocking for sensitive filenames that don’t match the approved template-style suffixes.

* **Tests**
  * Expanded policy coverage for allowed template filenames, blocked secret names, and path-based edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->