### PR TITLE
Promote Codex setup and command guard to v1.10.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "agent-guard",
       "source": "./plugins/agent-guard",
       "description": "Real-time secret-leak guardrails for AI coding agents (Claude Code, Codex), Git hooks, and CI.",
-      "version": "1.9.0"
+      "version": "1.10.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v1.10.0 - 2026-07-13
+
+- feat(codex): add guided dependency setup and host-native hook responses
+- feat(shell): graduate the Claude bang-command guard to a supported opt-in
+
 ## v1.9.0 - 2026-07-07
 
 - feat(plugin): warn on version drift between plugin hooks and the shell-integration CLI (#104)
@@ -125,4 +130,3 @@
 - chore: usability and robustness pass (#3)
 - [codex] Add CI and clean public-readiness scan noise (#2)
 - Harden against Bash/path bypass, Codex patch parsing, symlink, and action injection (#1)
-

--- a/README.md
+++ b/README.md
@@ -34,15 +34,15 @@ It should refuse:
 agent-guard: blocked sensitive file access: .env
 ```
 
-Detection needs `jq` and `gitleaks` on your machine (`brew install jq gitleaks`; see [Requirements](#requirements) for Linux). Using Codex, Git hooks, or CI instead? Pick your path below.
+Detection needs `jq` and `gitleaks` on your machine (`brew install jq gitleaks`; see [Requirements](#requirements)). The Codex plugin also ships a guided `$setup-agent-guard` skill. Using Codex, Git hooks, or CI instead? Pick your path below.
 
 ## Pick an install path
 
 | Use case | Install path | Best first check |
 |---|---|---|
 | Claude Code agent guardrails | [Quick start (Claude Code)](#quick-start-claude-code) | Ask the agent to read `.env`; it should be blocked. |
-| Codex stable guardrails | [Codex direct CLI + Git hook](#codex-plugin) | Run `agent-guard smoke-test`; commit a staged fixture secret, and it should fail. |
-| Codex experimental plugin hooks | [Codex plugin](#codex-plugin) | Enable `plugin_hooks`, trust hooks in `/hooks`, then ask Codex to read `.env`; it should be blocked. |
+| Codex plugin guardrails | [Codex plugin](#codex-plugin) | Trust the hooks, run `$setup-agent-guard`, then ask Codex to run `cat .env`; Bash should be blocked. |
+| Codex CLI + Git backstop | [Direct CLI](#direct-cli) + [Native Git hook](#native-git-hook) | Run `agent-guard smoke-test`; commit a staged fixture secret, and it should fail. |
 | Local commits | [Native Git hook](#native-git-hook) | Commit a staged fixture secret; commit should fail. |
 | CI / PRs | [GitHub Actions](#github-actions) | Push a test PR with a gitleaks-detectable fixture; workflow should fail. |
 | Manual scans | [Direct CLI](#direct-cli) | Run `agent-guard smoke-test`. |
@@ -76,7 +76,9 @@ make check
 make smoke-test
 ```
 
-The Claude Code and Codex plugin installs do not put `agent-guard` on your shell `PATH`; install `jq` and `gitleaks` with your package manager for those paths:
+The Claude Code and Codex plugin installs do not put `agent-guard` on your shell `PATH`. In Codex, invoke `$setup-agent-guard`: it checks first, presents the exact host-appropriate install plan, requests approval, and runs `check` plus `smoke-test`. It never installs software merely because a session started. Claude Code users can run the equivalent manual commands below.
+
+Manual macOS equivalent:
 
 ```sh
 brew install jq gitleaks
@@ -95,38 +97,27 @@ Install and verify in [Quick start (Claude Code)](#quick-start-claude-code). Use
 
 ## Codex Plugin
 
-Use the direct CLI plus the native Git hook as the stable Codex path:
+Install from the marketplace:
 
 ```sh
-curl -fsSL https://github.com/JeongJaeSoon/agent-guard/releases/latest/download/bootstrap.sh | sh
-agent-guard scan-working-tree
-~/.agent-guard/install.sh git-hooks
-```
-
-That path gives you on-demand scans and commit-time blocking.
-
-Codex plugin hooks are still behind an under-development Codex feature flag. If you accept that warning and want pre-tool read/write/bash guardrails, enable plugin hooks and install from the marketplace:
-
-```sh
-codex features enable plugin_hooks
 codex plugin marketplace add JeongJaeSoon/agent-guard
 ```
 
-Then open `/plugins` in the Codex TUI, install **Agent Guard**, restart Codex, open `/hooks`, and trust the **PreToolUse**, **PostToolUse**, and **Stop** hooks.
+Then open `/plugins` in Codex, install **Agent Guard**, trust the **SessionStart**, **PreToolUse**, **PostToolUse**, and **Stop** hooks, and restart Codex. SessionStart reports degraded protection when a dependency is unavailable and points Codex to `$setup-agent-guard`; installation remains approval-gated.
 
 Smoke test:
 
 ```text
-Please read .env
+Please run `cat .env` in the shell.
 ```
 
 Expected result:
 
 ```text
-agent-guard: blocked sensitive file access: .env
+agent-guard: blocked shell command referencing a deny-listed path
 ```
 
-Codex does not currently auto-discover this plugin's `commands/` directory. Ask Codex to run the binary directly when you need those workflows:
+Codex loads the plugin's `skills/` directory but does not use the Claude `commands/` directory. Use `$setup-agent-guard` for setup; ask Codex to run the binary directly for other workflows:
 
 ```sh
 ${PLUGIN_ROOT}/bin/agent-guard scan-working-tree
@@ -251,9 +242,8 @@ To enable it, add an Actions secret named `OPENAI_API_KEY` in the GitHub reposit
 
 ## What Gets Blocked
 
-- `Read`, `NotebookRead`, `Grep`, and `Glob` access to deny-listed paths such as `.env*`, private keys, `.aws/credentials`, `.npmrc`, and `.pypirc`
-- `Write`, `Edit`, `MultiEdit`, and Codex `apply_patch` content containing secret-like values
-- `WebFetch`, `WebSearch`, and MCP tool input JSON containing secret-like values
+- On Claude Code: `Read`, `NotebookRead`, `Grep`, and `Glob` access to deny-listed paths; `Write`, `Edit`, and `MultiEdit` secret-like content; and sensitive web/MCP inputs
+- On Codex: supported hook surfaces (`Bash`, `apply_patch`, and MCP tools). Current Codex hooks do not intercept arbitrary Read/Grep/WebSearch calls, so Agent Guard does not claim coverage for them.
 - risky shell commands such as `printenv`, `op read`, `vault kv get`, `aws secretsmanager get-secret-value`, `cat .env`, and `git commit --no-verify`
 - PII in proposed write, shell, web, or MCP inputs — all PII when `AGENT_GUARD_PII_HOOK_MODE=block`, or only Tier-2 PII (credit card, US SSN, Korean resident registration number) when `AGENT_GUARD_PII_HOOK_MODE=mask`
 - staged added lines in the native pre-commit hook
@@ -263,7 +253,7 @@ Patch and diff scans inspect added lines only. Removing an existing leaked value
 
 ## What Gets Masked
 
-Beyond blocking, Agent Guard **masks** secret-like values in a tool's *output* before the model sees them. A `PostToolUse` redactor scans the result of `Bash` (stdout/stderr) and read-style tools (`Read`, `NotebookRead`, `Grep`, `Glob`, `WebFetch`, `WebSearch`, and `mcp__.*`) and rewrites any detected secret to `[REDACTED]` in place via `updatedToolOutput`, preserving the result's shape. This closes the gap where a command *prints* a credential the pre-tool check never saw — e.g. `cat memo.txt`, an env-printing CLI, or a tool that dumps `KEY=value` pairs. Detection combines gitleaks with a `KEY=value` env-assignment heuristic. It is on by default; disable with `AGENT_GUARD_OUTPUT_REDACT=off`.
+Beyond blocking, Agent Guard **masks** secret-like values in a matched tool's output before the model sees them. Claude uses the native `updatedToolOutput` rewrite and preserves the result shape. Codex does not expose that Claude field, so Agent Guard blocks the original sensitive result and supplies a sanitized replacement through `additionalContext`. Detection combines gitleaks with a `KEY=value` env-assignment heuristic. It is on by default; disable with `AGENT_GUARD_OUTPUT_REDACT=off`.
 
 With `AGENT_GUARD_PII_HOOK_MODE=mask`, the same `PostToolUse` redactor also masks **PII** in tool output — email, phone (including Korean mobile), IPv4, credit card, US SSN, and Korean resident registration number become `[PII:TYPE]` placeholders in place. Secret redaction and PII masking compose into a single rewrite, so a result containing both is fully sanitized at once.
 
@@ -271,7 +261,7 @@ With `AGENT_GUARD_PII_HOOK_MODE=mask`, the same `PostToolUse` redactor also mask
 
 The `PostToolUse` redactor only ever sees the results of the agent's *tool calls*. When you type a `!`-prefixed command at the Claude Code prompt, it runs in the session shell and its **output is captured into the transcript and sent to the model** — but it is not a tool call, so **no** Agent Guard hook fires (a documented blind spot). If that output carries a credential, the model sees it unmasked.
 
-`agent-guard exec` closes that gap. It never blocks the command — it runs it to completion and propagates its exit code — but it captures the combined stdout+stderr, masks secret-like values (and PII, when `AGENT_GUARD_PII_HOOK_MODE=mask`) with the same detection engine the output redactor uses, and prints only the **redacted** text. So the command still runs, but everything you and the model see is the sanitized output — the raw secret is never emitted. Capture is buffered, so this is for non-interactive info commands (env / secret / config dumps), not TUIs or streaming programs. `AGENT_GUARD_OUTPUT_REDACT=off` disables secret masking; masking is on by default.
+`agent-guard exec` closes that gap. Before running anything, it verifies that the configured masking dependencies are usable; if they are not, the explicit wrapper fails closed and does not run the command. Once ready, it runs the command to completion, propagates its exit code, captures combined stdout+stderr, and prints only masked text. Capture is buffered, so this is for non-interactive info commands, not TUIs or streaming programs. `AGENT_GUARD_OUTPUT_REDACT=off` explicitly disables secret masking.
 
 ```sh
 agent-guard exec -- printenv          # runs it, but the transcript gets [REDACTED] in place of secrets
@@ -286,26 +276,26 @@ eval "$(agent-guard shell-init)"
 Or let `setup-shell` write (and later update) that line for you — idempotently, and by absolute path when `agent-guard` isn't on your `$PATH` yet:
 
 ```sh
-agent-guard setup-shell            # add `--experimental-bang-guard` to opt into the bang guard below
+agent-guard setup-shell            # add `--claude-bang-guard` to opt into the bang guard below
 ```
 
 This defines `agx` (a thin wrapper for `agent-guard exec --`) so you can run `agx <cmd>` — in Claude Code, `!agx <cmd>` — and have the output masked before the model sees it. It also installs a **warn-only, non-blocking** nudge (a zsh `preexec` / bash `DEBUG` trap) that reminds you to use `agx` when you run a known secret-loading idiom without it. The nudge never blocks or modifies your command; pass `--bash` or `--zsh` to force a target shell.
 
-### Experimental: auto-masking `!` reads (opt-in)
+### Claude bang-command guard (supported opt-in)
 
 The nudge above relies on a `preexec` / `DEBUG` hook — but Claude Code runs `!` commands from a **shell snapshot** that strips those hooks (and `unalias -a`s), so the nudge never fires for `!`. The snapshot *does* keep shell **functions**, so an opt-in flag installs function overrides for the common dump commands instead:
 
 ```sh
-eval "$(agent-guard shell-init --experimental-bang-guard)"
+eval "$(agent-guard shell-init --claude-bang-guard)"
 ```
 
 This overrides `cat`, `head`, and `printenv` so that — **only inside Claude Code** (gated on `$CLAUDECODE`) — they route through `agent-guard exec`, masking their output before the transcript captures it. So `!cat config.txt` gets its secrets redacted automatically, without you remembering to type `agx`. In a normal terminal (`$CLAUDECODE` unset) the overrides stay inert and fall back to plain `cat` / `head` / `printenv` behavior.
 
-The binary is resolved at call time in this order: an explicit `$AGENT_GUARD_BIN`, then `agent-guard` on your `$PATH`, then the **absolute path baked into the snippet** at `shell-init` time. That last fallback means the guard works on a **plugin-only install** — where `agent-guard` is never added to `$PATH` — with no extra CLI install. If none of the three resolve (e.g. a plugin update moved the binary and left the baked path stale), the guard **fails open**: it runs your command but prints a loud `output is NOT masked` warning to stderr telling you to re-run `agent-guard setup-shell`. (`agx`, being an *explicit* mask request, instead fails **closed** — it refuses to run rather than leak.)
+The binary is resolved at call time in this order: an explicit `$AGENT_GUARD_BIN`, then `agent-guard` on your `$PATH`, then the **absolute path baked into the snippet** at `shell-init` time. The transparent bang guard preflights dependencies too. If the binary cannot resolve or protection is degraded, it **fails open** because the user typed an ordinary `cat`/`head`/`printenv`: it runs the command but prints a loud `output is NOT masked` warning. `agx`, being an explicit mask request, instead fails closed.
 
 Because the plugin (auto-updated by `claude plugin update`) and the binary the integration actually resolves update independently, updating only one side can silently leave `agx` / `!`-command masking on older rules. To catch that, the `shell-init` snippet exports `AGENT_GUARD_SHELL_INIT_VERSION` — the version of the binary it resolved at rc-eval time (whichever of the three paths above won) — and a Claude Code `SessionStart` hook compares that marker against the plugin's own version, showing a **non-blocking warning** on mismatch. Because the marker records what the integration resolved at shell start (not a re-derivation the hook would have to guess), it stays silent unless the integration is genuinely loaded *and* drifting: a user who has `agent-guard` on `$PATH` but never ran `setup-shell` gets no warning, and a plugin-only install pinned to a stale baked binary is still covered. It is a start-up snapshot, so if you upgrade the resolved binary *in place* inside a long-lived shell and then launch Claude Code from it without opening a new shell, the warning reflects the version from when that shell started until you re-source your rc.
 
-> **Works without the CLI on `$PATH` — but a plugin can't edit your rc.** The one manual step for a plugin-only install is getting the `shell-init` line into your shell rc so it loads in every shell (hence every Claude Code snapshot). Run `agent-guard setup-shell --experimental-bang-guard` once — invoke it by the plugin binary's absolute path if `agent-guard` isn't on your `$PATH`; it bakes that same absolute path into the line it writes — then restart your shell and any Claude Code session.
+> **Works without the CLI on `$PATH` — but a plugin can't edit your rc.** The one manual step for a plugin-only install is getting the `shell-init` line into your shell rc so it loads in every shell (hence every Claude Code snapshot). Run `agent-guard setup-shell --claude-bang-guard` once — invoke it by the plugin binary's absolute path if `agent-guard` isn't on your `$PATH`; it bakes that same absolute path into the line it writes — then restart your shell and any Claude Code session. The former `--experimental-bang-guard` spelling remains a deprecated compatibility alias and is normalized to the stable option when `setup-shell` rewrites the managed block.
 
 **This is best-effort, not a security control.** It covers only those command names and is trivially bypassed by an absolute path (`/bin/cat`), `source` / `.`, `python -c 'open(...)'`, or a redirection (`< file`). Because `agent-guard exec` buffers the whole output before masking it, **streaming / follow commands would hang** — so `tail` is deliberately *not* wrapped, and you should not `agx` a `tail -f`, a pager, or any long-running program (wrap only terminating dump commands). Output is captured via shell substitution, so wrapping is **text-only** — a binary or NUL-containing read loses embedded NULs and its trailing newline, so use `command cat` / `\cat` for faithful binary output. Each wrapped call also pays a gitleaks scan. Treat it as a convenience nudge for the common cases, not a boundary — the only channel-agnostic fix remains an egress redaction proxy or an upstream `!`-command hook.
 
@@ -318,7 +308,7 @@ Agent Guard is a deterministic, thin guardrail — not a DLP system, EDR, or vau
 - **Path and command blocking use fixed lists.** Read/Grep/Glob blocking matches the paths in `deny-read-paths.txt`; shell blocking matches the idioms in `deny-bash-patterns.txt`. A secret in an unlisted path, or read by an unlisted tool or flag, is not blocked. Extend the lists with `AGENT_GUARD_DENY_READ_PATHS` / `AGENT_GUARD_DENY_BASH_PATTERNS`.
 - **Output masking is best-effort.** Secret-like values in a tool's output (`Bash` stdout/stderr, file reads) are masked in place by the `PostToolUse` redactor (`AGENT_GUARD_OUTPUT_REDACT`, on by default), but detection is heuristic — gitleaks plus a `KEY=value` env-assignment rule. Detection is also **entropy-gated**: a realistic high-entropy credential is masked regardless of context, but a low-entropy value is only caught when its key name looks secret-bearing (`*_TOKEN=`, `PASSWORD:`, …) or its shape carries a distinctive vendor prefix (GitHub `ghp_`/`github_pat_`, AWS `AKIA…`, Anthropic/OpenAI `sk-ant-`/`sk-proj-`, npm `npm_`, GCP `AIza…`, Slack `xox?-`, GitLab `glpat-`, DigitalOcean `dop_v1_` — matched by shape alone, with no entropy filter). A low-entropy secret under a generic variable name with no recognizable prefix passes through unmasked, non-secret-but-sensitive data (internal hostnames, base URLs, private config) is never a match at all, and other unusual or custom secret formats can still slip through. The redactor also only sees results of the agent's *tool calls*. PII masking (`AGENT_GUARD_PII_HOOK_MODE=mask`) is likewise regex-based: it can over-match (a version string read as an IPv4) or miss locale formats it has no rule for. Both the secret redactor and the PII masker walk JSON string *values* only — a secret or PII string that appears as an object *key* is left unmasked, because rewriting keys could collapse two distinct keys onto one placeholder and drop an entry. Treat output masking as defense in depth and keep real secrets and personal data out of agent sessions entirely.
 - **Bash detection is pattern-based.** The denylist targets common-accident and obvious-malicious idioms; an actively-evading agent can craft a command that matches none of them. Treat shell blocking as defense in depth, not a complete adversarial boundary.
-- **User-typed shell-escape commands bypass every hook.** Agent Guard works entirely through tool-use hooks (`PreToolUse` / `PostToolUse`) and git hooks. A command the user runs directly through the host's interactive shell escape — for example a `!`-prefixed command typed at the agent prompt — never becomes a tool call, so **no** Agent Guard hook fires: neither the input block nor the output redactor. A secret that such a command prints (e.g. an env- or vault-reading CLI whose output is not redirected to `/dev/null`) lands in the session transcript unmasked. The recommended mitigation is to run such commands via `agx <cmd>` / `agent-guard exec -- <cmd>` (see [Shell integration](#shell-integration-masking--shell-escape-output)) so their output is masked *before* it reaches the model — or, for automatic masking of the common dump commands, opt into the [experimental bang guard](#experimental-auto-masking--reads-opt-in). Alternatively, run secret-loading commands *through* the agent's tools so the hooks apply, or redirect their output away from the transcript — both streams, since many CLIs print credentials or secret-bearing diagnostics to stderr (`>/dev/null 2>&1`).
+- **User-typed shell-escape commands bypass every hook.** Agent Guard works entirely through tool-use hooks (`PreToolUse` / `PostToolUse`) and git hooks. A command the user runs directly through the host's interactive shell escape — for example a `!`-prefixed command typed at the agent prompt — never becomes a tool call, so **no** Agent Guard hook fires: neither the input block nor the output redactor. A secret that such a command prints (e.g. an env- or vault-reading CLI whose output is not redirected to `/dev/null`) lands in the session transcript unmasked. The recommended mitigation is to run such commands via `agx <cmd>` / `agent-guard exec -- <cmd>` (see [Shell integration](#shell-integration-masking--shell-escape-output)) so their output is masked *before* it reaches the model — or, for automatic masking of the common dump commands, opt into the [Claude bang-command guard](#claude-bang-command-guard-supported-opt-in). Alternatively, run secret-loading commands *through* the agent's tools so the hooks apply, or redirect their output away from the transcript — both streams, since many CLIs print credentials or secret-bearing diagnostics to stderr (`>/dev/null 2>&1`).
 
 For defense in depth, pair Agent Guard with GitHub Secret Scanning / Push Protection and a secrets manager so credentials never reach the working tree.
 
@@ -332,6 +322,8 @@ Override bundled policies with environment variables:
 
 ```sh
 AGENT_GUARD_GITLEAKS_CONFIG=/path/to/gitleaks.toml
+AGENT_GUARD_GITLEAKS_BIN=/absolute/path/to/gitleaks
+AGENT_GUARD_GITLEAKS_BIN_DIR=$HOME/.agent-guard/bin
 AGENT_GUARD_DENY_READ_PATHS=/path/to/deny-read-paths.txt
 AGENT_GUARD_DENY_BASH_PATTERNS=/path/to/deny-bash-patterns.txt
 AGENT_GUARD_PII_PROVIDER=regex
@@ -343,8 +335,9 @@ AGENT_GUARD_OUTPUT_REDACT=mask
 Set `AGENT_GUARD_OUTPUT_REDACT=off` to disable masking secret-like values in tool output (default `mask`). Set `AGENT_GUARD_PII_HOOK_MODE` to `block` (block PII in tool inputs), `mask` (mask PII in tool outputs + hard-block Tier-2 PII inputs), or `off` (default).
 
 Project-local `.gitleaks.toml` files are not automatically trusted.
+Gitleaks resolution is deterministic: `AGENT_GUARD_GITLEAKS_BIN`, then `PATH`, then `AGENT_GUARD_GITLEAKS_BIN_DIR/gitleaks` (default `~/.agent-guard/bin/gitleaks`). This makes the private `setup --install` destination immediately usable without editing `PATH`.
 
-## Checksums and Auto-Install
+## Checksums and Approval-Gated Install
 
 `agent-guard setup --install` can install `gitleaks`, but only with an explicit checksum:
 
@@ -355,7 +348,7 @@ agent-guard setup --install \
   --gitleaks-checksum <sha256-for-this-os-and-arch>
 ```
 
-The checksum helper prints all supported OS / arch values and paste-ready snippets for CLI setup and GitHub Actions.
+The checksum helper prints all supported OS / arch values and paste-ready snippets for CLI setup and GitHub Actions. `$setup-agent-guard` automates the diagnosis and checksum-selection workflow, but still asks before the download or a package-manager change.
 
 ## Host Integrations
 
@@ -363,8 +356,8 @@ Agent Guard shares its scanner implementation across Claude Code and Codex, but 
 
 - `plugins/agent-guard/bin/agent-guard`, `config/`, and `scripts/` are shared.
 - Claude Code uses `.claude-plugin/plugin.json`, `commands/`, and `hooks/hooks.json`.
-- Codex uses `.codex-plugin/plugin.json` and the plugin-root `hooks.json` companion file.
-- Codex does not auto-discover `commands/`, so on-demand workflows use the binary directly.
+- Codex uses `.codex-plugin/plugin.json`, which explicitly declares `hooks.json` and `skills/`; hook commands set `AGENT_GUARD_HOOK_HOST=codex` so output follows the Codex contract.
+- Codex uses `$setup-agent-guard` for guided dependency setup. Claude `commands/` remain Claude-specific; other Codex workflows use the binary directly.
 
 ## Development
 

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -31,7 +31,7 @@ interception point:
 | `read-tool` | `Read`/`Grep`/`Glob` of a sensitive file | `PreToolUse` → block (exit 2) |
 | `bash-read` | a shell command that reads a sensitive file | `PreToolUse` → block |
 | `bash-cmd` | a secret embedded in a shell command | `PreToolUse` → block (gitleaks on the command) |
-| `bash-output` | a secret in `Bash` stdout/stderr | `PostToolUse` → mask (`updatedToolOutput`) |
+| `bash-output` | a secret in `Bash` stdout/stderr | `PostToolUse` → sanitized replacement (`updatedToolOutput` on Claude; block + `additionalContext` on Codex) |
 | `read-output` | a secret in a non-denylisted file's contents | `PostToolUse` → mask |
 | `mcp-output` | a secret in an MCP tool response | `PostToolUse` → mask |
 | `bang` | a `!`-prefixed shell-escape (`!cat .env`) | **none — no hook fires** |

--- a/examples/codex/hooks.json
+++ b/examples/codex/hooks.json
@@ -2,11 +2,11 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Write|Edit|MultiEdit|Read|NotebookRead|Grep|Glob|Bash|WebFetch|WebSearch|apply_patch|mcp__.*",
+        "matcher": "Bash|apply_patch|mcp__.*",
         "hooks": [
           {
             "type": "command",
-            "command": "./plugins/agent-guard/bin/agent-guard hook-pre-tool",
+            "command": "AGENT_GUARD_HOOK_HOST=codex ./plugins/agent-guard/bin/agent-guard hook-pre-tool",
             "timeout": 10
           }
         ]
@@ -14,11 +14,11 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Write|Edit|MultiEdit|Bash|apply_patch|Read|NotebookRead|Grep|Glob|WebFetch|WebSearch|mcp__.*",
+        "matcher": "Bash|apply_patch|mcp__.*",
         "hooks": [
           {
             "type": "command",
-            "command": "./plugins/agent-guard/bin/agent-guard hook-post-tool",
+            "command": "AGENT_GUARD_HOOK_HOST=codex ./plugins/agent-guard/bin/agent-guard hook-post-tool",
             "timeout": 20
           }
         ]
@@ -30,8 +30,20 @@
         "hooks": [
           {
             "type": "command",
-            "command": "./plugins/agent-guard/bin/agent-guard hook-stop",
+            "command": "AGENT_GUARD_HOOK_HOST=codex ./plugins/agent-guard/bin/agent-guard hook-stop",
             "timeout": 20
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "AGENT_GUARD_HOOK_HOST=codex ./plugins/agent-guard/bin/agent-guard hook-session-start",
+            "timeout": 5
           }
         ]
       }

--- a/plugins/agent-guard/.claude-plugin/plugin.json
+++ b/plugins/agent-guard/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-guard",
   "description": "Real-time secret-leak guardrails for AI coding agents (Claude Code, Codex), Git hooks, and CI.",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "author": {
     "name": "Agent Guard contributors"
   }

--- a/plugins/agent-guard/.codex-plugin/plugin.json
+++ b/plugins/agent-guard/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-guard",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "Real-time secret-leak guardrails for AI coding agents (Claude Code, Codex), Git hooks, and CI.",
   "author": {
     "name": "Agent Guard contributors"
@@ -15,6 +15,8 @@
     "hooks",
     "security"
   ],
+  "hooks": "./hooks.json",
+  "skills": "./skills/",
   "interface": {
     "displayName": "Agent Guard",
     "shortDescription": "Real-time secret-leak guardrails for AI coding agents",

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -2,7 +2,7 @@
 set -u
 
 PROGRAM=agent-guard
-VERSION=1.9.0
+VERSION=1.10.0
 
 # Resolve the script's own path, following symlinks. The bootstrap installer
 # drops a symlink at ~/.local/bin/agent-guard that points into ~/.agent-guard/
@@ -51,6 +51,7 @@ sh_squote() {
 GITLEAKS_CONFIG=${AGENT_GUARD_GITLEAKS_CONFIG:-"$ROOT_DIR/config/gitleaks.toml"}
 DENY_READ_PATHS=${AGENT_GUARD_DENY_READ_PATHS:-"$ROOT_DIR/config/deny-read-paths.txt"}
 DENY_BASH_PATTERNS=${AGENT_GUARD_DENY_BASH_PATTERNS:-"$ROOT_DIR/config/deny-bash-patterns.txt"}
+GITLEAKS_PRIVATE_BIN_DIR=${AGENT_GUARD_GITLEAKS_BIN_DIR:-${AGENT_GUARD_BIN_DIR:-$HOME/.agent-guard/bin}}
 
 usage() {
   cat >&2 <<'EOF'
@@ -60,8 +61,8 @@ Usage:
   agent-guard hook-stop
   agent-guard hook-session-start
   agent-guard exec [--] <cmd> [args...]
-  agent-guard shell-init [--bash|--zsh] [--experimental-bang-guard]
-  agent-guard setup-shell [--bash|--zsh|--rc FILE] [--experimental-bang-guard]
+  agent-guard shell-init [--bash|--zsh] [--claude-bang-guard]
+  agent-guard setup-shell [--bash|--zsh|--rc FILE] [--claude-bang-guard]
   agent-guard pii-filter [--check]
   agent-guard scan-staged
   agent-guard scan-working-tree
@@ -87,28 +88,65 @@ need_cmd() {
   command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
 }
 
+resolve_gitleaks() {
+  if [ -n "${AGENT_GUARD_GITLEAKS_BIN:-}" ]; then
+    [ -x "$AGENT_GUARD_GITLEAKS_BIN" ] || return 1
+    printf '%s\n' "$AGENT_GUARD_GITLEAKS_BIN"
+    return 0
+  fi
+  if command -v gitleaks >/dev/null 2>&1; then
+    command -v gitleaks
+    return 0
+  fi
+  if [ -x "$GITLEAKS_PRIVATE_BIN_DIR/gitleaks" ]; then
+    printf '%s\n' "$GITLEAKS_PRIVATE_BIN_DIR/gitleaks"
+    return 0
+  fi
+  return 1
+}
+
 need_gitleaks() {
-  need_cmd gitleaks
+  GITLEAKS_BIN=$(resolve_gitleaks) \
+    || die "required command not found: gitleaks (run \$setup-agent-guard or: $PROGRAM setup)"
   [ -f "$GITLEAKS_CONFIG" ] || die "gitleaks config not found: $GITLEAKS_CONFIG"
+}
+
+hook_dependencies_ready() {
+  command -v jq >/dev/null 2>&1 || return 1
+  resolve_gitleaks >/dev/null 2>&1 || return 1
+  [ -f "$GITLEAKS_CONFIG" ] || return 1
+  [ -f "$DENY_READ_PATHS" ] || return 1
+  [ -f "$DENY_BASH_PATTERNS" ] || return 1
+}
+
+emit_degraded_hook_warning() {
+  event=$1
+  message='agent-guard: protection is DEGRADED because jq, git, gitleaks, or a policy file is unavailable. Run $setup-agent-guard (or agent-guard setup), approve any required installation, verify with agent-guard check and smoke-test, then restart the host.'
+  info "$message"
+  case "$event" in
+    PreToolUse|PostToolUse)
+      printf '{"hookSpecificOutput":{"hookEventName":"%s","additionalContext":"%s"}}\n' "$event" "$message"
+      ;;
+  esac
 }
 
 check_deps() {
   need_cmd sh
   need_cmd jq
   need_cmd git
-  need_cmd gitleaks
+  need_gitleaks
   [ -f "$GITLEAKS_CONFIG" ] || die "gitleaks config not found: $GITLEAKS_CONFIG"
   [ -f "$DENY_READ_PATHS" ] || die "deny read policy not found: $DENY_READ_PATHS"
   [ -f "$DENY_BASH_PATTERNS" ] || die "deny bash policy not found: $DENY_BASH_PATTERNS"
   info "$PROGRAM: dependencies ok"
-  gl_version=$(gitleaks version 2>/dev/null | head -1)
+  gl_version=$("$GITLEAKS_BIN" version 2>/dev/null | head -1)
   if [ -n "$gl_version" ]; then
     info "$PROGRAM: gitleaks $gl_version (>= 8.30 recommended)"
   fi
 }
 
 GITLEAKS_DEFAULT_VERSION=8.30.1
-SETUP_INSTALL_DIR=${AGENT_GUARD_BIN_DIR:-$HOME/.agent-guard/bin}
+SETUP_INSTALL_DIR=$GITLEAKS_PRIVATE_BIN_DIR
 
 setup_status_line() {
   name=$1
@@ -121,6 +159,20 @@ setup_status_line() {
     return 0
   fi
   info "$PROGRAM: $name  missing"
+  return 1
+}
+
+setup_gitleaks_status_line() {
+  if gl=$(resolve_gitleaks); then
+    ver=$("$gl" version 2>/dev/null | head -1)
+    info "$PROGRAM: gitleaks  ok  (${ver:-installed}; $gl)"
+    return 0
+  fi
+  if [ -n "${AGENT_GUARD_GITLEAKS_BIN:-}" ]; then
+    info "$PROGRAM: gitleaks  missing (AGENT_GUARD_GITLEAKS_BIN is not executable: $AGENT_GUARD_GITLEAKS_BIN)"
+  else
+    info "$PROGRAM: gitleaks  missing"
+  fi
   return 1
 }
 
@@ -230,11 +282,11 @@ EOF
   jq_ok=1; gitleaks_ok=1
   setup_status_line jq       || jq_ok=0
   setup_status_line git      || :
-  setup_status_line gitleaks || gitleaks_ok=0
+  setup_gitleaks_status_line || gitleaks_ok=0
 
   if [ "$install" -eq 1 ]; then
     if [ "$gitleaks_ok" -eq 1 ]; then
-      info "$PROGRAM: gitleaks already on PATH; skipping --install"
+      info "$PROGRAM: gitleaks already available; skipping --install"
     else
       setup_install_gitleaks "$version" "$checksum"
     fi
@@ -298,7 +350,7 @@ smoke_test() {
 
   mkdir -p "$tmp/clean" "$tmp/dirty"
   printf '%s\n' "console.log('ok')" >"$tmp/clean/app.js"
-  write_private_key_fixture "$tmp/dirty/key.pem"
+  write_private_key_fixture "$tmp/dirty/private-key-fixture.txt"
 
   smoke_expect 0 "scan-path allows a clean directory" scan_path "$tmp/clean"
   smoke_expect 1 "scan-path blocks a private-key fixture" scan_path "$tmp/dirty"
@@ -311,8 +363,8 @@ smoke_test() {
 
   write_payload=$(mktemp_file) || die "smoke: failed to create temp file"
   {
-    printf '%s' '{"tool_name":"Write","tool_input":{"file_path":"key.pem","content":"'
-    sed 's/\\/\\\\/g; s/"/\\"/g; s/$/\\n/' "$tmp/dirty/key.pem" | tr -d '\n'
+    printf '%s' '{"tool_name":"Write","tool_input":{"file_path":"guard-fixture.txt","content":"'
+    sed 's/\\/\\\\/g; s/"/\\"/g; s/$/\\n/' "$tmp/dirty/private-key-fixture.txt" | tr -d '\n'
     printf '%s\n' '"}}'
   } >"$write_payload"
   smoke_expect 2 "hook-pre-tool blocks secret-like writes" hook_pre_tool <"$write_payload"
@@ -336,8 +388,8 @@ smoke_test() {
     } >githooks/pre-commit
     chmod +x githooks/pre-commit || exit 2
     git config core.hooksPath githooks || exit 2
-    write_private_key_fixture leak.pem
-    git add leak.pem || exit 2
+    write_private_key_fixture staged-fixture.txt
+    git add staged-fixture.txt || exit 2
     git commit -m leak >/dev/null 2>&1
     status=$?
     [ "$status" -ne 0 ] || exit 1
@@ -569,7 +621,7 @@ check_pii_hook_input() {
       ;;
     apply_patch)
       patch=$(printf '%s' "$input" | jq -r '
-        .tool_input.patch // .tool_input.input // .tool_input.diff // .tool_input.content // empty
+        .tool_input.command // .tool_input.patch // .tool_input.input // .tool_input.diff // .tool_input.content // empty
         | if type == "string" then . else tojson end
       ')
       added=$(printf '%s\n' "$patch" | extract_patch_added_lines)
@@ -592,10 +644,18 @@ check_pii_hook_input() {
 
 run_gitleaks_stdin() {
   label=$1
+  need_gitleaks
   out=$(mktemp_file) || die "failed to create temp file"
-  gitleaks stdin --redact --no-banner --config "$GITLEAKS_CONFIG" --exit-code 1 >"$out" 2>&1
+  "$GITLEAKS_BIN" stdin --redact --no-banner --no-color --log-level error \
+    --config "$GITLEAKS_CONFIG" --exit-code 1 >"$out" 2>&1
   status=$?
   if [ "$status" -eq 0 ]; then
+    if [ -s "$out" ]; then
+      info "$PROGRAM: gitleaks reported an error while scanning $label"
+      sed 's/^/  /' "$out" >&2
+      rm -f "$out"
+      return 2
+    fi
     rm -f "$out"
     return 0
   fi
@@ -775,9 +835,17 @@ scan_path() {
   for path in "$@"; do
     [ -e "$path" ] || die "path not found: $path"
     out=$(mktemp_file) || die "failed to create temp file"
-    gitleaks dir "$path" --redact --no-banner --config "$GITLEAKS_CONFIG" --exit-code 1 >"$out" 2>&1
+    "$GITLEAKS_BIN" dir "$path" --redact --no-banner --no-color --log-level error \
+      --config "$GITLEAKS_CONFIG" --exit-code 1 >"$out" 2>&1
     status=$?
     if [ "$status" -eq 0 ]; then
+      if [ -s "$out" ]; then
+        info "$PROGRAM: gitleaks reported an error while scanning path: $path"
+        sed 's/^/  /' "$out" >&2
+        result=2
+        rm -f "$out"
+        continue
+      fi
       rm -f "$out"
       continue
     fi
@@ -1065,6 +1133,77 @@ shell_dequote_for_policy() {
   '
 }
 
+# Remove only exclusion operands whose command context proves they do not name a
+# file to read. This is intentionally narrow: globally dropping `!*.pem` would
+# turn a literal path such as `cat '!secret.pem'` into a policy bypass. Ripgrep's
+# negative glob is common in repository scans and has an unambiguous grammar.
+bash_strip_exclusion_operands() {
+  (
+    set -f
+    words=$(shell_command_words "$1")
+    # shellcheck disable=SC2086
+    set -- $words
+    result= command_name= pending_glob=
+
+    append_policy_token() {
+      if [ -z "$result" ]; then result=$1; else result="$result $1"; fi
+    }
+    is_negative_glob_value() {
+      value=$1
+      case "$value" in
+        \'*\') value=${value#\'}; value=${value%\'} ;;
+        \"*\") value=${value#\"}; value=${value%\"} ;;
+      esac
+      case "$value" in !*) return 0 ;; *) return 1 ;; esac
+    }
+
+    for token in "$@"; do
+      if is_shell_command_separator "$token"; then
+        [ -n "$pending_glob" ] && append_policy_token "$pending_glob"
+        pending_glob=
+        append_policy_token "$token"
+        command_name=
+        continue
+      fi
+
+      if [ -z "$command_name" ]; then
+        if is_assignment_token "$token" || is_noop_wrapper "${token##*/}"; then
+          append_policy_token "$token"
+          continue
+        fi
+        command_name=${token##*/}
+        command_name=$(printf '%s' "$command_name" | tr -d "'\"")
+        append_policy_token "$token"
+        continue
+      fi
+
+      if [ "$command_name" = rg ]; then
+        if [ -n "$pending_glob" ]; then
+          if is_negative_glob_value "$token"; then
+            pending_glob=
+            continue
+          fi
+          append_policy_token "$pending_glob"
+          pending_glob=
+        fi
+        case "$token" in
+          -g|--glob|--iglob)
+            pending_glob=$token
+            continue
+            ;;
+          --glob=*|--iglob=*)
+            value=${token#*=}
+            is_negative_glob_value "$value" && continue
+            ;;
+        esac
+      fi
+      append_policy_token "$token"
+    done
+    [ -n "$pending_glob" ] && append_policy_token "$pending_glob"
+    printf '%s' "$result"
+  )
+}
+
 # Drop tokens that name an allowed `.env` template (e.g. `.env.example`) before
 # the whole-command deny regex runs, so `cat .env.example` is allowed while
 # `cat .env.example .env` still blocks on the bare `.env` token. Globbing is
@@ -1093,6 +1232,7 @@ bash_strip_allowed_tokens() {
 
 bash_matches_deny_path() {
   cmd=$1
+  cmd=$(bash_strip_exclusion_operands "$cmd")
   cmd=$(bash_strip_allowed_tokens "$cmd")
   bash_matches_deny_path_mode "$cmd" "literal" && return 0
   bash_matches_deny_path_mode "$cmd" "shell-expanded" && return 0
@@ -1281,12 +1421,21 @@ is_git_hook_bypass() {
 
 check_git_command() {
   cmd=$1
+  workdir=${2:-}
   if is_git_commit_or_push "$cmd"; then
     if is_git_hook_bypass "$cmd"; then
       info "$PROGRAM: blocked git command that disables hooks/signing"
       exit 2
     fi
-    scan_staged
+    if [ -n "$workdir" ]; then
+      (
+        CDPATH= cd -- "$workdir" 2>/dev/null \
+          || die "hook workdir is not accessible: $workdir"
+        scan_staged
+      )
+    else
+      scan_staged
+    fi
     block_on_scan_status "$?" "staged changes contain secret-like values; blocking git command"
   fi
 }
@@ -1296,6 +1445,7 @@ check_bash_command() {
   need_cmd jq
   cmd=$(json_value '.tool_input.command // .tool_input.cmd // empty' "$input")
   [ -n "$cmd" ] || return 0
+  workdir=$(json_value '.tool_input.workdir // .tool_input.cwd // .cwd // empty' "$input")
 
   [ -f "$DENY_BASH_PATTERNS" ] || die "deny bash policy not found: $DENY_BASH_PATTERNS"
   patterns=$(mktemp_file) || die "failed to create temp file"
@@ -1329,7 +1479,7 @@ check_bash_command() {
   scan_text_direct "shell command" "$cmd"
   block_on_scan_status "$?" "shell command contains secret-like values"
 
-  check_git_command "$cmd"
+  check_git_command "$cmd" "$workdir"
 }
 
 scan_tool_input() {
@@ -1374,7 +1524,7 @@ scan_proposed_write() {
       ;;
     apply_patch)
       patch=$(printf '%s' "$input" | jq -r '
-        .tool_input.patch // .tool_input.input // .tool_input.diff // .tool_input.content // empty
+        .tool_input.command // .tool_input.patch // .tool_input.input // .tool_input.diff // .tool_input.content // empty
         | if type == "string" then . else tojson end
       ')
       added=$(printf '%s\n' "$patch" | extract_patch_added_lines)
@@ -1429,6 +1579,10 @@ check_broad_grep_content() {
 }
 
 hook_pre_tool() {
+  if ! hook_dependencies_ready; then
+    emit_degraded_hook_warning PreToolUse
+    return 0
+  fi
   need_cmd jq
   input=$(cat)
   [ -n "$input" ] || return 0
@@ -1491,9 +1645,9 @@ is_mutation_tool() {
 # see what a command PRINTS or what a file read RETURNS. A shell command that
 # dumps credentials to stdout (an env-printing CLI, `cat` of a secret-bearing
 # note) therefore leaks the secret into the model context unscanned. PostToolUse
-# can rewrite an already-produced result before the model sees it via
-# `hookSpecificOutput.updatedToolOutput` (Claude Code >= 2.1.121), so here we
-# scan the tool_response and mask any secret-like spans in place.
+# can replace an already-produced result before the model sees it. Claude uses
+# `hookSpecificOutput.updatedToolOutput`; Codex blocks the original result and
+# receives a sanitized replacement in `additionalContext`.
 #
 # Fail-safe: this path runs for (potentially) every tool result, so any error
 # emits NOTHING and lets the original output through unchanged. A redaction bug
@@ -1547,11 +1701,11 @@ detect_output_secrets() {
     # tool results reaching the hook are already harness-truncated; if a large
     # WebFetch/MCP stream ever dominates latency, gate this on a size cap or an
     # in-process pre-filter before the fork.
-    if command -v gitleaks >/dev/null 2>&1 && [ -f "$GITLEAKS_CONFIG" ]; then
+    if gl=$(resolve_gitleaks) && [ -f "$GITLEAKS_CONFIG" ]; then
       report=$(mktemp_file) || report=''
       if [ -n "$report" ]; then
         printf '%s\n' "$text" \
-          | gitleaks stdin --report-format json --report-path "$report" \
+          | "$gl" stdin --report-format json --report-path "$report" \
               --no-banner --config "$GITLEAKS_CONFIG" >/dev/null 2>&1
         [ -s "$report" ] && jq -r '.[]?.Secret // empty' "$report" 2>/dev/null
         rm -f "$report"
@@ -1670,10 +1824,25 @@ redact_tool_output() {
 
   [ "$out" != "$resp" ] || return 0
 
-  printf '%s' "$input" \
-    | jq -c --argjson ut "$out" \
-        '{hookSpecificOutput: {hookEventName: "PostToolUse", updatedToolOutput: $ut}}' 2>/dev/null \
-    || return 0
+  case "${AGENT_GUARD_HOOK_HOST:-claude}" in
+    codex)
+      printf '%s' "$input" \
+        | jq -c --argjson ut "$out" '
+            {decision: "block",
+             reason: "Agent Guard blocked the original tool output because it contained sensitive values; use the sanitized replacement in additionalContext.",
+             hookSpecificOutput: {
+               hookEventName: "PostToolUse",
+               additionalContext: ("Agent Guard sanitized tool output:\n" + ($ut | tojson))
+             }}' 2>/dev/null \
+        || return 0
+      ;;
+    *)
+      printf '%s' "$input" \
+        | jq -c --argjson ut "$out" \
+            '{hookSpecificOutput: {hookEventName: "PostToolUse", updatedToolOutput: $ut}}' 2>/dev/null \
+        || return 0
+      ;;
+  esac
 
   tool=$(json_value '.tool_name // "tool"' "$input")
   if [ "$did_secret" -eq 1 ] && [ "$did_pii" -eq 1 ]; then
@@ -1687,6 +1856,10 @@ redact_tool_output() {
 }
 
 hook_post_tool() {
+  if ! hook_dependencies_ready; then
+    emit_degraded_hook_warning PostToolUse
+    return 0
+  fi
   need_cmd jq
   input=$(cat)
   [ -n "$input" ] || return 0
@@ -1695,20 +1868,24 @@ hook_post_tool() {
   # Mutation tools keep the working-tree backstop (may exit 2). It runs first so
   # a secret written to disk is still surfaced even when redaction is enabled.
   if is_mutation_tool "$tool"; then
-    need_cmd git
-    if inside_git_repo; then
+    if ! command -v git >/dev/null 2>&1; then
+      info "$PROGRAM: git is unavailable; skipping the post-tool working-tree backstop"
+    elif inside_git_repo; then
       scan_working_tree
       block_on_scan_status "$?" "changed files contain secret-like values after tool execution"
     fi
   fi
 
   # All matched tools: mask secret-like values (and PII, when
-  # AGENT_GUARD_PII_HOOK_MODE=mask) in the tool's output before the model sees
-  # them (may emit updatedToolOutput and exit 0).
+  # AGENT_GUARD_PII_HOOK_MODE=mask) using the selected host's output contract.
   redact_tool_output "$input"
 }
 
 hook_stop() {
+  if ! hook_dependencies_ready || ! command -v git >/dev/null 2>&1; then
+    emit_degraded_hook_warning Stop
+    return 0
+  fi
   need_cmd jq
   need_cmd git
   input=$(cat)
@@ -1726,7 +1903,7 @@ hook_stop() {
   block_on_scan_status "$?" "changed files contain secret-like values before stop"
 }
 
-# --- hook-session-start: warn when shell-integration masking drifts -----------
+# --- hook-session-start: report degraded setup and shell-integration drift ----
 # The plugin and the binary the shell integration (agx / bang guard) resolves at
 # runtime update independently, so updating one side silently leaves masking on
 # the OLD rules while the hooks look current — an invisible failure. Instead of
@@ -1742,24 +1919,37 @@ hook_stop() {
 # launched from a shell that sourced the rc, the marker is absent AND the
 # integration is inactive, so silence is correct (nothing is masking to drift).
 #
-# Output contract (SessionStart, per the docs): plain stdout on exit 0 is
-# injected into Claude's CONTEXT, and a non-zero exit renders as a "hook error"
-# notice — neither is a clean user-facing warning. The top-level `systemMessage`
-# JSON field on exit 0 is the documented non-blocking way to show the user a
-# message, so that is what this emits. Stays SILENT (exit 0, no output) when the
-# marker is absent (integration not loaded), equals the plugin version, or is
-# unparseable — a warn-only hook must never become session-start noise or block.
+# SessionStart is non-mutating: it reports missing dependencies and directs the
+# host to the approval-gated setup skill. It also reports Claude shell-wrapper
+# version drift. The Codex variant duplicates the message in additionalContext
+# so the model can act on it; both hosts receive a user-facing systemMessage.
 hook_session_start() {
+  message=
+  if ! hook_dependencies_ready || ! command -v git >/dev/null 2>&1; then
+    message='agent-guard protection is DEGRADED because jq, git, gitleaks, or a policy file is unavailable. Run $setup-agent-guard (or agent-guard setup), approve any required installation, verify with agent-guard check and smoke-test, then restart the host.'
+  fi
+
   marker=${AGENT_GUARD_SHELL_INIT_VERSION:-}
   # Accept only a digit-led version token drawn from a safe charset: an empty or
   # unparseable marker fails quiet, and the charset keeps the hand-built JSON
   # below injection-safe (no quotes/backslashes/whitespace to escape).
   case $marker in
-    ''|[!0-9]*|*[!0-9A-Za-z.+-]*) return 0 ;;
+    ''|[!0-9]*|*[!0-9A-Za-z.+-]*) ;;
+    *)
+      if [ "$marker" != "$VERSION" ]; then
+        drift="agent-guard plugin hooks are $VERSION but the Claude shell integration masks with $marker. Update whichever is older, then rerun agent-guard setup-shell."
+        if [ -n "$message" ]; then message="$message $drift"; else message=$drift; fi
+      fi
+      ;;
   esac
-  [ "$marker" != "$VERSION" ] || return 0
-  printf '{"systemMessage":"%s"}\n' \
-    "agent-guard: plugin hooks are $VERSION but the shell integration (agx / bang-guard) masks with $marker - update whichever is older (re-run the installer for the CLI, or 'claude plugin update' for the plugin), then re-run: agent-guard setup-shell"
+
+  [ -n "$message" ] || return 0
+  case "${AGENT_GUARD_HOOK_HOST:-claude}" in
+    codex)
+      printf '{"systemMessage":"%s","hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"%s"}}\n' "$message" "$message"
+      ;;
+    *) printf '{"systemMessage":"%s"}\n' "$message" ;;
+  esac
 }
 
 # --- exec: mask secrets/PII in a shell-escape command's captured output -------
@@ -1767,10 +1957,11 @@ hook_session_start() {
 # and its OUTPUT is captured into the transcript and sent to the model, but NO
 # agent-guard hook fires for `!` (a documented blind spot). The user is fine with
 # the command running and seeing its output themselves; the risk is secret-bearing
-# output reaching the model. `agent-guard exec` closes that gap: it RUNS the
-# command (never blocks), captures combined stdout+stderr, masks secret-like
-# values (and PII, when enabled), prints the REDACTED text, and propagates the
-# command's exit code. Capture is BUFFERED, so this is for NON-INTERACTIVE info
+# output reaching the model. `agent-guard exec` closes that gap: it first checks
+# that masking is available (and fails closed before execution when it is not),
+# then captures combined stdout+stderr, masks secret-like values (and PII, when
+# enabled), prints the REDACTED text, and propagates the command's exit code.
+# Capture is BUFFERED, so this is for NON-INTERACTIVE info
 # commands (env / secret / config dumps), not TUIs or streaming programs.
 
 # Literal (non-regex) replacement of every detected secret in $1 with [REDACTED],
@@ -1827,6 +2018,13 @@ do_exec() {
   # Validate the PII mode up front so a misconfiguration fails loud (pii_hook_mode
   # dies on an unsupported value) instead of silently leaving PII unmasked.
   pii_hook_mode >/dev/null
+  if output_redact_enabled; then
+    need_cmd jq
+    need_gitleaks
+  fi
+  if [ "$(pii_hook_mode)" = mask ]; then
+    need_cmd awk
+  fi
 
   out=$("$@" 2>&1)
   status=$?
@@ -1870,10 +2068,11 @@ shell_init_target() {
     case "$1" in
       --bash) target=bash ;;
       --zsh) target=zsh ;;
-      # Handled separately in shell_init(); accepted here so parsing doesn't die.
-      --experimental-bang-guard) : ;;
+      # Handled separately in shell_init(); the experimental spelling remains a
+      # deprecated compatibility alias for rc files written by older releases.
+      --claude-bang-guard|--experimental-bang-guard) : ;;
       -h|--help) target=help ;;
-      *) die "shell-init: unknown argument: $1 (expected --bash, --zsh, or --experimental-bang-guard)" ;;
+      *) die "shell-init: unknown argument: $1 (expected --bash, --zsh, or --claude-bang-guard)" ;;
     esac
     shift
   done
@@ -1924,9 +2123,9 @@ esac
 EOF
 }
 
-# EXPERIMENTAL, opt-in (`shell-init --experimental-bang-guard`). Emit function
-# overrides for the common file/env dump commands so `!`-typed reads are routed
-# through `agent-guard exec` (output masked) BEFORE the transcript captures them.
+# Supported opt-in (`shell-init --claude-bang-guard`). Emit function overrides
+# for common file/env dump commands so `!`-typed reads are routed through
+# `agent-guard exec` (output masked) BEFORE the transcript captures them.
 #
 # Why functions, not the preexec nudge above: Claude Code builds a "shell
 # snapshot" of your interactive shell for `!` commands. That snapshot runs
@@ -1947,7 +2146,7 @@ EOF
 #     without this flag). This guard targets text config/secret dumps, not blobs.
 shell_init_bang_guard() {
   cat <<'EOF'
-# --- agent-guard EXPERIMENTAL bang-command guard (opt-in) --------------------
+# --- agent-guard Claude bang-command guard (supported opt-in) ----------------
 # Routes `!`-typed dump commands through `agent-guard exec` so their output is
 # masked before Claude Code captures it. Active ONLY inside Claude Code
 # ($CLAUDECODE); inert in a normal terminal. Best-effort — see docs.
@@ -1962,7 +2161,12 @@ __agentguard_guard() {  # $1 = real command name, remaining args forwarded
     # process, where these overrides do not exist, so the real binary runs with
     # no re-entry (no inner `command` needed).
     if __ag_exe=$(__agentguard_exe); then
-      command "$__ag_exe" exec -- "$__ag_cmd" "$@"
+      if command "$__ag_exe" check >/dev/null 2>&1; then
+        command "$__ag_exe" exec -- "$__ag_cmd" "$@"
+        return
+      fi
+      printf 'agent-guard: bang-guard dependencies are not ready; %s output is NOT masked. Run: agent-guard setup\n' "$__ag_cmd" >&2
+      command "$__ag_cmd" "$@"
       return
     fi
     # Unlike agx, this is a TRANSPARENT override (the user just typed `cat`), so
@@ -1992,14 +2196,17 @@ shell_init() {
   target=$(shell_init_target "$@")
   bang_guard=0
   for __ag_arg in "$@"; do
-    [ "$__ag_arg" = --experimental-bang-guard ] && bang_guard=1
+    case "$__ag_arg" in
+      --claude-bang-guard|--experimental-bang-guard) bang_guard=1 ;;
+    esac
   done
   if [ "$target" = help ]; then
     {
-      printf '%s\n' "Usage: $PROGRAM shell-init [--bash|--zsh] [--experimental-bang-guard]"
+      printf '%s\n' "Usage: $PROGRAM shell-init [--bash|--zsh] [--claude-bang-guard]"
       printf '%s\n' "Emits a shell snippet for: eval \"\$($PROGRAM shell-init)\""
-      printf '%s\n' "  --experimental-bang-guard  also override cat/head/printenv so"
-      printf '%s\n' "                             \`!\`-typed reads are masked inside Claude Code"
+      printf '%s\n' "  --claude-bang-guard       also override cat/head/printenv so"
+      printf '%s\n' "                            \`!\`-typed reads are masked inside Claude Code"
+      printf '%s\n' "  --experimental-bang-guard deprecated alias for --claude-bang-guard"
     } >&2
     return 0
   fi
@@ -2129,12 +2336,13 @@ do_setup_shell() {
       --bash) sh_target=bash ;;
       --zsh) sh_target=zsh ;;
       --rc) shift; rc=${1:-}; [ -n "$rc" ] || die "setup-shell: --rc requires a path" ;;
-      --experimental-bang-guard) bang=' --experimental-bang-guard' ;;
+      --claude-bang-guard|--experimental-bang-guard) bang=' --claude-bang-guard' ;;
       -h|--help)
         {
-          printf '%s\n' "Usage: $PROGRAM setup-shell [--bash|--zsh|--rc FILE] [--experimental-bang-guard]"
+          printf '%s\n' "Usage: $PROGRAM setup-shell [--bash|--zsh|--rc FILE] [--claude-bang-guard]"
           printf '%s\n' "Adds the shell-init line to your shell rc (idempotent). Restart your"
           printf '%s\n' "shell and any Claude Code session afterwards to apply."
+          printf '%s\n' "--experimental-bang-guard remains a deprecated compatibility alias."
         } >&2
         return 0 ;;
       *) die "setup-shell: unknown option: $1 (see: $PROGRAM setup-shell --help)" ;;
@@ -2158,7 +2366,7 @@ do_setup_shell() {
   # stdout, and fall back to the baked absolute path whenever it is empty — whether
   # because the bare name left $PATH (CLI uninstalled, plugin-only left) OR because
   # a stale/stub `agent-guard` earlier on $PATH errored or emitted nothing (e.g. an
-  # older build that rejects --experimental-bang-guard). Either way the guard still
+  # older build that rejects --claude-bang-guard). Either way the guard still
   # installs from $SELF_BIN instead of silently vanishing. The probe's stderr is
   # suppressed (it is speculative and handled); the fallback runs unmuted. Without
   # this, snippet generation could fail and the runtime resolver can't help once the

--- a/plugins/agent-guard/hooks.json
+++ b/plugins/agent-guard/hooks.json
@@ -2,11 +2,11 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Write|Edit|MultiEdit|Read|NotebookRead|Grep|Glob|Bash|WebFetch|WebSearch|apply_patch|mcp__.*",
+        "matcher": "Bash|apply_patch|mcp__.*",
         "hooks": [
           {
             "type": "command",
-            "command": "sh -c '[ -n \"${PLUGIN_ROOT:-}\" ] || { echo \"agent-guard: PLUGIN_ROOT env not set\" >&2; exit 2; }; \"${PLUGIN_ROOT}/bin/agent-guard\" hook-pre-tool'",
+            "command": "sh -c '[ -n \"${PLUGIN_ROOT:-}\" ] || { echo \"agent-guard: PLUGIN_ROOT env not set\" >&2; exit 2; }; AGENT_GUARD_HOOK_HOST=codex \"${PLUGIN_ROOT}/bin/agent-guard\" hook-pre-tool'",
             "timeout": 10
           }
         ]
@@ -14,11 +14,11 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Write|Edit|MultiEdit|Bash|apply_patch|Read|NotebookRead|Grep|Glob|WebFetch|WebSearch|mcp__.*",
+        "matcher": "Bash|apply_patch|mcp__.*",
         "hooks": [
           {
             "type": "command",
-            "command": "sh -c '[ -n \"${PLUGIN_ROOT:-}\" ] || { echo \"agent-guard: PLUGIN_ROOT env not set\" >&2; exit 2; }; \"${PLUGIN_ROOT}/bin/agent-guard\" hook-post-tool'",
+            "command": "sh -c '[ -n \"${PLUGIN_ROOT:-}\" ] || { echo \"agent-guard: PLUGIN_ROOT env not set\" >&2; exit 2; }; AGENT_GUARD_HOOK_HOST=codex \"${PLUGIN_ROOT}/bin/agent-guard\" hook-post-tool'",
             "timeout": 20
           }
         ]
@@ -30,8 +30,20 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sh -c '[ -n \"${PLUGIN_ROOT:-}\" ] || { echo \"agent-guard: PLUGIN_ROOT env not set\" >&2; exit 2; }; \"${PLUGIN_ROOT}/bin/agent-guard\" hook-stop'",
+            "command": "sh -c '[ -n \"${PLUGIN_ROOT:-}\" ] || { echo \"agent-guard: PLUGIN_ROOT env not set\" >&2; exit 2; }; AGENT_GUARD_HOOK_HOST=codex \"${PLUGIN_ROOT}/bin/agent-guard\" hook-stop'",
             "timeout": 20
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c '[ -n \"${PLUGIN_ROOT:-}\" ] || { echo \"agent-guard: PLUGIN_ROOT env not set\" >&2; exit 2; }; AGENT_GUARD_HOOK_HOST=codex \"${PLUGIN_ROOT}/bin/agent-guard\" hook-session-start'",
+            "timeout": 5
           }
         ]
       }

--- a/plugins/agent-guard/hooks/hooks.json
+++ b/plugins/agent-guard/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sh -c '[ -n \"${CLAUDE_PLUGIN_ROOT:-}\" ] || { echo \"agent-guard: CLAUDE_PLUGIN_ROOT env not set\" >&2; exit 2; }; \"${CLAUDE_PLUGIN_ROOT}/bin/agent-guard\" hook-pre-tool'",
+            "command": "sh -c '[ -n \"${CLAUDE_PLUGIN_ROOT:-}\" ] || { echo \"agent-guard: CLAUDE_PLUGIN_ROOT env not set\" >&2; exit 2; }; AGENT_GUARD_HOOK_HOST=claude \"${CLAUDE_PLUGIN_ROOT}/bin/agent-guard\" hook-pre-tool'",
             "timeout": 10
           }
         ]
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sh -c '[ -n \"${CLAUDE_PLUGIN_ROOT:-}\" ] || { echo \"agent-guard: CLAUDE_PLUGIN_ROOT env not set\" >&2; exit 2; }; \"${CLAUDE_PLUGIN_ROOT}/bin/agent-guard\" hook-post-tool'",
+            "command": "sh -c '[ -n \"${CLAUDE_PLUGIN_ROOT:-}\" ] || { echo \"agent-guard: CLAUDE_PLUGIN_ROOT env not set\" >&2; exit 2; }; AGENT_GUARD_HOOK_HOST=claude \"${CLAUDE_PLUGIN_ROOT}/bin/agent-guard\" hook-post-tool'",
             "timeout": 20
           }
         ]
@@ -30,7 +30,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "sh -c '[ -n \"${CLAUDE_PLUGIN_ROOT:-}\" ] || { echo \"agent-guard: CLAUDE_PLUGIN_ROOT env not set\" >&2; exit 2; }; \"${CLAUDE_PLUGIN_ROOT}/bin/agent-guard\" hook-stop'",
+            "command": "sh -c '[ -n \"${CLAUDE_PLUGIN_ROOT:-}\" ] || { echo \"agent-guard: CLAUDE_PLUGIN_ROOT env not set\" >&2; exit 2; }; AGENT_GUARD_HOOK_HOST=claude \"${CLAUDE_PLUGIN_ROOT}/bin/agent-guard\" hook-stop'",
             "timeout": 20
           }
         ]
@@ -38,11 +38,11 @@
     ],
     "SessionStart": [
       {
-        "matcher": "startup|resume|clear",
+        "matcher": "startup|resume|clear|compact",
         "hooks": [
           {
             "type": "command",
-            "command": "sh -c '[ -n \"${CLAUDE_PLUGIN_ROOT:-}\" ] || { echo \"agent-guard: CLAUDE_PLUGIN_ROOT env not set\" >&2; exit 2; }; \"${CLAUDE_PLUGIN_ROOT}/bin/agent-guard\" hook-session-start'",
+            "command": "sh -c '[ -n \"${CLAUDE_PLUGIN_ROOT:-}\" ] || { echo \"agent-guard: CLAUDE_PLUGIN_ROOT env not set\" >&2; exit 2; }; AGENT_GUARD_HOOK_HOST=claude \"${CLAUDE_PLUGIN_ROOT}/bin/agent-guard\" hook-session-start'",
             "timeout": 5
           }
         ]

--- a/plugins/agent-guard/skills/setup-agent-guard/SKILL.md
+++ b/plugins/agent-guard/skills/setup-agent-guard/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: setup-agent-guard
+description: Diagnose, install, and verify the jq and gitleaks dependencies required by the Agent Guard plugin. Use when Agent Guard reports degraded protection, a SessionStart warning asks for setup, plugin hooks fail because a dependency is missing, or a user asks to finish or repair Agent Guard installation.
+---
+
+# Setup Agent Guard
+
+Make Agent Guard operational without silently changing the machine. Diagnose first, request approval before package-manager or download actions, and finish with a real smoke test.
+
+## Workflow
+
+1. Resolve the Agent Guard executable.
+   - Prefer `command -v agent-guard`.
+   - If it is not on `PATH`, use the plugin binary two directories above this skill: `../../bin/agent-guard` relative to this `SKILL.md` directory.
+   - Do not install a second copy of Agent Guard merely to get a command on `PATH`.
+
+2. Run the read-only diagnosis:
+
+   ```sh
+   "<agent-guard-bin>" setup
+   ```
+
+3. If `jq` is missing, identify the available system package manager and show the exact install command. Ask for explicit user approval before running it. Do not use `sudo` unless the user explicitly approves elevated installation.
+
+4. If `gitleaks` is missing, prefer Agent Guard's private, checksum-pinned installer:
+   - Determine the target OS and architecture.
+   - Fetch the official checksum list for the version reported by `agent-guard setup`.
+   - Select the checksum for the exact archive name and show the version, archive, source URL, checksum, and destination.
+   - Ask for explicit approval before downloading or installing.
+   - After approval, run:
+
+   ```sh
+   "<agent-guard-bin>" setup --install \
+     --gitleaks-version "<version>" \
+     --gitleaks-checksum "<published-sha256>"
+   ```
+
+   Never substitute an unverified checksum and never bypass TLS verification.
+
+5. Verify the installation:
+
+   ```sh
+   "<agent-guard-bin>" check
+   "<agent-guard-bin>" smoke-test
+   ```
+
+   Treat `check` as dependency/config validation and `smoke-test` as the runtime proof. Report either both passing or the exact failing command and error.
+
+6. Restart the host application after hook or dependency setup if protection was already loaded in a degraded state. In Codex, plugin hooks provide the supported command boundary; do not configure the Claude-specific bang-command shell wrapper as a Codex setup step.
+
+## Safety And Host Boundaries
+
+- Dependency setup is intentionally approval-gated. A SessionStart hook may diagnose and recommend this skill, but it must never install software itself.
+- If installation is declined, leave the machine unchanged and state that Agent Guard is in degraded mode.
+- Codex currently protects supported hook surfaces such as `Bash`, `apply_patch`, and MCP tools. Do not claim that Codex hooks intercept arbitrary read, grep, or web-search tools.
+- `agent-guard setup-shell`, `agx`, and the bang-command guard are optional Claude Code shell-snapshot integrations. Only configure them when the user explicitly asks for Claude Code coverage.
+- If plugin hooks are not trusted or enabled, explain that dependencies alone do not activate runtime protection; trust the plugin hooks and restart the host.

--- a/plugins/agent-guard/skills/setup-agent-guard/agents/openai.yaml
+++ b/plugins/agent-guard/skills/setup-agent-guard/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Set Up Agent Guard"
+  short_description: "Check and install Agent Guard dependencies safely"
+  default_prompt: "Use $setup-agent-guard to check Agent Guard dependencies, guide approved installation, and verify protection."

--- a/scripts/validate-plugin-layout.sh
+++ b/scripts/validate-plugin-layout.sh
@@ -110,14 +110,40 @@ validate_archive_contains() {
   fi
 }
 
+validate_setup_skill() {
+  skill="$PLUGIN_ROOT/skills/setup-agent-guard/SKILL.md"
+  metadata="$PLUGIN_ROOT/skills/setup-agent-guard/agents/openai.yaml"
+
+  require_file "$skill"
+  require_file "$metadata"
+  if [ -f "$skill" ] \
+     && [ "$(sed -n '1p' "$skill")" = "---" ] \
+     && [ "$(sed -n '2p' "$skill")" = "name: setup-agent-guard" ] \
+     && sed -n '3p' "$skill" | grep -Eq '^description: .+' \
+     && [ "$(sed -n '4p' "$skill")" = "---" ]; then
+    ok "setup-agent-guard skill has valid required frontmatter"
+  else
+    fail "setup-agent-guard skill has valid required frontmatter"
+  fi
+  if [ -f "$metadata" ] \
+     && grep -Eq '^[[:space:]]*display_name:[[:space:]]+"?.+"?$' "$metadata" \
+     && grep -Eq '^[[:space:]]*short_description:[[:space:]]+"?.+"?$' "$metadata" \
+     && grep -Fq '$setup-agent-guard' "$metadata"; then
+    ok "setup-agent-guard UI metadata is complete"
+  else
+    fail "setup-agent-guard UI metadata is complete"
+  fi
+}
+
 validate_codex() {
   require_json "$PLUGIN_ROOT/.codex-plugin/plugin.json"
   require_json "$PLUGIN_ROOT/hooks.json"
+  validate_setup_skill
 
-  if jq -e 'has("hooks") or has("apps") or has("mcpServers")' "$PLUGIN_ROOT/.codex-plugin/plugin.json" >/dev/null; then
-    fail "Codex plugin manifest does not declare unsupported companion fields"
+  if jq -e '.hooks == "./hooks.json" and .skills == "./skills/"' "$PLUGIN_ROOT/.codex-plugin/plugin.json" >/dev/null; then
+    ok "Codex plugin manifest declares hook and skill paths"
   else
-    ok "Codex plugin manifest does not declare unsupported companion fields"
+    fail "Codex plugin manifest declares hook and skill paths"
   fi
 
   validate_hook_commands "$PLUGIN_ROOT/hooks.json" "Codex" "PLUGIN_ROOT"
@@ -172,6 +198,8 @@ validate_archive() {
   validate_archive_contains "$archive" ".claude-plugin/plugin.json"
   validate_archive_contains "$archive" "hooks.json"
   validate_archive_contains "$archive" "hooks/hooks.json"
+  validate_archive_contains "$archive" "skills/setup-agent-guard/SKILL.md"
+  validate_archive_contains "$archive" "skills/setup-agent-guard/agents/openai.yaml"
 
   if [ -d "$PLUGIN_ROOT/commands" ]; then
     archive_command_count=$(find "$PLUGIN_ROOT/commands" -type f -name '*.md' | wc -l | tr -d ' ')

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -114,31 +114,23 @@ for file in \
   run_expect 0 "json syntax: $file" jq -e . "$file"
 done
 
-codex_manifest_hooks=$(jq -r 'has("hooks")' "$PLUGIN_ROOT/.codex-plugin/plugin.json")
-if [ "$codex_manifest_hooks" = "false" ]; then
-  ok "Codex plugin manifest leaves hooks to the root hooks.json companion"
+if jq -e '.hooks == "./hooks.json" and .skills == "./skills/"' "$PLUGIN_ROOT/.codex-plugin/plugin.json" >/dev/null; then
+  ok "Codex plugin manifest explicitly declares hook and skill paths"
 else
-  not_ok "Codex plugin manifest leaves hooks to the root hooks.json companion"
+  not_ok "Codex plugin manifest explicitly declares hook and skill paths"
 fi
 
 for event in PreToolUse PostToolUse Stop; do
   claude_canonical=$(jq -r ".hooks.${event}[0].matcher" "$PLUGIN_ROOT/hooks/hooks.json")
   codex_canonical=$(jq -r ".hooks.${event}[0].matcher" "$PLUGIN_ROOT/hooks.json")
-  if [ "$codex_canonical" = "$claude_canonical" ]; then
-    ok "$event matcher in Codex hooks matches Claude hooks"
-  else
-    not_ok "$event matcher in Codex hooks matches Claude hooks (got: $codex_canonical)"
-  fi
-  for file in \
-    "$ROOT/examples/claude/settings.project.json" \
-    "$ROOT/examples/codex/hooks.json"; do
-    actual=$(jq -r ".hooks.${event}[0].matcher" "$file")
-    if [ "$actual" = "$claude_canonical" ]; then
-      ok "$event matcher in $file matches hooks/hooks.json"
-    else
-      not_ok "$event matcher in $file matches hooks/hooks.json (got: $actual)"
-    fi
-  done
+  claude_example=$(jq -r ".hooks.${event}[0].matcher" "$ROOT/examples/claude/settings.project.json")
+  codex_example=$(jq -r ".hooks.${event}[0].matcher" "$ROOT/examples/codex/hooks.json")
+  [ "$claude_example" = "$claude_canonical" ] \
+    && ok "$event matcher in Claude example matches Claude plugin hooks" \
+    || not_ok "$event matcher in Claude example matches Claude plugin hooks (got: $claude_example)"
+  [ "$codex_example" = "$codex_canonical" ] \
+    && ok "$event matcher in Codex example matches Codex plugin hooks" \
+    || not_ok "$event matcher in Codex example matches Codex plugin hooks (got: $codex_example)"
 done
 
 # Full hook-object parity: type, timeout, and the trailing hook-* subcommand
@@ -204,17 +196,20 @@ for event in PreToolUse PostToolUse Stop; do
   done
 done
 
-# SessionStart (version-drift warning) is wired in hooks/hooks.json alone: the
-# Codex host has no SessionStart event, and the manual-install example ships no
-# plugin (same binary is both plugin and CLI), so plugin/CLI drift cannot occur.
+# SessionStart reports dependency readiness on both hosts and version drift for
+# the optional Claude shell integration.
 ss_hook_matcher=$(jq -r '.hooks.SessionStart[0].matcher' "$PLUGIN_ROOT/hooks/hooks.json")
 ss_hook_command=$(jq -r '.hooks.SessionStart[0].hooks[0].command' "$PLUGIN_ROOT/hooks/hooks.json")
 ss_hook_timeout=$(jq -r '.hooks.SessionStart[0].hooks[0].timeout' "$PLUGIN_ROOT/hooks/hooks.json")
-if [ "$ss_hook_matcher" = "startup|resume|clear" ]; then
-  ok "SessionStart matcher covers startup/resume/clear in hooks/hooks.json"
+if [ "$ss_hook_matcher" = "startup|resume|clear|compact" ]; then
+  ok "SessionStart matcher covers startup/resume/clear/compact in hooks/hooks.json"
 else
-  not_ok "SessionStart matcher covers startup/resume/clear in hooks/hooks.json (got: $ss_hook_matcher)"
+  not_ok "SessionStart matcher covers startup/resume/clear/compact in hooks/hooks.json (got: $ss_hook_matcher)"
 fi
+codex_ss_matcher=$(jq -r '.hooks.SessionStart[0].matcher' "$PLUGIN_ROOT/hooks.json")
+[ "$codex_ss_matcher" = "$ss_hook_matcher" ] \
+  && ok "Codex SessionStart matcher matches the supported lifecycle set" \
+  || not_ok "Codex SessionStart matcher matches the supported lifecycle set (got: $codex_ss_matcher)"
 case "$ss_hook_command" in
   *'CLAUDE_PLUGIN_ROOT'*'hook-session-start'*)
     ok "SessionStart command invokes hook-session-start via CLAUDE_PLUGIN_ROOT" ;;
@@ -377,6 +372,22 @@ else
   not_ok "gitleaks default version drift: bin=$bin_ver script=$script_ver action=$action_ver"
 fi
 
+# Release version is consumed independently by both plugin hosts and the Claude
+# marketplace. Keep every published surface aligned with the executable, and
+# require the latest changelog entry to describe that same release.
+plugin_ver=$(awk -F= '/^VERSION=/ {print $2; exit}' "$PLUGIN_ROOT/bin/agent-guard")
+claude_ver=$(jq -r '.version' "$PLUGIN_ROOT/.claude-plugin/plugin.json")
+codex_ver=$(jq -r '.version' "$PLUGIN_ROOT/.codex-plugin/plugin.json")
+market_ver=$(jq -r '.plugins[] | select(.name == "agent-guard") | .version' "$ROOT/.claude-plugin/marketplace.json")
+changelog_ver=$(sed -n 's/^## v\([^ ]*\) .*/\1/p' "$ROOT/CHANGELOG.md" | head -n1)
+if [ -n "$plugin_ver" ] && [ "$plugin_ver" = "$claude_ver" ] \
+   && [ "$plugin_ver" = "$codex_ver" ] && [ "$plugin_ver" = "$market_ver" ] \
+   && [ "$plugin_ver" = "$changelog_ver" ]; then
+  ok "release version in sync across binary, plugin manifests, marketplace, and changelog ($plugin_ver)"
+else
+  not_ok "release version drift: bin=$plugin_ver claude=$claude_ver codex=$codex_ver marketplace=$market_ver changelog=$changelog_ver"
+fi
+
 expect_json_status 2 "Claude Write secret is blocked" \
   '{"tool_name":"Write","tool_input":{"file_path":"app.txt","content":"AGENT_GUARD_TEST_SECRET"}}' \
   hook-pre-tool
@@ -387,6 +398,10 @@ expect_json_status 0 "safe example token is allowed" \
 
 expect_json_status 2 "Codex apply_patch added secret is blocked" \
   '{"tool_name":"apply_patch","tool_input":{"patch":"*** Begin Patch\n*** Add File: x\n+AGENT_GUARD_TEST_SECRET\n*** End Patch"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Codex canonical apply_patch command field is scanned" \
+  '{"tool_name":"apply_patch","tool_input":{"command":"*** Begin Patch\n*** Add File: x\n+AGENT_GUARD_TEST_SECRET\n*** End Patch"}}' \
   hook-pre-tool
 
 expect_json_status 0 "Codex apply_patch deleted secret is allowed" \
@@ -447,6 +462,26 @@ expect_json_status 2 "Bash glob wildcard path bypass is blocked" \
 
 expect_json_status 0 "Bash benign glob remains allowed" \
   '{"tool_name":"Bash","tool_input":{"command":"ls *.md"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "ripgrep negative glob over a denied extension is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"rg --files -g '\''!*.pem'\''"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "command-wrapped ripgrep negative glob is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"command rg --files --glob='\''!*.pem'\''"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "ripgrep positive glob over a denied extension remains blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"rg --files -g '\''*.pem'\''"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "literal bang-prefixed denied path remains blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"cat '\''!secret.pem'\''"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "negative glob does not hide a chained denied read" \
+  '{"tool_name":"Bash","tool_input":{"command":"rg --files -g '\''!*.pem'\'' && cat secret.pem"}}' \
   hook-pre-tool
 
 expect_json_status 2 "Bash command literal secret is blocked" \
@@ -973,6 +1008,36 @@ else
   sed 's/^/  stderr: /' "$ERR"
 fi
 
+# Codex runs hooks from the task root, which can differ from exec_command's
+# workdir. Honor the tool payload so the staged scan runs in the target repo.
+(
+  cd "$TMP_ROOT" || exit 2
+  jq -nc --arg workdir "$TEST_REPO" \
+    '{tool_name:"Bash",tool_input:{command:"git commit -m leak",workdir:$workdir}}' \
+    | "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool >"$OUT" 2>"$ERR"
+)
+status=$?
+if [ "$status" -eq 2 ] && grep -q 'staged changes contain secret-like values' "$ERR"; then
+  ok "Codex hook scans staged changes from tool_input.workdir"
+else
+  not_ok "Codex hook scans staged changes from tool_input.workdir (expected staged-secret block, got $status)"
+  sed 's/^/  stderr: /' "$ERR"
+fi
+
+(
+  cd "$TMP_ROOT" || exit 2
+  jq -nc --arg cwd "$TEST_REPO" \
+    '{tool_name:"Bash",cwd:$cwd,tool_input:{command:"git push origin main"}}' \
+    | "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool >"$OUT" 2>"$ERR"
+)
+status=$?
+if [ "$status" -eq 2 ] && grep -q 'staged changes contain secret-like values' "$ERR"; then
+  ok "host hook scans staged changes from top-level cwd"
+else
+  not_ok "host hook scans staged changes from top-level cwd (expected staged-secret block, got $status)"
+  sed 's/^/  stderr: /' "$ERR"
+fi
+
 (
   cd "$TEST_REPO" || exit 2
   printf '%s' '{"tool_name":"Bash","tool_input":{"command":"git status && git -C . push origin main"}}' \
@@ -1062,17 +1127,20 @@ SYMLINK_REPO="$TMP_ROOT/symlink-repo"
 mkdir -p "$SYMLINK_REPO"
 (
   cd "$SYMLINK_REPO" || exit 2
-  printf '%s\n' "AGENT_GUARD_TEST_SECRET" > .env
-  ln -s .env safe-link
+  printf '%s\n' "sensitive fixture" > blocked-target.txt
+  ln -s blocked-target.txt safe-link
 )
+SYMLINK_DENY="$TESTTMP/symlink-deny-paths.txt"
+printf '%s\n' 'blocked-target.txt' >"$SYMLINK_DENY"
 if [ -L "$SYMLINK_REPO/safe-link" ]; then
   payload='{"tool_name":"Read","tool_input":{"file_path":"'"$SYMLINK_REPO"'/safe-link"}}'
-  printf '%s' "$payload" | "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool >"$OUT" 2>"$ERR"
+  printf '%s' "$payload" \
+    | AGENT_GUARD_DENY_READ_PATHS="$SYMLINK_DENY" "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool >"$OUT" 2>"$ERR"
   status=$?
   if [ "$status" -eq 2 ]; then
-    ok "symlink to .env is blocked via realpath resolution"
+    ok "symlink to a deny-listed target is blocked via realpath resolution"
   else
-    not_ok "symlink to .env is blocked via realpath resolution (expected 2, got $status)"
+    not_ok "symlink to a deny-listed target is blocked via realpath resolution (expected 2, got $status)"
     sed 's/^/  stderr: /' "$ERR"
   fi
 else
@@ -1532,6 +1600,24 @@ else
   sed 's/^/  stderr: /' "$ERR"
 fi
 
+ERROR_ZERO_BIN="$TMP_ROOT/error-zero-bin"
+mkdir -p "$ERROR_ZERO_BIN"
+cat > "$ERROR_ZERO_BIN/gitleaks" <<'EOSH'
+#!/usr/bin/env sh
+echo "ERR skipping file: synthetic unreadable fixture" >&2
+exit 0
+EOSH
+chmod +x "$ERROR_ZERO_BIN/gitleaks"
+
+PATH="$ERROR_ZERO_BIN:$PATH" "$PLUGIN_ROOT/bin/agent-guard" scan-path "$CLEAN_DIR" >"$OUT" 2>"$ERR"
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "scan-path fail-closes when gitleaks exits 0 but reports an error"
+else
+  not_ok "scan-path fail-closes on gitleaks exit-0 error output (expected 2, got $status)"
+  sed 's/^/  stderr: /' "$ERR"
+fi
+
 PATH="$ERROR_BIN:$PATH" sh -c '
   printf "%s" "{\"tool_name\":\"Write\",\"tool_input\":{\"content\":\"x\"}}" \
     | "'"$PLUGIN_ROOT"'/bin/agent-guard" hook-pre-tool
@@ -1676,7 +1762,8 @@ mkdir -p "$NO_GITLEAKS_BIN"
 ln -s "$REAL_SH" "$NO_GITLEAKS_BIN/sh"
 ln -s "$REAL_DIRNAME" "$NO_GITLEAKS_BIN/dirname"
 ln -s "$REAL_PWD" "$NO_GITLEAKS_BIN/pwd"
-PATH="$NO_GITLEAKS_BIN" "$PLUGIN_ROOT/bin/agent-guard" scan-path "$CLEAN_DIR" >"$OUT" 2>"$ERR"
+AGENT_GUARD_GITLEAKS_BIN=/nonexistent/gitleaks PATH="$NO_GITLEAKS_BIN" \
+  "$PLUGIN_ROOT/bin/agent-guard" scan-path "$CLEAN_DIR" >"$OUT" 2>"$ERR"
 status=$?
 if [ "$status" -eq 2 ]; then
   ok "scan-path dies when gitleaks is unavailable"
@@ -1688,10 +1775,12 @@ fi
 # while gitleaks is missing.
 ln -sf "$(command -v jq)" "$NO_GITLEAKS_BIN/jq"
 ln -sf "$(command -v git)" "$NO_GITLEAKS_BIN/git"
+ln -sf "$(command -v head)" "$NO_GITLEAKS_BIN/head"
 ln -sf "$(command -v command)" "$NO_GITLEAKS_BIN/command" 2>/dev/null || true
 ln -sf "$(command -v uname)" "$NO_GITLEAKS_BIN/uname" 2>/dev/null || true
 
-PATH="$NO_GITLEAKS_BIN" "$PLUGIN_ROOT/bin/agent-guard" setup >"$OUT" 2>"$ERR"
+AGENT_GUARD_GITLEAKS_BIN=/nonexistent/gitleaks PATH="$NO_GITLEAKS_BIN" \
+  "$PLUGIN_ROOT/bin/agent-guard" setup >"$OUT" 2>"$ERR"
 status=$?
 if [ "$status" -eq 1 ]; then
   ok "setup exits 1 when gitleaks missing"
@@ -1700,12 +1789,49 @@ else
   sed 's/^/  stderr: /' "$ERR"
 fi
 
-PATH="$NO_GITLEAKS_BIN" "$PLUGIN_ROOT/bin/agent-guard" setup --install >"$OUT" 2>"$ERR"
+AGENT_GUARD_GITLEAKS_BIN=/nonexistent/gitleaks PATH="$NO_GITLEAKS_BIN" \
+  "$PLUGIN_ROOT/bin/agent-guard" setup --install >"$OUT" 2>"$ERR"
 status=$?
 if [ "$status" -eq 2 ]; then
   ok "setup --install without --gitleaks-checksum exits 2"
 else
   not_ok "setup --install without --gitleaks-checksum exits 2 (expected 2, got $status)"
+  sed 's/^/  stderr: /' "$ERR"
+fi
+
+printf '%s' '{"tool_name":"Bash","tool_input":{"command":"brew install gitleaks"}}' \
+  | AGENT_GUARD_GITLEAKS_BIN=/nonexistent/gitleaks PATH="$NO_GITLEAKS_BIN" \
+    "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool >"$OUT" 2>"$ERR"
+status=$?
+if [ "$status" -eq 0 ] && grep -q 'DEGRADED' "$ERR" && grep -q '\$setup-agent-guard' "$ERR"; then
+  ok "hook degrades open with an actionable setup warning when dependencies are missing"
+else
+  not_ok "hook degraded mode allows setup commands with a warning (status $status)"
+  sed 's/^/  stdout: /' "$OUT"
+  sed 's/^/  stderr: /' "$ERR"
+fi
+
+EXEC_NOT_RUN="$TESTTMP/exec-not-run.txt"
+AGENT_GUARD_GITLEAKS_BIN=/nonexistent/gitleaks PATH="$NO_GITLEAKS_BIN" \
+  "$PLUGIN_ROOT/bin/agent-guard" exec -- sh -c 'printf ran >"$1"' _ "$EXEC_NOT_RUN" >"$OUT" 2>"$ERR"
+status=$?
+if [ "$status" -eq 2 ] && [ ! -e "$EXEC_NOT_RUN" ]; then
+  ok "exec fails closed before running a command when masking dependencies are missing"
+else
+  not_ok "exec missing-dependency preflight prevents execution (status $status)"
+fi
+
+PRIVATE_GL_DIR="$TESTTMP/private-gitleaks-bin"
+mkdir -p "$PRIVATE_GL_DIR"
+cp "$ROOT/tests/fixtures/mock-gitleaks" "$PRIVATE_GL_DIR/gitleaks"
+chmod +x "$PRIVATE_GL_DIR/gitleaks"
+AGENT_GUARD_GITLEAKS_BIN_DIR="$PRIVATE_GL_DIR" PATH="$NO_GITLEAKS_BIN" \
+  "$PLUGIN_ROOT/bin/agent-guard" check >"$OUT" 2>"$ERR"
+status=$?
+if [ "$status" -eq 0 ] && grep -q 'gitleaks 0.0.0-mock' "$ERR"; then
+  ok "check discovers gitleaks in Agent Guard's private install directory"
+else
+  not_ok "check discovers privately installed gitleaks (status $status)"
   sed 's/^/  stderr: /' "$ERR"
 fi
 
@@ -2008,7 +2134,7 @@ if [ -n "$REAL_GITLEAKS" ]; then
     printf '%s%s\n' '-----BEGIN RSA ' 'PRIVATE KEY-----'
     printf '%s\n' "$PEM_BODY"
     printf '%s%s\n' '-----END RSA ' 'PRIVATE KEY-----'
-  } > "$RSA_FIXTURE_DIR/key.pem"
+  } > "$RSA_FIXTURE_DIR/rsa-private-key-fixture.txt"
   PATH="$(dirname "$REAL_GITLEAKS"):$ORIGINAL_PATH" "$PLUGIN_ROOT/bin/agent-guard" scan-path "$RSA_FIXTURE_DIR" >"$OUT" 2>"$ERR"
   status=$?
   if [ "$status" -eq 1 ]; then
@@ -2024,7 +2150,7 @@ if [ -n "$REAL_GITLEAKS" ]; then
     printf '%s%s\n' '-----BEGIN OPENSSH ' 'PRIVATE KEY-----'
     printf '%s\n' "$PEM_BODY"
     printf '%s%s\n' '-----END OPENSSH ' 'PRIVATE KEY-----'
-  } > "$OPENSSH_FIXTURE_DIR/openssh.key"
+  } > "$OPENSSH_FIXTURE_DIR/openssh-private-key-fixture.txt"
   PATH="$(dirname "$REAL_GITLEAKS"):$ORIGINAL_PATH" "$PLUGIN_ROOT/bin/agent-guard" scan-path "$OPENSSH_FIXTURE_DIR" >"$OUT" 2>"$ERR"
   status=$?
   if [ "$status" -eq 1 ]; then
@@ -2198,6 +2324,20 @@ if [ "$post_status" -eq 0 ] \
 else
   not_ok "post-tool masks a gitleaks-detected secret in Bash stdout (status $post_status)"
   printf '%s\n' "$post_out" | sed 's/^/  out: /'
+fi
+
+printf '%s' '{"tool_name":"Bash","tool_input":{"command":"loadsecrets"},"tool_response":{"stdout":"token AGENT_GUARD_TEST_SECRET here\n","stderr":"","interrupted":false,"isImage":false}}' \
+  | (cd "$TMP_ROOT" && AGENT_GUARD_HOOK_HOST=codex "$PLUGIN_ROOT/bin/agent-guard" hook-post-tool) \
+    >"$OUT" 2>"$ERR"
+codex_post_status=$?
+codex_post_out=$(cat "$OUT")
+if [ "$codex_post_status" -eq 0 ] \
+   && printf '%s' "$codex_post_out" | jq -e '.decision == "block" and (.reason | type == "string") and (.hookSpecificOutput.additionalContext | contains("[REDACTED]"))' >/dev/null 2>&1 \
+   && ! printf '%s' "$codex_post_out" | grep -q 'AGENT_GUARD_TEST_SECRET'; then
+  ok "Codex post-tool uses decision block plus sanitized additionalContext"
+else
+  not_ok "Codex post-tool emits the supported sanitized-output contract (status $codex_post_status)"
+  printf '%s\n' "$codex_post_out" | sed 's/^/  out: /'
 fi
 
 post_tool_out '{"tool_name":"Bash","tool_input":{"command":"printenv-like"},"tool_response":{"stdout":"DATABASE_PASSWORD=hunter2-long-value\n","stderr":"","interrupted":false,"isImage":false}}'
@@ -2661,8 +2801,8 @@ else
   not_ok "shell-init nudge stays silent on a benign command"
 fi
 
-# --- shell-init experimental bang guard (opt-in function overrides) -----------
-# Emitted ONLY with --experimental-bang-guard; overrides cat/head/printenv
+# --- shell-init Claude bang guard (supported opt-in function overrides) -------
+# Emitted ONLY with --claude-bang-guard; overrides cat/head/printenv
 # to route through `agent-guard exec` (mask) but ONLY inside Claude Code
 # ($CLAUDECODE), staying inert in a normal terminal.
 if printf '%s' "$shellinit_auto" | grep -q '__agentguard_guard'; then
@@ -2670,11 +2810,17 @@ if printf '%s' "$shellinit_auto" | grep -q '__agentguard_guard'; then
 else
   ok "shell-init omits the bang guard without the opt-in flag"
 fi
-shellinit_bg=$("$PLUGIN_ROOT/bin/agent-guard" shell-init --experimental-bang-guard 2>/dev/null)
+shellinit_bg=$("$PLUGIN_ROOT/bin/agent-guard" shell-init --claude-bang-guard 2>/dev/null)
 if printf '%s' "$shellinit_bg" | grep -q '__agentguard_guard'; then
-  ok "shell-init --experimental-bang-guard emits the guard functions"
+  ok "shell-init --claude-bang-guard emits the guard functions"
 else
-  not_ok "shell-init --experimental-bang-guard emits the guard functions"
+  not_ok "shell-init --claude-bang-guard emits the guard functions"
+fi
+shellinit_bg_legacy=$("$PLUGIN_ROOT/bin/agent-guard" shell-init --experimental-bang-guard 2>/dev/null)
+if printf '%s' "$shellinit_bg_legacy" | grep -q '__agentguard_guard'; then
+  ok "shell-init accepts the deprecated --experimental-bang-guard alias"
+else
+  not_ok "shell-init accepts the deprecated --experimental-bang-guard alias"
 fi
 if printf '%s\n' "$shellinit_bg" | sh -n - 2>"$ERR"; then
   ok "bang guard snippet parses under sh -n"
@@ -2713,6 +2859,19 @@ if [ "$bg_out_cc" = hello-plain ]; then
   ok "bang guard is inert (passthrough) outside Claude Code"
 else
   not_ok "bang guard passthrough outside Claude Code (got: $bg_out_cc)"
+fi
+
+AGENT_GUARD_BIN="$PLUGIN_ROOT/bin/agent-guard" \
+AGENT_GUARD_GITLEAKS_BIN=/nonexistent/gitleaks \
+CLAUDECODE=1 sh -c '. "$1"; cat "$2"' _ "$bg_dir/guard.sh" "$bg_dir/file.txt" >"$OUT" 2>"$ERR"
+status=$?
+if [ "$status" -eq 0 ] && [ "$(cat "$OUT")" = hello-plain ] \
+   && grep -q 'dependencies are not ready' "$ERR"; then
+  ok "transparent bang guard fails open with a loud warning when masking is unavailable"
+else
+  not_ok "transparent bang guard degraded mode preserves command behavior with a warning (status $status)"
+  sed 's/^/  stdout: /' "$OUT"
+  sed 's/^/  stderr: /' "$ERR"
 fi
 # Regression: a pre-existing `alias cat=...` must NOT stop the override from
 # installing. Without the per-name `unalias` before each `eval`, the alias
@@ -2810,7 +2969,8 @@ AG_VERSION=$(sed -n 's/^VERSION=//p' "$PLUGIN_ROOT/bin/agent-guard" | head -n1)
 run_session_start() {  # $1 = value for the marker env ('' => marker unset)
   sh -c 'unset AGENT_GUARD_SHELL_INIT_VERSION
          [ -n "$1" ] && export AGENT_GUARD_SHELL_INIT_VERSION="$1"
-         PATH=/usr/bin:/bin exec "$2" hook-session-start' _ "$1" "$PLUGIN_ROOT/bin/agent-guard"
+         AGENT_GUARD_GITLEAKS_BIN="$3" PATH="$4" exec "$2" hook-session-start' \
+    _ "$1" "$PLUGIN_ROOT/bin/agent-guard" "$MOCK_BIN/gitleaks" "$MOCK_BIN:$ORIGINAL_PATH"
 }
 
 vd_out=$(run_session_start 0.0.1 2>"$ERR")
@@ -2844,6 +3004,16 @@ if [ $? -eq 0 ] && [ -z "$vd_out" ]; then
   ok "hook-session-start is silent when the marker cannot be parsed"
 else
   not_ok "hook-session-start silent on unparseable marker (got: $vd_out)"
+fi
+
+vd_out=$(AGENT_GUARD_GITLEAKS_BIN=/nonexistent/gitleaks \
+  PATH="$NO_GITLEAKS_BIN" "$PLUGIN_ROOT/bin/agent-guard" hook-session-start 2>"$ERR")
+if [ $? -eq 0 ] \
+   && printf '%s' "$vd_out" | jq -e '.systemMessage | contains("DEGRADED")' >/dev/null 2>&1 \
+   && printf '%s' "$vd_out" | grep -q '\$setup-agent-guard'; then
+  ok "hook-session-start guides dependency setup while protection is degraded"
+else
+  not_ok "hook-session-start emits an actionable degraded-mode warning (got: $vd_out)"
 fi
 
 # --- shell-init exports the resolved binary's version as the marker -----------
@@ -2951,17 +3121,25 @@ if grep -q 'export AG_TEST_KEEP=1' "$ss_rc" 2>/dev/null; then
 else
   not_ok "setup-shell preserves unrelated rc lines"
 fi
-"$PLUGIN_ROOT/bin/agent-guard" setup-shell --rc "$ss_rc" --experimental-bang-guard >/dev/null 2>&1
-if grep -q 'shell-init --experimental-bang-guard' "$ss_rc" 2>/dev/null; then
-  ok "setup-shell threads --experimental-bang-guard into the rc line"
+"$PLUGIN_ROOT/bin/agent-guard" setup-shell --rc "$ss_rc" --claude-bang-guard >/dev/null 2>&1
+if grep -q 'shell-init --claude-bang-guard' "$ss_rc" 2>/dev/null; then
+  ok "setup-shell threads --claude-bang-guard into the rc line"
 else
-  not_ok "setup-shell threads --experimental-bang-guard into the rc line"
+  not_ok "setup-shell threads --claude-bang-guard into the rc line"
+fi
+ss_legacy="$TESTTMP/setup-legacy.rc"
+"$PLUGIN_ROOT/bin/agent-guard" setup-shell --rc "$ss_legacy" --experimental-bang-guard >/dev/null 2>&1
+if grep -q 'shell-init --claude-bang-guard' "$ss_legacy" 2>/dev/null \
+   && ! grep -q 'shell-init --experimental-bang-guard' "$ss_legacy" 2>/dev/null; then
+  ok "setup-shell normalizes the deprecated bang-guard alias to the stable option"
+else
+  not_ok "setup-shell normalizes the deprecated bang-guard alias to the stable option"
 fi
 # Self-healing invocation: the rc line prefers `agent-guard` on $PATH but bakes an
 # absolute-path fallback keyed on OUTPUT (not mere presence), so it stays a valid
 # generator even if the bare name later leaves $PATH or a stale binary emits nothing.
 ss_heal="$TESTTMP/setup-heal.rc"
-"$PLUGIN_ROOT/bin/agent-guard" setup-shell --rc "$ss_heal" --experimental-bang-guard >/dev/null 2>&1
+"$PLUGIN_ROOT/bin/agent-guard" setup-shell --rc "$ss_heal" --claude-bang-guard >/dev/null 2>&1
 if grep -q '_agi=$(agent-guard shell-init' "$ss_heal" 2>/dev/null \
    && grep -q 'if \[ -n "$_agi" \]' "$ss_heal" 2>/dev/null; then
   ok "setup-shell bakes a self-healing invocation (output probe + absolute fallback)"


### PR DESCRIPTION
## Summary

- add an approval-gated Codex setup skill that checks Agent Guard dependencies and guides installation when they are missing
- make Codex hooks host-native, declare hook/skill paths in the plugin manifest, and surface degraded protection at session start
- promote the Claude command-output wrapper to the stable `--claude-bang-guard` option while retaining the experimental option as a deprecated alias
- make pre-tool staged scans honor `tool_input.workdir`, `tool_input.cwd`, or the host-level `cwd`, so projectless Codex tasks scan the repository targeted by the command
- release the combined behavior as Agent Guard 1.10.0 and update documentation, examples, layout validation, and benchmarks

## Why

Installing the plugin alone cannot safely and silently install host dependencies. The new setup skill detects the missing pieces, explains the impact, and keeps installation behind the host approval boundary.

The existing 1.9.0 pre-tool hook also ran `scan-staged` from the Codex task root. In a projectless task whose command targeted an isolated worktree, valid commit and push commands failed with `scan-staged must run inside a git work tree`. The hook now scans from the working directory carried by the host payload.

The command-output wrapper has enough compatibility and failure-mode coverage to be treated as supported behavior. The previous option remains accepted so existing shell configuration does not break during upgrade.

## Impact

- Codex users get actionable dependency setup instead of a silently degraded installation.
- Claude shell users can opt into the supported command-output guard without using an experimental flag.
- Codex commands that specify a repository workdir no longer fail because the task itself is projectless.
- Existing users of `--experimental-bang-guard` remain compatible and receive normalized managed configuration on the next setup run.

## Functional verification

- `./tests/run.sh` — 412 passed, 0 failed
- `sh -n plugins/agent-guard/bin/agent-guard`
- `sh -n tests/run.sh`
- `git diff --cached --check`
- `plugins/agent-guard/bin/agent-guard scan-staged`
- installed Codex managed policy validated with TOML parsing and a GitHub-only domain allowlist
- `gh auth status -h github.com` and `gh api user --jq .login`
- SSH remote discovery and branch push to `JeongJaeSoon/agent-guard`

## Notes

The current task initially reproduced the 1.9.0 workdir bug during commit. After adding the payload-workdir regression tests, the updated binary completed the staged scan successfully and the resulting commit was verified with a good ED25519 SSH signature.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guided, approval-based dependency setup and verification for Codex.
  * Added Codex hook and skill integrations, including session-start guidance.
  * Introduced the supported opt-in Claude bang-command guard.
  * Added configurable gitleaks resolution and improved host-specific output masking.

* **Bug Fixes**
  * Improved scanning for Git working directories, deny-path commands, and degraded dependency states.
  * Strengthened secret detection and fail-closed behavior.

* **Documentation**
  * Updated installation, integration, masking, limitations, configuration, and benchmark guidance for Claude Code and Codex.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->