### PR TITLE
Fix live Agent Guard hook verification

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "agent-guard",
       "source": "./plugins/agent-guard",
       "description": "Real-time secret-leak guardrails for AI coding agents (Claude Code, Codex), Git hooks, and CI.",
-      "version": "1.10.0"
+      "version": "1.10.1"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v1.10.1 - 2026-07-14
 
 - fix(codex): verify the plugin-local binary, hook trust, and live host dispatch during guided setup
+- fix(codex): use harmless dedicated sentinels for live PreToolUse and PostToolUse probes
 - docs(codex): document wrapping-tool boundaries and require pre/post live probes
 - fix(shell): mask bare `printenv NAME` values with their variable-name context
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.10.1 - 2026-07-14
+
+- fix(codex): verify the plugin-local binary, hook trust, and live host dispatch during guided setup
+- docs(codex): document wrapping-tool boundaries and require pre/post live probes
+- fix(shell): mask bare `printenv NAME` values with their variable-name context
+
 ## v1.10.0 - 2026-07-13
 
 - feat(codex): add guided dependency setup and host-native hook responses

--- a/README.md
+++ b/README.md
@@ -105,17 +105,19 @@ codex plugin marketplace add JeongJaeSoon/agent-guard
 
 Then open `/plugins` in Codex, install **Agent Guard**, open **Settings > Hooks**, trust the **SessionStart**, **PreToolUse**, **PostToolUse**, and **Stop** hooks, and restart Codex. Re-check this screen after plugin updates: a changed hook is marked **Modified** and remains inactive until you review and trust it again. SessionStart reports degraded protection when a dependency is unavailable and points Codex to `$setup-agent-guard`; installation remains approval-gated. An untrusted SessionStart hook cannot display that guidance.
 
-Run `$setup-agent-guard` and require all three layers to pass: plugin-local `check`, plugin-local `smoke-test`, and the live host probes. For the pre-tool probe, ask Codex to run this harmless command; the comment is inspected but no sensitive file is read:
+Run `$setup-agent-guard` and require all three layers to pass: plugin-local `check`, plugin-local `smoke-test`, and the live host probes. For the pre-tool probe, ask Codex to run this harmless sentinel command:
 
 ```sh
-printf '%s\n' 'AGENT_GUARD_LIVE_PROBE_EXECUTED'; : # cat .env
+printf '%s\n' 'AGENT_GUARD_LIVE_PRE_TOOL_PROBE'
 ```
 
-Expected result: Agent Guard blocks the command before `AGENT_GUARD_LIVE_PROBE_EXECUTED` is printed. For the post-tool probe, print the documented fake value below and confirm that the raw value is masked or replaced before it reaches the model:
+Expected result: Agent Guard blocks the command before the sentinel is printed. For the post-tool probe, run the paired harmless sentinel and confirm that the raw marker is masked or replaced before it reaches the model:
 
 ```sh
-printf '%s\n' 'DEMO_TOKEN=ghp_abcdefghijklmnopqrstuvwxyz0123456789'
+printf '%s\n' 'AGENT_GUARD_LIVE_POST_TOOL_PROBE'
 ```
+
+These sentinels test only whether the host dispatched PreToolUse and PostToolUse. The plugin-local `smoke-test` separately exercises the real deny-list and secret-redaction rules without placing sensitive-looking instructions in the setup skill.
 
 Codex may expose shell execution through a wrapping or orchestration tool such as `functions.exec`. Agent Guard cannot replace or wrap Codex's host executor; it protects only nested operations that the current Codex release dispatches to plugin hooks. Test the exact route used in the current task. If the pre-tool marker or raw fake token appears, protection is not active on that route even when the binary smoke test passes. Use a native Git hook or CI as the backstop and do not treat the plugin setup as complete for that host route.
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Detection needs `jq` and `gitleaks` on your machine (`brew install jq gitleaks`;
 | Use case | Install path | Best first check |
 |---|---|---|
 | Claude Code agent guardrails | [Quick start (Claude Code)](#quick-start-claude-code) | Ask the agent to read `.env`; it should be blocked. |
-| Codex plugin guardrails | [Codex plugin](#codex-plugin) | Trust the hooks, run `$setup-agent-guard`, then ask Codex to run `cat .env`; Bash should be blocked. |
+| Codex plugin guardrails | [Codex plugin](#codex-plugin) | Trust the hooks, run `$setup-agent-guard`, and require both live hook probes to pass. |
 | Codex CLI + Git backstop | [Direct CLI](#direct-cli) + [Native Git hook](#native-git-hook) | Run `agent-guard smoke-test`; commit a staged fixture secret, and it should fail. |
 | Local commits | [Native Git hook](#native-git-hook) | Commit a staged fixture secret; commit should fail. |
 | CI / PRs | [GitHub Actions](#github-actions) | Push a test PR with a gitleaks-detectable fixture; workflow should fail. |
@@ -76,7 +76,7 @@ make check
 make smoke-test
 ```
 
-The Claude Code and Codex plugin installs do not put `agent-guard` on your shell `PATH`. In Codex, invoke `$setup-agent-guard`: it checks first, presents the exact host-appropriate install plan, requests approval, and runs `check` plus `smoke-test`. It never installs software merely because a session started. Claude Code users can run the equivalent manual commands below.
+The Claude Code and Codex plugin installs do not put `agent-guard` on your shell `PATH`. In Codex, invoke `$setup-agent-guard`: it uses the plugin-local binary even when a different standalone version is on `PATH`, presents the exact host-appropriate install plan, requests approval, runs `check` plus `smoke-test`, verifies hook trust, and runs live host probes. It never installs software merely because a session started. Claude Code users can run the equivalent manual commands below.
 
 Manual macOS equivalent:
 
@@ -103,19 +103,21 @@ Install from the marketplace:
 codex plugin marketplace add JeongJaeSoon/agent-guard
 ```
 
-Then open `/plugins` in Codex, install **Agent Guard**, trust the **SessionStart**, **PreToolUse**, **PostToolUse**, and **Stop** hooks, and restart Codex. SessionStart reports degraded protection when a dependency is unavailable and points Codex to `$setup-agent-guard`; installation remains approval-gated.
+Then open `/plugins` in Codex, install **Agent Guard**, open **Settings > Hooks**, trust the **SessionStart**, **PreToolUse**, **PostToolUse**, and **Stop** hooks, and restart Codex. Re-check this screen after plugin updates: a changed hook is marked **Modified** and remains inactive until you review and trust it again. SessionStart reports degraded protection when a dependency is unavailable and points Codex to `$setup-agent-guard`; installation remains approval-gated. An untrusted SessionStart hook cannot display that guidance.
 
-Smoke test:
+Run `$setup-agent-guard` and require all three layers to pass: plugin-local `check`, plugin-local `smoke-test`, and the live host probes. For the pre-tool probe, ask Codex to run this harmless command; the comment is inspected but no sensitive file is read:
 
-```text
-Please run `cat .env` in the shell.
+```sh
+printf '%s\n' 'AGENT_GUARD_LIVE_PROBE_EXECUTED'; : # cat .env
 ```
 
-Expected result:
+Expected result: Agent Guard blocks the command before `AGENT_GUARD_LIVE_PROBE_EXECUTED` is printed. For the post-tool probe, print the documented fake value below and confirm that the raw value is masked or replaced before it reaches the model:
 
-```text
-agent-guard: blocked shell command referencing a deny-listed path
+```sh
+printf '%s\n' 'DEMO_TOKEN=ghp_abcdefghijklmnopqrstuvwxyz0123456789'
 ```
+
+Codex may expose shell execution through a wrapping or orchestration tool such as `functions.exec`. Agent Guard cannot replace or wrap Codex's host executor; it protects only nested operations that the current Codex release dispatches to plugin hooks. Test the exact route used in the current task. If the pre-tool marker or raw fake token appears, protection is not active on that route even when the binary smoke test passes. Use a native Git hook or CI as the backstop and do not treat the plugin setup as complete for that host route.
 
 Codex loads the plugin's `skills/` directory but does not use the Claude `commands/` directory. Use `$setup-agent-guard` for setup; ask Codex to run the binary directly for other workflows:
 

--- a/plugins/agent-guard/.claude-plugin/plugin.json
+++ b/plugins/agent-guard/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-guard",
   "description": "Real-time secret-leak guardrails for AI coding agents (Claude Code, Codex), Git hooks, and CI.",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "author": {
     "name": "Agent Guard contributors"
   }

--- a/plugins/agent-guard/.codex-plugin/plugin.json
+++ b/plugins/agent-guard/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-guard",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Real-time secret-leak guardrails for AI coding agents (Claude Code, Codex), Git hooks, and CI.",
   "author": {
     "name": "Agent Guard contributors"

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -52,6 +52,8 @@ GITLEAKS_CONFIG=${AGENT_GUARD_GITLEAKS_CONFIG:-"$ROOT_DIR/config/gitleaks.toml"}
 DENY_READ_PATHS=${AGENT_GUARD_DENY_READ_PATHS:-"$ROOT_DIR/config/deny-read-paths.txt"}
 DENY_BASH_PATTERNS=${AGENT_GUARD_DENY_BASH_PATTERNS:-"$ROOT_DIR/config/deny-bash-patterns.txt"}
 GITLEAKS_PRIVATE_BIN_DIR=${AGENT_GUARD_GITLEAKS_BIN_DIR:-${AGENT_GUARD_BIN_DIR:-$HOME/.agent-guard/bin}}
+LIVE_PRE_TOOL_PROBE=AGENT_GUARD_LIVE_PRE_TOOL_PROBE
+LIVE_POST_TOOL_PROBE=AGENT_GUARD_LIVE_POST_TOOL_PROBE
 
 usage() {
   cat >&2 <<'EOF'
@@ -1447,6 +1449,16 @@ check_bash_command() {
   [ -n "$cmd" ] || return 0
   workdir=$(json_value '.tool_input.workdir // .tool_input.cwd // .cwd // empty' "$input")
 
+  # A harmless, deterministic sentinel lets setup prove that the host really
+  # dispatched PreToolUse without naming or touching any sensitive file. Keep
+  # this before configurable policy checks so the probe is stable everywhere.
+  case "$cmd" in
+    *"$LIVE_PRE_TOOL_PROBE"*)
+      info "$PROGRAM: blocked the live PreToolUse probe"
+      exit 2
+      ;;
+  esac
+
   [ -f "$DENY_BASH_PATTERNS" ] || die "deny bash policy not found: $DENY_BASH_PATTERNS"
   patterns=$(mktemp_file) || die "failed to create temp file"
   grep -Ev '^[[:space:]]*(#|$)' "$DENY_BASH_PATTERNS" >"$patterns"
@@ -1724,6 +1736,11 @@ detect_output_secrets() {
     printf '%s\n' "$text" \
       | grep -Eio 'bearer[ \t]+[-A-Za-z0-9._~+/=]+' 2>/dev/null \
       | awk '{ tok = $2; if (length(tok) >= 8) print tok }' || true
+    # The paired harmless sentinel proves that PostToolUse can rewrite a live
+    # host result. It is deliberately not credential-shaped and is used only as
+    # a dispatch probe; the ordinary smoke tests cover real detection rules.
+    printf '%s\n' "$text" \
+      | grep -Eo "$LIVE_POST_TOOL_PROBE" 2>/dev/null || true
   } | awk 'NF' | sort -u
 }
 

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -2,7 +2,7 @@
 set -u
 
 PROGRAM=agent-guard
-VERSION=1.10.0
+VERSION=1.10.1
 
 # Resolve the script's own path, following symlinks. The bootstrap installer
 # drops a symlink at ~/.local/bin/agent-guard that points into ~/.agent-guard/
@@ -1727,6 +1727,27 @@ detect_output_secrets() {
   } | awk 'NF' | sort -u
 }
 
+# `printenv NAME` prints only the value, so the output loses the secret-bearing
+# variable name that secretish_env_values needs as context. Reconstruct that
+# context from simple variable-name arguments, then emit only the detected
+# values for literal redaction of the original bare output. This intentionally
+# ignores options and invalid names; the normal gitleaks scan still covers them.
+detect_printenv_argument_secrets() {
+  [ "$#" -gt 1 ] || return 0
+  cmd_name=${1##*/}
+  [ "$cmd_name" = printenv ] || return 0
+  shift
+  for name in "$@"; do
+    case "$name" in
+      [A-Za-z_]* )
+        case "$name" in *[!A-Za-z0-9_]*) continue ;; esac
+        value=$(printenv "$name" 2>/dev/null) || continue
+        printf '%s=%s\n' "$name" "$value"
+        ;;
+    esac
+  done | secretish_env_values
+}
+
 # Replace every detected secret literal with a placeholder inside ANY string leaf
 # of the tool_response JSON ($1), preserving the original shape exactly
 # (updatedToolOutput must match the tool's native output shape). $2 is the
@@ -2034,7 +2055,12 @@ do_exec() {
   # Secret-literal redaction (AGENT_GUARD_OUTPUT_REDACT, default mask). Fail-safe:
   # on any error the original output is preserved rather than swallowed.
   if output_redact_enabled; then
-    secrets=$(detect_output_secrets "$masked" 2>/dev/null) || secrets=''
+    secrets=$(
+      {
+        detect_output_secrets "$masked"
+        detect_printenv_argument_secrets "$@"
+      } 2>/dev/null | awk 'NF' | sort -u
+    ) || secrets=''
     if [ -n "$secrets" ]; then
       r=$(redact_plaintext_literal "$masked" "$secrets" 2>/dev/null)
       [ -n "$r" ] && masked=$r

--- a/plugins/agent-guard/skills/setup-agent-guard/SKILL.md
+++ b/plugins/agent-guard/skills/setup-agent-guard/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: setup-agent-guard
-description: Diagnose, install, and verify the jq and gitleaks dependencies required by the Agent Guard plugin. Use when Agent Guard reports degraded protection, a SessionStart warning asks for setup, plugin hooks fail because a dependency is missing, or a user asks to finish or repair Agent Guard installation.
+description: Diagnose, install, and verify Agent Guard's plugin-local binary, jq and gitleaks dependencies, Codex hook trust, and live hook protection. Use when Agent Guard reports degraded protection, a SessionStart warning asks for setup, plugin hooks fail or appear bypassed, or a user asks to finish or repair Agent Guard installation.
 ---
 
 # Setup Agent Guard
@@ -9,9 +9,11 @@ Make Agent Guard operational without silently changing the machine. Diagnose fir
 
 ## Workflow
 
-1. Resolve the Agent Guard executable.
-   - Prefer `command -v agent-guard`.
-   - If it is not on `PATH`, use the plugin binary two directories above this skill: `../../bin/agent-guard` relative to this `SKILL.md` directory.
+1. Resolve the Agent Guard executable without confusing the plugin with a standalone install.
+   - First use the plugin binary two directories above this skill: `../../bin/agent-guard` relative to this `SKILL.md` directory.
+   - Resolve the path from the skill directory, confirm that it is executable, and use it for every plugin diagnosis and smoke test.
+   - Separately inspect `command -v agent-guard`, if present. Compare its `version` with the plugin binary and report version drift, but do not substitute it for the plugin binary or modify the standalone installation without explicit approval.
+   - Only fall back to `command -v agent-guard` when the plugin-relative binary is unavailable, and clearly state that plugin-local verification could not be completed.
    - Do not install a second copy of Agent Guard merely to get a command on `PATH`.
 
 2. Run the read-only diagnosis:
@@ -37,21 +39,38 @@ Make Agent Guard operational without silently changing the machine. Diagnose fir
 
    Never substitute an unverified checksum and never bypass TLS verification.
 
-5. Verify the installation:
+5. Verify the plugin-local installation:
 
    ```sh
    "<agent-guard-bin>" check
    "<agent-guard-bin>" smoke-test
    ```
 
-   Treat `check` as dependency/config validation and `smoke-test` as the runtime proof. Report either both passing or the exact failing command and error.
+   Treat `check` as dependency/config validation and `smoke-test` as proof of the binary's own behavior. They do not prove that the host is dispatching plugin hooks.
 
-6. Restart the host application after hook or dependency setup if protection was already loaded in a degraded state. In Codex, plugin hooks provide the supported command boundary; do not configure the Claude-specific bang-command shell wrapper as a Codex setup step.
+6. Verify Codex hook readiness before claiming that protection is active.
+   - Confirm that the Agent Guard plugin is installed and enabled.
+   - In Codex **Settings > Hooks**, inspect Agent Guard's `SessionStart`, `PreToolUse`, `PostToolUse`, and `Stop` hooks. Every hook must be enabled and trusted. Treat `Untrusted` and `Modified` as inactive; an updated hook must be reviewed and trusted again.
+   - Do not edit `hooks.state` or copy trust hashes into `config.toml`. Hook trust is a user security decision and must go through the Codex trust UI.
+   - If `SessionStart` itself is untrusted, explain that it cannot emit the setup warning or invoke this skill automatically.
+
+7. Run live host probes through the normal command tool that Codex selected for the current task. Do not read a real sensitive file.
+   - Pre-tool probe:
+
+     ```sh
+     printf '%s\n' 'AGENT_GUARD_LIVE_PROBE_EXECUTED'; : # cat .env
+     ```
+
+     The expected result is an Agent Guard block before the marker is printed. If the marker appears, the live command boundary is not protected.
+   - Post-tool probe: print the documented fake value `DEMO_TOKEN=ghp_abcdefghijklmnopqrstuvwxyz0123456789`. The raw value must not reach the model; expect a masked or sanitized replacement.
+   - If Codex exposes only a wrapping/orchestration tool such as `functions.exec`, test that exact route. Agent Guard cannot replace or wrap Codex's host executor; it can protect only nested calls that Codex exposes to plugin hooks. If either probe bypasses the hook, report the route as unsupported in the current host instead of claiming successful setup.
+
+8. After dependency, enablement, or trust changes, restart Codex and run both live probes again in a new task. In Codex, plugin hooks provide the supported command boundary; do not configure the Claude-specific bang-command shell wrapper as a Codex setup step.
 
 ## Safety And Host Boundaries
 
 - Dependency setup is intentionally approval-gated. A SessionStart hook may diagnose and recommend this skill, but it must never install software itself.
 - If installation is declined, leave the machine unchanged and state that Agent Guard is in degraded mode.
-- Codex currently protects supported hook surfaces such as `Bash`, `apply_patch`, and MCP tools. Do not claim that Codex hooks intercept arbitrary read, grep, or web-search tools.
+- Codex protects only hook surfaces that the current host actually dispatches, such as supported `Bash`, `apply_patch`, and MCP calls. Do not claim that Codex hooks intercept arbitrary read, grep, web-search, or opaque wrapping-tool calls.
 - `agent-guard setup-shell`, `agx`, and the bang-command guard are optional Claude Code shell-snapshot integrations. Only configure them when the user explicitly asks for Claude Code coverage.
-- If plugin hooks are not trusted or enabled, explain that dependencies alone do not activate runtime protection; trust the plugin hooks and restart the host.
+- If plugin hooks are not trusted, enabled, or reached by both live probes, explain that dependencies alone do not activate runtime protection. Never report Agent Guard as operational based only on `check` and `smoke-test`.

--- a/plugins/agent-guard/skills/setup-agent-guard/SKILL.md
+++ b/plugins/agent-guard/skills/setup-agent-guard/SKILL.md
@@ -58,11 +58,17 @@ Make Agent Guard operational without silently changing the machine. Diagnose fir
    - Pre-tool probe:
 
      ```sh
-     printf '%s\n' 'AGENT_GUARD_LIVE_PROBE_EXECUTED'; : # cat .env
+     printf '%s\n' 'AGENT_GUARD_LIVE_PRE_TOOL_PROBE'
      ```
 
      The expected result is an Agent Guard block before the marker is printed. If the marker appears, the live command boundary is not protected.
-   - Post-tool probe: print the documented fake value `DEMO_TOKEN=ghp_abcdefghijklmnopqrstuvwxyz0123456789`. The raw value must not reach the model; expect a masked or sanitized replacement.
+   - Post-tool probe:
+
+     ```sh
+     printf '%s\n' 'AGENT_GUARD_LIVE_POST_TOOL_PROBE'
+     ```
+
+     The raw marker must not reach the model; expect `[REDACTED]` in a masked or sanitized replacement. These sentinels prove host dispatch without reading a sensitive file or printing a credential-shaped value; the plugin-local smoke test separately proves the real detection rules.
    - If Codex exposes only a wrapping/orchestration tool such as `functions.exec`, test that exact route. Agent Guard cannot replace or wrap Codex's host executor; it can protect only nested calls that Codex exposes to plugin hooks. If either probe bypasses the hook, report the route as unsupported in the current host instead of claiming successful setup.
 
 8. After dependency, enablement, or trust changes, restart Codex and run both live probes again in a new task. In Codex, plugin hooks provide the supported command boundary; do not configure the Claude-specific bang-command shell wrapper as a Codex setup step.

--- a/plugins/agent-guard/skills/setup-agent-guard/agents/openai.yaml
+++ b/plugins/agent-guard/skills/setup-agent-guard/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Set Up Agent Guard"
-  short_description: "Check and install Agent Guard dependencies safely"
-  default_prompt: "Use $setup-agent-guard to check Agent Guard dependencies, guide approved installation, and verify protection."
+  short_description: "Verify Agent Guard setup and live hooks"
+  default_prompt: "Use $setup-agent-guard to verify the plugin-local Agent Guard binary, guide approved dependency installation, confirm Codex hook trust, and prove live protection."

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -2677,7 +2677,9 @@ fi
 # low-entropy or documented fake value under a secret-bearing key is still
 # masked by exec and by the Claude bang-command wrapper.
 PRINTENV_KEY='DEMO_TOKEN'
-PRINTENV_VAL='ghp_''abcdefghijklmnopqrstuvwxyz0123456789'
+# Keep the value deliberately non-vendor-shaped: this regression proves that
+# the variable name supplies the missing secret context for bare printenv output.
+PRINTENV_VAL='documented-fake-printenv-value-123456'
 exec_printenv=$(DEMO_TOKEN="$PRINTENV_VAL" "$PLUGIN_ROOT/bin/agent-guard" exec -- printenv "$PRINTENV_KEY" 2>/dev/null)
 if printf '%s' "$exec_printenv" | grep -q '\[REDACTED\]' \
    && ! printf '%s' "$exec_printenv" | grep -q "$PRINTENV_VAL"; then

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -128,8 +128,9 @@ if grep -Fq '../../bin/agent-guard' "$setup_skill" \
    && grep -Fq 'Compare its `version` with the plugin binary' "$setup_skill" \
    && grep -Fq 'Settings > Hooks' "$setup_skill" \
    && grep -Fq '`Untrusted` and `Modified` as inactive' "$setup_skill" \
-   && grep -Fq 'AGENT_GUARD_LIVE_PROBE_EXECUTED' "$setup_skill" \
-   && grep -Fq 'DEMO_TOKEN=ghp_abcdefghijklmnopqrstuvwxyz0123456789' "$setup_skill" \
+   && grep -Fq 'AGENT_GUARD_LIVE_PRE_TOOL_PROBE' "$setup_skill" \
+   && grep -Fq 'AGENT_GUARD_LIVE_POST_TOOL_PROBE' "$setup_skill" \
+   && ! grep -Fq 'cat .env' "$setup_skill" \
    && grep -Fq '`functions.exec`' "$setup_skill" \
    && grep -Fq 'They do not prove that the host is dispatching plugin hooks' "$setup_skill"; then
   ok "Codex setup skill verifies plugin-local, trust, and live-hook layers"
@@ -1479,6 +1480,10 @@ expect_json_status 0 "Bash on benign command passes" \
   '{"tool_name":"Bash","tool_input":{"command":"ls -la"}}' \
   hook-pre-tool
 
+expect_json_status 2 "live PreToolUse sentinel is blocked before execution" \
+  '{"tool_name":"Bash","tool_input":{"command":"printf %s AGENT_GUARD_LIVE_PRE_TOOL_PROBE"}}' \
+  hook-pre-tool
+
 expect_json_status 2 "MultiEdit with one secret edit is blocked" \
   '{"tool_name":"MultiEdit","tool_input":{"edits":[{"new_string":"clean line"},{"new_string":"AGENT_GUARD_TEST_SECRET"}]}}' \
   hook-pre-tool
@@ -2340,6 +2345,16 @@ if [ "$post_status" -eq 0 ] \
   ok "post-tool masks a gitleaks-detected secret in Bash stdout (shape preserved)"
 else
   not_ok "post-tool masks a gitleaks-detected secret in Bash stdout (status $post_status)"
+  printf '%s\n' "$post_out" | sed 's/^/  out: /'
+fi
+
+post_tool_out '{"tool_name":"Bash","tool_input":{"command":"printf sentinel"},"tool_response":{"stdout":"AGENT_GUARD_LIVE_POST_TOOL_PROBE\n","stderr":"","interrupted":false,"isImage":false}}'
+post_out=$(cat "$OUT")
+if printf '%s' "$post_out" | grep -q '\[REDACTED\]' \
+   && ! printf '%s' "$post_out" | grep -q 'AGENT_GUARD_LIVE_POST_TOOL_PROBE'; then
+  ok "live PostToolUse sentinel is rewritten before reaching the model"
+else
+  not_ok "live PostToolUse sentinel is rewritten before reaching the model"
   printf '%s\n' "$post_out" | sed 's/^/  out: /'
 fi
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -120,6 +120,23 @@ else
   not_ok "Codex plugin manifest explicitly declares hook and skill paths"
 fi
 
+# Guided setup must verify the installed plugin itself and the live Codex hook
+# boundary. A standalone PATH binary or a passing binary smoke test is not proof
+# that the plugin hooks are trusted or dispatched by the host.
+setup_skill="$PLUGIN_ROOT/skills/setup-agent-guard/SKILL.md"
+if grep -Fq '../../bin/agent-guard' "$setup_skill" \
+   && grep -Fq 'Compare its `version` with the plugin binary' "$setup_skill" \
+   && grep -Fq 'Settings > Hooks' "$setup_skill" \
+   && grep -Fq '`Untrusted` and `Modified` as inactive' "$setup_skill" \
+   && grep -Fq 'AGENT_GUARD_LIVE_PROBE_EXECUTED' "$setup_skill" \
+   && grep -Fq 'DEMO_TOKEN=ghp_abcdefghijklmnopqrstuvwxyz0123456789' "$setup_skill" \
+   && grep -Fq '`functions.exec`' "$setup_skill" \
+   && grep -Fq 'They do not prove that the host is dispatching plugin hooks' "$setup_skill"; then
+  ok "Codex setup skill verifies plugin-local, trust, and live-hook layers"
+else
+  not_ok "Codex setup skill verifies plugin-local, trust, and live-hook layers"
+fi
+
 for event in PreToolUse PostToolUse Stop; do
   claude_canonical=$(jq -r ".hooks.${event}[0].matcher" "$PLUGIN_ROOT/hooks/hooks.json")
   codex_canonical=$(jq -r ".hooks.${event}[0].matcher" "$PLUGIN_ROOT/hooks.json")
@@ -2641,6 +2658,20 @@ else
   printf '%s\n' "  out: $exec_out"
 fi
 
+# `printenv NAME` emits a bare value. Preserve the variable-name context so a
+# low-entropy or documented fake value under a secret-bearing key is still
+# masked by exec and by the Claude bang-command wrapper.
+PRINTENV_KEY='DEMO_TOKEN'
+PRINTENV_VAL='ghp_''abcdefghijklmnopqrstuvwxyz0123456789'
+exec_printenv=$(DEMO_TOKEN="$PRINTENV_VAL" "$PLUGIN_ROOT/bin/agent-guard" exec -- printenv "$PRINTENV_KEY" 2>/dev/null)
+if printf '%s' "$exec_printenv" | grep -q '\[REDACTED\]' \
+   && ! printf '%s' "$exec_printenv" | grep -q "$PRINTENV_VAL"; then
+  ok "exec masks a bare printenv value using its variable-name context"
+else
+  not_ok "exec masks a bare printenv value using its variable-name context"
+  printf '%s\n' "  out: $exec_printenv"
+fi
+
 # Exit-code passthrough: the wrapped command's status propagates.
 "$PLUGIN_ROOT/bin/agent-guard" exec -- sh -c 'exit 7' >/dev/null 2>&1
 if [ "$?" -eq 7 ]; then
@@ -2859,6 +2890,16 @@ if [ "$bg_out_cc" = hello-plain ]; then
   ok "bang guard is inert (passthrough) outside Claude Code"
 else
   not_ok "bang guard passthrough outside Claude Code (got: $bg_out_cc)"
+fi
+
+bg_printenv=$(DEMO_TOKEN="$PRINTENV_VAL" AGENT_GUARD_BIN="$PLUGIN_ROOT/bin/agent-guard" \
+  CLAUDECODE=1 sh -c '. "$1"; printenv DEMO_TOKEN' _ "$bg_dir/guard.sh" 2>/dev/null)
+if printf '%s' "$bg_printenv" | grep -q '\[REDACTED\]' \
+   && ! printf '%s' "$bg_printenv" | grep -q "$PRINTENV_VAL"; then
+  ok "Claude bang guard masks a bare printenv value"
+else
+  not_ok "Claude bang guard masks a bare printenv value"
+  printf '%s\n' "  out: $bg_printenv"
 fi
 
 AGENT_GUARD_BIN="$PLUGIN_ROOT/bin/agent-guard" \

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -2680,7 +2680,7 @@ PRINTENV_KEY='DEMO_TOKEN'
 # Keep the value deliberately non-vendor-shaped: this regression proves that
 # the variable name supplies the missing secret context for bare printenv output.
 PRINTENV_VAL='documented-fake-printenv-value-123456'
-exec_printenv=$(DEMO_TOKEN="$PRINTENV_VAL" "$PLUGIN_ROOT/bin/agent-guard" exec -- printenv "$PRINTENV_KEY" 2>/dev/null)
+exec_printenv=$(DEMO_TOKEN="${PRINTENV_VAL}" "$PLUGIN_ROOT/bin/agent-guard" exec -- printenv "$PRINTENV_KEY" 2>/dev/null)
 if printf '%s' "$exec_printenv" | grep -q '\[REDACTED\]' \
    && ! printf '%s' "$exec_printenv" | grep -q "$PRINTENV_VAL"; then
   ok "exec masks a bare printenv value using its variable-name context"
@@ -2909,7 +2909,7 @@ else
   not_ok "bang guard passthrough outside Claude Code (got: $bg_out_cc)"
 fi
 
-bg_printenv=$(DEMO_TOKEN="$PRINTENV_VAL" AGENT_GUARD_BIN="$PLUGIN_ROOT/bin/agent-guard" \
+bg_printenv=$(DEMO_TOKEN="${PRINTENV_VAL}" AGENT_GUARD_BIN="$PLUGIN_ROOT/bin/agent-guard" \
   CLAUDECODE=1 sh -c '. "$1"; printenv DEMO_TOKEN' _ "$bg_dir/guard.sh" 2>/dev/null)
 if printf '%s' "$bg_printenv" | grep -q '\[REDACTED\]' \
    && ! printf '%s' "$bg_printenv" | grep -q "$PRINTENV_VAL"; then


### PR DESCRIPTION
## Summary

- make Agent Guard 1.10.1 verify Codex Desktop hook trust and live dispatch explicitly
- add harmless, dedicated PreToolUse and PostToolUse sentinels for live host verification
- document the boundary between plugin hooks and Codex's outer `functions.exec` transport
- distinguish binary smoke tests from live host-hook verification
- preserve variable-name context for `printenv NAME` so Claude Code shell wrapping redacts bare secret values
- add regression coverage for the Codex setup contract and Claude Code command wrappers

## Root cause

The previous setup flow could prove that the Agent Guard binary worked, but it could not prove that Codex Desktop had trusted and dispatched the installed plugin hooks. The experimental Claude Code shell wrapper also scanned bare `printenv` output without the environment variable name, which could remove the signal needed for secret classification.

The first live-probe design used sensitive-looking examples. HOL correctly classified those instructions as risky, so the final design uses dedicated non-sensitive sentinels. Binary smoke tests continue to exercise the real deny-list and secret-redaction rules.

## Impact

Users now get an explicit trust-and-live-probe workflow for Codex, clear limitations for outer command transport, and reliable redaction for simple `printenv NAME` calls through the Claude Code wrapper. Live verification no longer requires naming a sensitive file or printing a credential-shaped value.

## Functional verification

- `make test` — 417 passed, 0 failed
- `make check`
- `git diff --check`
- `sh -n plugins/agent-guard/bin/agent-guard`
- Ruby Psych parsing of `plugins/agent-guard/skills/setup-agent-guard/SKILL.md` frontmatter and `plugins/agent-guard/skills/setup-agent-guard/agents/openai.yaml`
- isolated Codex install:
  - `CODEX_HOME=/private/tmp/agent-guard-codex-home-1101 codex plugin marketplace add <workspace>`
  - `CODEX_HOME=/private/tmp/agent-guard-codex-home-1101 codex plugin add agent-guard@agent-guard`
  - installed-cache `agent-guard version`, `setup`, `check`, and `smoke-test`
- live-hook sentinel regressions:
  - PreToolUse blocks `AGENT_GUARD_LIVE_PRE_TOOL_PROBE` before execution
  - PostToolUse rewrites `AGENT_GUARD_LIVE_POST_TOOL_PROBE` before model delivery
- Claude Code compatibility:
  - `claude --version`
  - plugin-local `agent-guard setup`, `check`, and `smoke-test`
  - direct Claude `PreToolUse` payload blocked before a safe marker executed
  - direct Claude `PostToolUse` payload returned a redacted replacement
  - `DEMO_TOKEN=<documented fake token> agent-guard exec -- printenv DEMO_TOKEN` returned exactly `[REDACTED]`
  - isolated `setup-shell --zsh --rc /private/tmp/... --claude-bang-guard` wrapped `cat`, `head`, and `printenv` under `CLAUDECODE=1`

A live non-interactive Claude API session could not be exercised in this sandbox because outbound access to `api.anthropic.com` is blocked. The release will be reinstalled and verified through the official Codex and Claude plugin flows after merge.
