### PR TITLE
Make command wrapping stable by default in v2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "agent-guard",
       "source": "./plugins/agent-guard",
       "description": "Real-time secret-leak guardrails for AI coding agents (Claude Code, Codex), Git hooks, and CI.",
-      "version": "1.10.1"
+      "version": "2.0.0"
     }
   ]
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,6 +231,18 @@ jobs:
           git checkout main
           git pull --ff-only origin main
 
+          # Releasing a new major line must not move an older major's compatibility
+          # tag. Capture v1 before publishing v2+ and prove it is unchanged after
+          # the new moving tag is pushed.
+          legacy_v1_before=""
+          if [ "${maj}" != "v1" ]; then
+            legacy_v1_before=$(git ls-remote origin refs/tags/v1 | awk '{print $1; exit}')
+            if [ -z "$legacy_v1_before" ]; then
+              echo "required legacy moving tag v1 is missing; refusing to publish ${maj}"
+              exit 1
+            fi
+          fi
+
           # Idempotent tag create. The Detect step's advisory skip_tag was
           # computed before any PR-cycle merge could change main HEAD, so the
           # authoritative comparison happens here against the freshly-pulled
@@ -252,6 +264,14 @@ jobs:
           # Major moving tag is idempotent by design (-f always replaces).
           git tag -f "${maj}"
           git push origin "${maj}" --force
+          if [ -n "$legacy_v1_before" ]; then
+            legacy_v1_after=$(git ls-remote origin refs/tags/v1 | awk '{print $1; exit}')
+            if [ "$legacy_v1_after" != "$legacy_v1_before" ]; then
+              echo "legacy moving tag v1 changed while publishing ${maj}; aborting release"
+              exit 1
+            fi
+            echo "verified legacy moving tag v1 remains at $legacy_v1_after"
+          fi
 
           # Build the tarball outside the directory tar is enumerating to
           # avoid the "file changed as we read it" race documented for runs
@@ -260,7 +280,7 @@ jobs:
           #
           # Tarball root is plugins/agent-guard/ so the bootstrap-extracted
           # layout (~/.agent-guard/bin/agent-guard) stays unchanged for
-          # existing v1.2.x Direct-CLI users on update.
+          # existing Direct-CLI users across major-version updates.
           tarball_tmp=$(mktemp -d)/agent-guard-${v}.tar.gz
           scripts/build-release-tarball.sh "$v" "$tarball_tmp"
           mv "$tarball_tmp" "agent-guard-${v}.tar.gz"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v2.0.0 - 2026-07-14
+
+- feat(shell)!: make Claude command wrapping stable and default-on, with `--no-command-wrapping` and `AGENT_GUARD_COMMAND_WRAPPING=off` opt-outs
+- feat(install): enable command wrapping from direct bootstrap and add `/agent-guard:setup-shell` for plugin installs
+- docs: add the 1.x to 2.x migration guide and move GitHub Action examples to the preserved `v2` release line
+- ci(release): verify publishing `v2` does not move the existing `v1` compatibility tag
+
 ## v1.10.1 - 2026-07-14
 
 - fix(codex): verify the plugin-local binary, hook trust, and live host dispatch during guided setup

--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ Install from the marketplace:
 /plugin marketplace add JeongJaeSoon/agent-guard
 /plugin install agent-guard@agent-guard
 /reload-plugins
+/agent-guard:setup-shell
 ```
+
+The last command installs the default-on Claude command wrapping into your shell rc. Restart the shell and Claude Code after it succeeds. Plugin hooks are active after reload; shell wrapping for user-typed `!` commands requires this explicit rc update because plugins cannot edit it during installation.
 
 Verify it's live — ask the agent to read your `.env`:
 
@@ -93,6 +96,7 @@ Install and verify in [Quick start (Claude Code)](#quick-start-claude-code). Use
 ```text
 /agent-guard:verify
 /agent-guard:checksum [VERSION]
+/agent-guard:setup-shell
 ```
 
 ## Codex Plugin
@@ -136,7 +140,7 @@ Install the latest release without cloning:
 curl -fsSL https://github.com/JeongJaeSoon/agent-guard/releases/latest/download/bootstrap.sh | sh
 ```
 
-The installer verifies the release archive checksum, extracts to `~/.agent-guard`, links `agent-guard` into `~/.local/bin`, and runs `agent-guard setup`.
+The installer verifies the release archive checksum, extracts to `~/.agent-guard`, links `agent-guard` into `~/.local/bin`, runs `agent-guard setup`, and installs the default-on shell integration. Set `AGENT_GUARD_COMMAND_WRAPPING=off` on the bootstrap command for a persistent command-wrapping opt-out.
 
 Common commands:
 
@@ -150,7 +154,7 @@ agent-guard smoke-test
 agent-guard checksum
 ```
 
-Override install defaults with `AGENT_GUARD_VERSION`, `AGENT_GUARD_HOME`, or `AGENT_GUARD_BIN_DIR`.
+Override install defaults with `AGENT_GUARD_VERSION`, `AGENT_GUARD_HOME`, `AGENT_GUARD_BIN_DIR`, or `AGENT_GUARD_COMMAND_WRAPPING`.
 
 ## PII Filtering
 
@@ -222,13 +226,13 @@ This sets `core.hooksPath=githooks` only when it will not overwrite an existing 
 Add a workflow step:
 
 ```yaml
-- uses: JeongJaeSoon/agent-guard@v1
+- uses: JeongJaeSoon/agent-guard@v2
   with:
     paths: "."
     gitleaks-checksum: "<sha256 of the gitleaks release archive>"
 ```
 
-Use `@v1` for compatible updates, or pin a full tag / commit SHA for stricter reproducibility.
+Use `@v2` for compatible 2.x updates. The existing `@v1` moving tag remains on the 1.x line; pin `@v1`, a full tag, or a commit SHA when you intentionally stay on 1.x.
 
 Get the checksum with:
 
@@ -280,26 +284,29 @@ eval "$(agent-guard shell-init)"
 Or let `setup-shell` write (and later update) that line for you — idempotently, and by absolute path when `agent-guard` isn't on your `$PATH` yet:
 
 ```sh
-agent-guard setup-shell            # add `--claude-bang-guard` to opt into the bang guard below
+agent-guard setup-shell
 ```
 
 This defines `agx` (a thin wrapper for `agent-guard exec --`) so you can run `agx <cmd>` — in Claude Code, `!agx <cmd>` — and have the output masked before the model sees it. It also installs a **warn-only, non-blocking** nudge (a zsh `preexec` / bash `DEBUG` trap) that reminds you to use `agx` when you run a known secret-loading idiom without it. The nudge never blocks or modifies your command; pass `--bash` or `--zsh` to force a target shell.
 
-### Claude bang-command guard (supported opt-in)
+### Claude command wrapping (stable, default on)
 
-The nudge above relies on a `preexec` / `DEBUG` hook — but Claude Code runs `!` commands from a **shell snapshot** that strips those hooks (and `unalias -a`s), so the nudge never fires for `!`. The snapshot *does* keep shell **functions**, so an opt-in flag installs function overrides for the common dump commands instead:
+The nudge above relies on a `preexec` / `DEBUG` hook — but Claude Code runs `!` commands from a **shell snapshot** that strips those hooks (and `unalias -a`s), so the nudge never fires for `!`. The snapshot *does* keep shell **functions**, so Agent Guard installs function overrides for the common dump commands by default.
+
+The default `shell-init` output overrides `cat`, `head`, and `printenv` so that — **only inside Claude Code** (gated on `$CLAUDECODE`) — they route through `agent-guard exec`, masking their output before the transcript captures it. So `!cat config.txt` gets its secrets redacted automatically, without you remembering to type `agx`. In a normal terminal (`$CLAUDECODE` unset) the overrides stay inert and fall back to plain `cat` / `head` / `printenv` behavior.
+
+Turn automatic wrapping off for one process or shell by exporting `AGENT_GUARD_COMMAND_WRAPPING=off`. For a persistent opt-out, rewrite the managed block without the automatic overrides:
 
 ```sh
-eval "$(agent-guard shell-init --claude-bang-guard)"
+export AGENT_GUARD_COMMAND_WRAPPING=off  # runtime opt-out
+agent-guard setup-shell --no-command-wrapping  # persistent opt-out
 ```
 
-This overrides `cat`, `head`, and `printenv` so that — **only inside Claude Code** (gated on `$CLAUDECODE`) — they route through `agent-guard exec`, masking their output before the transcript captures it. So `!cat config.txt` gets its secrets redacted automatically, without you remembering to type `agx`. In a normal terminal (`$CLAUDECODE` unset) the overrides stay inert and fall back to plain `cat` / `head` / `printenv` behavior.
-
-The binary is resolved at call time in this order: an explicit `$AGENT_GUARD_BIN`, then `agent-guard` on your `$PATH`, then the **absolute path baked into the snippet** at `shell-init` time. The transparent bang guard preflights dependencies too. If the binary cannot resolve or protection is degraded, it **fails open** because the user typed an ordinary `cat`/`head`/`printenv`: it runs the command but prints a loud `output is NOT masked` warning. `agx`, being an explicit mask request, instead fails closed.
+The binary is resolved at call time in this order: an explicit `$AGENT_GUARD_BIN`, then `agent-guard` on your `$PATH`, then the **absolute path baked into the snippet** at `shell-init` time. Transparent command wrapping preflights dependencies too. If the binary cannot resolve or protection is degraded, it **fails open** because the user typed an ordinary `cat`/`head`/`printenv`: it runs the command but prints a loud `output is NOT masked` warning. `agx`, being an explicit mask request, instead fails closed.
 
 Because the plugin (auto-updated by `claude plugin update`) and the binary the integration actually resolves update independently, updating only one side can silently leave `agx` / `!`-command masking on older rules. To catch that, the `shell-init` snippet exports `AGENT_GUARD_SHELL_INIT_VERSION` — the version of the binary it resolved at rc-eval time (whichever of the three paths above won) — and a Claude Code `SessionStart` hook compares that marker against the plugin's own version, showing a **non-blocking warning** on mismatch. Because the marker records what the integration resolved at shell start (not a re-derivation the hook would have to guess), it stays silent unless the integration is genuinely loaded *and* drifting: a user who has `agent-guard` on `$PATH` but never ran `setup-shell` gets no warning, and a plugin-only install pinned to a stale baked binary is still covered. It is a start-up snapshot, so if you upgrade the resolved binary *in place* inside a long-lived shell and then launch Claude Code from it without opening a new shell, the warning reflects the version from when that shell started until you re-source your rc.
 
-> **Works without the CLI on `$PATH` — but a plugin can't edit your rc.** The one manual step for a plugin-only install is getting the `shell-init` line into your shell rc so it loads in every shell (hence every Claude Code snapshot). Run `agent-guard setup-shell --claude-bang-guard` once — invoke it by the plugin binary's absolute path if `agent-guard` isn't on your `$PATH`; it bakes that same absolute path into the line it writes — then restart your shell and any Claude Code session. The former `--experimental-bang-guard` spelling remains a deprecated compatibility alias and is normalized to the stable option when `setup-shell` rewrites the managed block.
+> **Works without the CLI on `$PATH` — but a plugin can't edit your rc.** Direct CLI bootstrap installs the default-on shell integration automatically. For a plugin-only install, run the plugin-local `agent-guard setup-shell` once — invoke it by absolute path if `agent-guard` isn't on your `$PATH`; it bakes that same absolute path into the line it writes — then restart your shell and any Claude Code session. See [Migrating from 1.x to 2.x](docs/migration-v2.md) for old managed blocks and opt-out behavior.
 
 **This is best-effort, not a security control.** It covers only those command names and is trivially bypassed by an absolute path (`/bin/cat`), `source` / `.`, `python -c 'open(...)'`, or a redirection (`< file`). Because `agent-guard exec` buffers the whole output before masking it, **streaming / follow commands would hang** — so `tail` is deliberately *not* wrapped, and you should not `agx` a `tail -f`, a pager, or any long-running program (wrap only terminating dump commands). Output is captured via shell substitution, so wrapping is **text-only** — a binary or NUL-containing read loses embedded NULs and its trailing newline, so use `command cat` / `\cat` for faithful binary output. Each wrapped call also pays a gitleaks scan. Treat it as a convenience nudge for the common cases, not a boundary — the only channel-agnostic fix remains an egress redaction proxy or an upstream `!`-command hook.
 
@@ -312,13 +319,13 @@ Agent Guard is a deterministic, thin guardrail — not a DLP system, EDR, or vau
 - **Path and command blocking use fixed lists.** Read/Grep/Glob blocking matches the paths in `deny-read-paths.txt`; shell blocking matches the idioms in `deny-bash-patterns.txt`. A secret in an unlisted path, or read by an unlisted tool or flag, is not blocked. Extend the lists with `AGENT_GUARD_DENY_READ_PATHS` / `AGENT_GUARD_DENY_BASH_PATTERNS`.
 - **Output masking is best-effort.** Secret-like values in a tool's output (`Bash` stdout/stderr, file reads) are masked in place by the `PostToolUse` redactor (`AGENT_GUARD_OUTPUT_REDACT`, on by default), but detection is heuristic — gitleaks plus a `KEY=value` env-assignment rule. Detection is also **entropy-gated**: a realistic high-entropy credential is masked regardless of context, but a low-entropy value is only caught when its key name looks secret-bearing (`*_TOKEN=`, `PASSWORD:`, …) or its shape carries a distinctive vendor prefix (GitHub `ghp_`/`github_pat_`, AWS `AKIA…`, Anthropic/OpenAI `sk-ant-`/`sk-proj-`, npm `npm_`, GCP `AIza…`, Slack `xox?-`, GitLab `glpat-`, DigitalOcean `dop_v1_` — matched by shape alone, with no entropy filter). A low-entropy secret under a generic variable name with no recognizable prefix passes through unmasked, non-secret-but-sensitive data (internal hostnames, base URLs, private config) is never a match at all, and other unusual or custom secret formats can still slip through. The redactor also only sees results of the agent's *tool calls*. PII masking (`AGENT_GUARD_PII_HOOK_MODE=mask`) is likewise regex-based: it can over-match (a version string read as an IPv4) or miss locale formats it has no rule for. Both the secret redactor and the PII masker walk JSON string *values* only — a secret or PII string that appears as an object *key* is left unmasked, because rewriting keys could collapse two distinct keys onto one placeholder and drop an entry. Treat output masking as defense in depth and keep real secrets and personal data out of agent sessions entirely.
 - **Bash detection is pattern-based.** The denylist targets common-accident and obvious-malicious idioms; an actively-evading agent can craft a command that matches none of them. Treat shell blocking as defense in depth, not a complete adversarial boundary.
-- **User-typed shell-escape commands bypass every hook.** Agent Guard works entirely through tool-use hooks (`PreToolUse` / `PostToolUse`) and git hooks. A command the user runs directly through the host's interactive shell escape — for example a `!`-prefixed command typed at the agent prompt — never becomes a tool call, so **no** Agent Guard hook fires: neither the input block nor the output redactor. A secret that such a command prints (e.g. an env- or vault-reading CLI whose output is not redirected to `/dev/null`) lands in the session transcript unmasked. The recommended mitigation is to run such commands via `agx <cmd>` / `agent-guard exec -- <cmd>` (see [Shell integration](#shell-integration-masking--shell-escape-output)) so their output is masked *before* it reaches the model — or, for automatic masking of the common dump commands, opt into the [Claude bang-command guard](#claude-bang-command-guard-supported-opt-in). Alternatively, run secret-loading commands *through* the agent's tools so the hooks apply, or redirect their output away from the transcript — both streams, since many CLIs print credentials or secret-bearing diagnostics to stderr (`>/dev/null 2>&1`).
+- **User-typed shell-escape commands bypass every hook.** Agent Guard works entirely through tool-use hooks (`PreToolUse` / `PostToolUse`) and git hooks. A command the user runs directly through the host's interactive shell escape — for example a `!`-prefixed command typed at the agent prompt — never becomes a tool call, so **no** Agent Guard hook fires: neither the input block nor the output redactor. A secret that such a command prints (e.g. an env- or vault-reading CLI whose output is not redirected to `/dev/null`) lands in the session transcript unmasked. The recommended mitigation is to run such commands via `agx <cmd>` / `agent-guard exec -- <cmd>` (see [Shell integration](#shell-integration-masking--shell-escape-output)) so their output is masked *before* it reaches the model, or use the default-on [Claude command wrapping](#claude-command-wrapping-stable-default-on) for the common dump commands. Alternatively, run secret-loading commands *through* the agent's tools so the hooks apply, or redirect their output away from the transcript — both streams, since many CLIs print credentials or secret-bearing diagnostics to stderr (`>/dev/null 2>&1`).
 
 For defense in depth, pair Agent Guard with GitHub Secret Scanning / Push Protection and a secrets manager so credentials never reach the working tree.
 
 ## Coverage benchmark
 
-`make bench` runs a deterministic, per-channel leak-prevention benchmark against the **real** gitleaks engine, classifying each case as `blocked` / `masked` / `leaked` (plus `false-positive` for benign controls) across the read-tool, bash-read, bash-cmd, bash-output, read-output, mcp-output, and `!` bang channels. It honestly records the `!` bang channel as structurally uncovered and surfaces coverage gaps as measurements rather than hiding them. See [`docs/benchmark.md`](docs/benchmark.md) for the channel model, latest results, and findings.
+`make bench` runs a deterministic, per-channel leak-prevention benchmark against the **real** gitleaks engine, classifying each case as `blocked` / `masked` / `leaked` (plus `false-positive` for benign controls) across the read-tool, bash-read, bash-cmd, bash-output, read-output, mcp-output, and `!` bang channels. It honestly records the raw `!` channel as structurally uncovered by hooks; default command wrapping and explicit `agx` are reported as best-effort shell mitigations, not counted as hook coverage. See [`docs/benchmark.md`](docs/benchmark.md) for the channel model, latest results, and findings.
 
 ## Configuration
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,11 +3,12 @@
 ## Supported versions
 
 Agent Guard ships fixes on the latest release line. Use the most recent tag:
-`@v1` for the GitHub Action, and the latest release for CLI and plugin installs.
+`@v2` for the GitHub Action, and the latest release for CLI and plugin installs.
 
 | Version | Supported |
 |---|---|
-| Latest release (1.x) | ✅ |
+| Latest release (2.x) | ✅ |
+| 1.x / `@v1` | Security fixes only |
 | Older 1.x tags | Best effort |
 
 ## Reporting a vulnerability

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,12 +5,15 @@
 #   curl -fsSL https://github.com/JeongJaeSoon/agent-guard/releases/latest/download/bootstrap.sh | sh
 #
 # Environment overrides:
-#   AGENT_GUARD_VERSION   pin a specific version (e.g. 1.2.0). Defaults to the
+#   AGENT_GUARD_VERSION   pin a specific version (e.g. 2.0.0). Defaults to the
 #                         latest release resolved via the GitHub redirect.
 #   AGENT_GUARD_HOME      install destination (default: $HOME/.agent-guard).
 #   AGENT_GUARD_BIN_DIR   directory the agent-guard symlink lives in (default:
 #                         $HOME/.local/bin).
 #   AGENT_GUARD_REPO      override the source repo (default: JeongJaeSoon/agent-guard).
+#   AGENT_GUARD_COMMAND_WRAPPING
+#                         command wrapping is installed on by default. Set to
+#                         off, false, no, or 0 for a persistent opt-out.
 
 set -eu
 
@@ -98,6 +101,24 @@ main() {
   # 'setup' may exit 1 if deps are missing; that's expected and not a bootstrap
   # failure -- the user just gets the install hints.
   "$bin_path" setup || true
+  info ""
+
+  case "${AGENT_GUARD_COMMAND_WRAPPING:-on}" in
+    0|off|OFF|false|FALSE|no|NO)
+      info "$prog: installing shell integration with command wrapping off"
+      if ! "$bin_path" setup-shell --no-command-wrapping; then
+        info "$prog: WARNING: shell integration was not installed; run:"
+        info "  $bin_path setup-shell --no-command-wrapping"
+      fi
+      ;;
+    *)
+      info "$prog: installing shell integration with command wrapping on"
+      if ! "$bin_path" setup-shell; then
+        info "$prog: WARNING: shell integration was not installed; run:"
+        info "  $bin_path setup-shell"
+      fi
+      ;;
+  esac
   info ""
   info "$prog: done. v${VERSION} installed at $HOME_DIR."
 }

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -35,7 +35,7 @@ interception point:
 | `read-output` | a secret in a non-denylisted file's contents | `PostToolUse` → mask |
 | `mcp-output` | a secret in an MCP tool response | `PostToolUse` → mask |
 | `bang` | a `!`-prefixed shell-escape (`!cat .env`) | **none — no hook fires** |
-| `bang-wrapped` | `!agent-guard exec -- <cmd>` | `exec` wrapper → mask |
+| `bang-wrapped` | `!agent-guard exec -- <cmd>` | explicit `exec` wrapper → mask |
 
 ## Latest results
 
@@ -63,9 +63,9 @@ Engine `agent-guard 1.5.0`, `gitleaks 8.30.0`:
 
 - Passive hook-channel leak-prevention: **9/9 (100%)** secret cases blocked or masked (on the
   channels + variants tested — see *Not yet covered* for the important caveat). This counts
-  only channels a hook covers automatically; the opt-in `bang-wrapped` case is **not** folded in.
+  only channels a hook covers automatically; the explicit `bang-wrapped` case is **not** folded in.
 - `!` bang channel: **UNCOVERED** — no hook fires.
-- `!` bang + `agent-guard exec` (opt-in): **masked** — a mitigation the user must invoke, reported
+- `!` bang + `agent-guard exec` (explicit): **masked** — a mitigation the user must invoke, reported
   separately so it never inflates the passive-coverage number.
 - False-positive rate: **1/4 (25%)** benign cases mis-flagged.
 
@@ -93,8 +93,10 @@ peer (nopeek, claude-guard, Runwall, Cursor, Windsurf, Aider, Continue) shares t
 spot. The only channel-agnostic fix is to move the boundary off the hook system entirely: an
 **egress redaction proxy** in front of the model API (the approach taken by Lakera, Nightfall,
 Prompt Security, LiteLLM's `hide-secrets`, etc.), which sees every prompt regardless of how
-the agent produced it. Agent Guard's in-scope mitigation is the opt-in `agent-guard exec`
-wrapper (`bang-wrapped`), which masks the command's output before it reaches the model.
+the agent produced it. Agent Guard 2.x enables best-effort wrapping for `cat`, `head`, and
+`printenv` by default inside Claude Code, and keeps the explicit `agent-guard exec` / `agx`
+wrapper (`bang-wrapped`) for other terminating commands. The benchmark keeps raw `bang`
+separate because neither mitigation turns the shell-escape channel into a hook boundary.
 
 See also the upstream request to close this at the source:
 [`docs/upstream-bang-hook-request.md`](upstream-bang-hook-request.md), and Claude Code issue

--- a/docs/migration-v2.md
+++ b/docs/migration-v2.md
@@ -1,0 +1,96 @@
+# Migrating from Agent Guard 1.x to 2.x
+
+Agent Guard 2.0 makes Claude command wrapping stable and default-on. The plugin
+hooks, `agent-guard exec`, `agx`, policy environment variables, Git hook layout,
+and release archive layout remain compatible with 1.x.
+
+## Breaking changes
+
+- `shell-init` and `setup-shell` now enable the Claude `cat`, `head`, and
+  `printenv` wrappers by default. In 1.10.x, these wrappers required an opt-in
+  flag.
+- The supported opt-out surface is now `--no-command-wrapping` for a persistent
+  managed-rc setting and `AGENT_GUARD_COMMAND_WRAPPING=off` for a runtime
+  setting.
+- The old bang-guard names are no longer documented or shown in CLI help. The
+  2.0 binary still accepts the 1.x stable and experimental flags as hidden
+  upgrade shims, then `setup-shell` rewrites the managed block without them.
+- GitHub Actions examples move from `JeongJaeSoon/agent-guard@v1` to `@v2`.
+  The `v1` moving tag is retained for users who intentionally stay on 1.x.
+
+Command wrapping is best-effort and remains scoped to Claude Code shell
+snapshots. The overrides are inert outside Claude Code, fail open with a warning
+when transparent masking is unavailable, and do not cover absolute paths,
+redirections, sourced files, arbitrary interpreters, binary output, or streaming
+commands. `agx` remains the explicit fail-closed wrapper.
+
+## Direct CLI upgrade
+
+Upgrade to the latest release:
+
+```sh
+curl -fsSL https://github.com/JeongJaeSoon/agent-guard/releases/latest/download/bootstrap.sh | sh
+```
+
+The 2.x bootstrap refreshes the managed shell block with command wrapping on.
+To keep automatic wrapping off during the upgrade:
+
+```sh
+curl -fsSL https://github.com/JeongJaeSoon/agent-guard/releases/latest/download/bootstrap.sh \
+  | AGENT_GUARD_COMMAND_WRAPPING=off sh
+```
+
+Restart the shell and every Claude Code session, then verify:
+
+```sh
+agent-guard version
+agent-guard check
+agent-guard smoke-test
+```
+
+## Claude Code plugin upgrade
+
+Update and reload the plugin, then refresh the managed shell block:
+
+```text
+/plugin update agent-guard@agent-guard
+/reload-plugins
+/agent-guard:setup-shell
+```
+
+Restart the shell and Claude Code. If SessionStart reports different plugin and
+shell-integration versions, update the older installation and run
+`/agent-guard:setup-shell` again. An existing 1.x managed block using either old
+flag continues to load under 2.0 and is normalized on this setup run.
+
+For a persistent opt-out, invoke the installed plugin binary by absolute path:
+
+```sh
+<plugin-root>/bin/agent-guard setup-shell --no-command-wrapping
+```
+
+For a temporary opt-out, export `AGENT_GUARD_COMMAND_WRAPPING=off` before
+starting Claude Code.
+
+## Codex plugin upgrade
+
+Update Agent Guard from Codex's plugin UI. Open **Settings > Hooks**, review the
+updated `SessionStart`, `PreToolUse`, `PostToolUse`, and `Stop` hooks, trust each
+one again when Codex marks it **Modified**, and restart Codex. Run
+`$setup-agent-guard`; completion requires both plugin-local checks and the live
+PreToolUse/PostToolUse probes.
+
+Claude command wrapping is not a Codex command boundary and should not be added
+as part of Codex-only setup.
+
+## GitHub Actions migration
+
+Change the moving tag in workflows:
+
+```diff
+- uses: JeongJaeSoon/agent-guard@v1
++ uses: JeongJaeSoon/agent-guard@v2
+```
+
+The Action inputs and checksum requirement are unchanged. Staying on `@v1` is
+supported for the 1.x line but does not opt into 2.x behavior.

--- a/docs/upstream-bang-hook-request.md
+++ b/docs/upstream-bang-hook-request.md
@@ -1,7 +1,9 @@
 # Upstream feature request draft — a hook (or output redaction) for `!` bang commands
 
-> **Status: draft.** This is a ready-to-file issue for `anthropics/claude-code`. It is not
-> filed automatically — filing is an outward-facing action left to a maintainer's decision.
+> **Status: draft.** Agent Guard 2.x mitigates common dump commands with default-on
+> command wrapping, but a native upstream hook is still required for complete coverage.
+> This is a ready-to-file issue for `anthropics/claude-code`; filing remains a
+> maintainer decision.
 
 ---
 

--- a/examples/github/secret-guard.yml
+++ b/examples/github/secret-guard.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: JeongJaeSoon/agent-guard@v1
+      - uses: JeongJaeSoon/agent-guard@v2
         with:
           paths: "."
           gitleaks-checksum: "<sha256 of the gitleaks release archive>"

--- a/plugins/agent-guard/.claude-plugin/plugin.json
+++ b/plugins/agent-guard/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-guard",
   "description": "Real-time secret-leak guardrails for AI coding agents (Claude Code, Codex), Git hooks, and CI.",
-  "version": "1.10.1",
+  "version": "2.0.0",
   "author": {
     "name": "Agent Guard contributors"
   }

--- a/plugins/agent-guard/.codex-plugin/plugin.json
+++ b/plugins/agent-guard/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-guard",
-  "version": "1.10.1",
+  "version": "2.0.0",
   "description": "Real-time secret-leak guardrails for AI coding agents (Claude Code, Codex), Git hooks, and CI.",
   "author": {
     "name": "Agent Guard contributors"

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -2244,15 +2244,18 @@ __agentguard_wrap_command() {  # $1 = real command name, remaining args forwarde
 }
 # A user alias for one of these (e.g. `alias cat='cat -n'`) would otherwise
 # alias-expand the `${name}()` token while this eval is PARSED, so the function
-# would fail to define and `!cat` would stay unguarded. Drop the alias FIRST, as
-# its own statement, so by the time the inner eval is parsed no alias remains.
-# (Claude Code's snapshot `unalias -a`s anyway, so this is a no-op for a normal
-# terminal — it only fixes the shell where you run `eval "$(... shell-init)"`.)
+# would fail to define and `!cat` would stay unguarded. Drop the alias before the
+# inner eval, then restore it so the normal interactive shell keeps its existing
+# behavior. Claude Code's snapshot runs `unalias -a`, exposing the function it
+# retained underneath the alias.
 for __ag_name in cat head printenv; do
+  __ag_alias=$(alias "$__ag_name" 2>/dev/null || :)
+  __ag_alias=${__ag_alias#alias }
   unalias "$__ag_name" 2>/dev/null || :
   eval "${__ag_name}() { __agentguard_wrap_command ${__ag_name} \"\$@\"; }"
+  [ -n "$__ag_alias" ] && eval "alias $__ag_alias"
 done
-unset __ag_name
+unset __ag_name __ag_alias
 EOF
 }
 

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -2,7 +2,7 @@
 set -u
 
 PROGRAM=agent-guard
-VERSION=1.10.1
+VERSION=2.0.0
 
 # Resolve the script's own path, following symlinks. The bootstrap installer
 # drops a symlink at ~/.local/bin/agent-guard that points into ~/.agent-guard/
@@ -63,8 +63,8 @@ Usage:
   agent-guard hook-stop
   agent-guard hook-session-start
   agent-guard exec [--] <cmd> [args...]
-  agent-guard shell-init [--bash|--zsh] [--claude-bang-guard]
-  agent-guard setup-shell [--bash|--zsh|--rc FILE] [--claude-bang-guard]
+  agent-guard shell-init [--bash|--zsh] [--no-command-wrapping]
+  agent-guard setup-shell [--bash|--zsh|--rc FILE] [--no-command-wrapping]
   agent-guard pii-filter [--check]
   agent-guard scan-staged
   agent-guard scan-working-tree
@@ -1942,7 +1942,7 @@ hook_stop() {
 }
 
 # --- hook-session-start: report degraded setup and shell-integration drift ----
-# The plugin and the binary the shell integration (agx / bang guard) resolves at
+# The plugin and the binary the shell integration (agx / command wrapping) resolves at
 # runtime update independently, so updating one side silently leaves masking on
 # the OLD rules while the hooks look current — an invisible failure. Instead of
 # re-deriving which binary masks (a proxy this hook can't get right — it can't
@@ -1953,9 +1953,9 @@ hook_stop() {
 #
 # Env inheritance (verified against the Claude Code hooks docs): a command hook
 # inherits the `claude` process env, which inherits the launching shell's
-# exported vars — so the rc-set marker reaches this hook. If `claude` was NOT
-# launched from a shell that sourced the rc, the marker is absent AND the
-# integration is inactive, so silence is correct (nothing is masking to drift).
+# exported vars — so the rc-set marker reaches this hook. In 2.x an absent marker
+# triggers Claude-only setup guidance because command wrapping is default-on;
+# Codex remains silent because it does not use this shell boundary.
 #
 # SessionStart is non-mutating: it reports missing dependencies and directs the
 # host to the approval-gated setup skill. It also reports Claude shell-wrapper
@@ -1980,6 +1980,15 @@ hook_session_start() {
       fi
       ;;
   esac
+
+  # Claude plugins cannot edit the user's shell rc during installation. In 2.x
+  # command wrapping is default-on, so an absent marker means the one-time
+  # shell setup has not loaded. Keep Codex silent: Claude shell snapshots are
+  # not a Codex command boundary.
+  if [ -z "$marker" ] && [ "${AGENT_GUARD_HOOK_HOST:-claude}" = claude ]; then
+    wrapping_setup='agent-guard command wrapping is not loaded. Run /agent-guard:setup-shell, then restart the shell and Claude Code. Use setup-shell --no-command-wrapping for a persistent opt-out.'
+    if [ -n "$message" ]; then message="$message $wrapping_setup"; else message=$wrapping_setup; fi
+  fi
 
   [ -n "$message" ] || return 0
   case "${AGENT_GUARD_HOOK_HOST:-claude}" in
@@ -2095,7 +2104,7 @@ do_exec() {
   exit "$status"
 }
 
-# --- shell-init: emit an rc snippet installing `agx` + a warn-only nudge -------
+# --- shell-init: emit `agx`, a warn-only nudge, and default command wrapping ---
 # `eval "$(agent-guard shell-init)"` in the user's shell rc defines `agx` (an
 # alias for `agent-guard exec --`) and a NON-BLOCKING preexec/DEBUG nudge that
 # reminds the user to wrap known secret-loading idioms with `agx` so their output
@@ -2111,11 +2120,12 @@ shell_init_target() {
     case "$1" in
       --bash) target=bash ;;
       --zsh) target=zsh ;;
-      # Handled separately in shell_init(); the experimental spelling remains a
-      # deprecated compatibility alias for rc files written by older releases.
-      --claude-bang-guard|--experimental-bang-guard) : ;;
+      # 1.x flags remain accepted as hidden compatibility shims so existing
+      # managed rc blocks keep working during an upgrade. Command wrapping is
+      # enabled by default in 2.x, so both flags are now no-ops.
+      --claude-bang-guard|--experimental-bang-guard|--no-command-wrapping) : ;;
       -h|--help) target=help ;;
-      *) die "shell-init: unknown argument: $1 (expected --bash, --zsh, or --claude-bang-guard)" ;;
+      *) die "shell-init: unknown argument: $1 (expected --bash, --zsh, or --no-command-wrapping)" ;;
     esac
     shift
   done
@@ -2166,9 +2176,11 @@ esac
 EOF
 }
 
-# Supported opt-in (`shell-init --claude-bang-guard`). Emit function overrides
-# for common file/env dump commands so `!`-typed reads are routed through
-# `agent-guard exec` (output masked) BEFORE the transcript captures them.
+# Stable, default-on Claude command wrapping. Emit function overrides for common
+# file/env dump commands so `!`-typed reads are routed through `agent-guard exec`
+# (output masked) BEFORE the transcript captures them. Users can opt out for a
+# managed rc with `setup-shell --no-command-wrapping`, or at runtime with
+# `AGENT_GUARD_COMMAND_WRAPPING=off`.
 #
 # Why functions, not the preexec nudge above: Claude Code builds a "shell
 # snapshot" of your interactive shell for `!` commands. That snapshot runs
@@ -2185,20 +2197,29 @@ EOF
 #     scan per call, so wrap only cheap, interactive dump commands.
 #   * `exec` captures output via shell substitution, so it is TEXT-ONLY: a
 #     binary / NUL-containing read loses embedded NULs and its trailing newline.
-#     For faithful binary output use `command cat` / `\cat` (or shell-init
-#     without this flag). This guard targets text config/secret dumps, not blobs.
-shell_init_bang_guard() {
+#     For faithful binary output use `command cat` / `\cat` (or
+#     `shell-init --no-command-wrapping`). This targets text config/secret dumps,
+#     not blobs.
+shell_init_command_wrapping() {
   cat <<'EOF'
-# --- agent-guard Claude bang-command guard (supported opt-in) ----------------
+# --- agent-guard Claude command wrapping (enabled by default) ----------------
 # Routes `!`-typed dump commands through `agent-guard exec` so their output is
 # masked before Claude Code captures it. Active ONLY inside Claude Code
-# ($CLAUDECODE); inert in a normal terminal. Best-effort — see docs.
+# ($CLAUDECODE); inert in a normal terminal. Set
+# AGENT_GUARD_COMMAND_WRAPPING=off to pass through without masking.
+# Best-effort — see docs.
 # NOTE: `agent-guard exec` buffers the whole output, so streaming/follow commands
 # would hang. `tail` is deliberately NOT wrapped for that reason; wrap only
 # terminating dump commands.
-__agentguard_guard() {  # $1 = real command name, remaining args forwarded
+__agentguard_wrap_command() {  # $1 = real command name, remaining args forwarded
   __ag_cmd=$1; shift
   if [ -n "${CLAUDECODE:-}" ]; then
+    case "${AGENT_GUARD_COMMAND_WRAPPING:-on}" in
+      0|off|OFF|false|FALSE|no|NO)
+        command "$__ag_cmd" "$@"
+        return
+        ;;
+    esac
     # Route through `agent-guard exec` (resolved via $PATH or the baked path) so
     # the output is masked. `exec` runs the command in agent-guard's OWN child
     # process, where these overrides do not exist, so the real binary runs with
@@ -2208,7 +2229,7 @@ __agentguard_guard() {  # $1 = real command name, remaining args forwarded
         command "$__ag_exe" exec -- "$__ag_cmd" "$@"
         return
       fi
-      printf 'agent-guard: bang-guard dependencies are not ready; %s output is NOT masked. Run: agent-guard setup\n' "$__ag_cmd" >&2
+      printf 'agent-guard: command wrapping dependencies are not ready; %s output is NOT masked. Run: agent-guard setup\n' "$__ag_cmd" >&2
       command "$__ag_cmd" "$@"
       return
     fi
@@ -2216,7 +2237,7 @@ __agentguard_guard() {  # $1 = real command name, remaining args forwarded
     # fail OPEN — run the command — but WARN loudly that the output is unmasked
     # rather than leaking silently. A stale baked path after a plugin update
     # lands here; `agent-guard setup-shell` re-bakes it.
-    printf 'agent-guard: bang-guard cannot locate the agent-guard binary; %s output is NOT masked. Re-run: agent-guard setup-shell\n' "$__ag_cmd" >&2
+    printf 'agent-guard: command wrapping cannot locate the agent-guard binary; %s output is NOT masked. Re-run: agent-guard setup-shell\n' "$__ag_cmd" >&2
   fi
   # `command` bypasses this override so the real binary runs (no recursion).
   command "$__ag_cmd" "$@"
@@ -2229,7 +2250,7 @@ __agentguard_guard() {  # $1 = real command name, remaining args forwarded
 # terminal — it only fixes the shell where you run `eval "$(... shell-init)"`.)
 for __ag_name in cat head printenv; do
   unalias "$__ag_name" 2>/dev/null || :
-  eval "${__ag_name}() { __agentguard_guard ${__ag_name} \"\$@\"; }"
+  eval "${__ag_name}() { __agentguard_wrap_command ${__ag_name} \"\$@\"; }"
 done
 unset __ag_name
 EOF
@@ -2237,19 +2258,22 @@ EOF
 
 shell_init() {
   target=$(shell_init_target "$@")
-  bang_guard=0
+  command_wrapping=1
   for __ag_arg in "$@"; do
     case "$__ag_arg" in
-      --claude-bang-guard|--experimental-bang-guard) bang_guard=1 ;;
+      --no-command-wrapping) command_wrapping=0 ;;
+      # Hidden 1.x compatibility shims. They explicitly preserve the new
+      # default and are normalized away by setup-shell.
+      --claude-bang-guard|--experimental-bang-guard) command_wrapping=1 ;;
     esac
   done
   if [ "$target" = help ]; then
     {
-      printf '%s\n' "Usage: $PROGRAM shell-init [--bash|--zsh] [--claude-bang-guard]"
+      printf '%s\n' "Usage: $PROGRAM shell-init [--bash|--zsh] [--no-command-wrapping]"
       printf '%s\n' "Emits a shell snippet for: eval \"\$($PROGRAM shell-init)\""
-      printf '%s\n' "  --claude-bang-guard       also override cat/head/printenv so"
-      printf '%s\n' "                            \`!\`-typed reads are masked inside Claude Code"
-      printf '%s\n' "  --experimental-bang-guard deprecated alias for --claude-bang-guard"
+      printf '%s\n' "Command wrapping is on by default: cat/head/printenv are masked inside"
+      printf '%s\n' "Claude Code. Set AGENT_GUARD_COMMAND_WRAPPING=off for a runtime opt-out."
+      printf '%s\n' "  --no-command-wrapping     omit the automatic command overrides"
     } >&2
     return 0
   fi
@@ -2362,9 +2386,9 @@ EOF
       printf '%s\n' 'fi'
       ;;
   esac
-  # The bang guard is shell-agnostic (plain functions), so it is emitted after
-  # the shell-specific hook wiring, for any target, only when opted in.
-  [ "$bang_guard" = 1 ] && shell_init_bang_guard
+  # Command wrapping is shell-agnostic (plain functions), so it is emitted after
+  # the shell-specific hook wiring for any target unless explicitly disabled.
+  [ "$command_wrapping" = 1 ] && shell_init_command_wrapping
 }
 
 # `setup-shell` — write the `eval "$(... shell-init ...)"` line into the user's
@@ -2373,19 +2397,23 @@ EOF
 # cannot edit your rc, so run this once (by absolute path if agent-guard is not
 # yet on $PATH). Idempotent — re-running replaces the managed block in place.
 do_setup_shell() {
-  sh_target= rc= bang=
+  sh_target= rc= wrapping=
   while [ "$#" -gt 0 ]; do
     case "$1" in
       --bash) sh_target=bash ;;
       --zsh) sh_target=zsh ;;
       --rc) shift; rc=${1:-}; [ -n "$rc" ] || die "setup-shell: --rc requires a path" ;;
-      --claude-bang-guard|--experimental-bang-guard) bang=' --claude-bang-guard' ;;
+      --no-command-wrapping) wrapping=' --no-command-wrapping' ;;
+      # Hidden compatibility shims for 1.x managed blocks. The 2.x default is
+      # on, so accepting either option and writing no option normalizes the rc.
+      --claude-bang-guard|--experimental-bang-guard) wrapping= ;;
       -h|--help)
         {
-          printf '%s\n' "Usage: $PROGRAM setup-shell [--bash|--zsh|--rc FILE] [--claude-bang-guard]"
+          printf '%s\n' "Usage: $PROGRAM setup-shell [--bash|--zsh|--rc FILE] [--no-command-wrapping]"
           printf '%s\n' "Adds the shell-init line to your shell rc (idempotent). Restart your"
           printf '%s\n' "shell and any Claude Code session afterwards to apply."
-          printf '%s\n' "--experimental-bang-guard remains a deprecated compatibility alias."
+          printf '%s\n' "Command wrapping is enabled by default. Use --no-command-wrapping for"
+          printf '%s\n' "a persistent opt-out, or AGENT_GUARD_COMMAND_WRAPPING=off at runtime."
         } >&2
         return 0 ;;
       *) die "setup-shell: unknown option: $1 (see: $PROGRAM setup-shell --help)" ;;
@@ -2409,14 +2437,14 @@ do_setup_shell() {
   # stdout, and fall back to the baked absolute path whenever it is empty — whether
   # because the bare name left $PATH (CLI uninstalled, plugin-only left) OR because
   # a stale/stub `agent-guard` earlier on $PATH errored or emitted nothing (e.g. an
-  # older build that rejects --claude-bang-guard). Either way the guard still
+  # older build that rejects --no-command-wrapping). Either way the integration
   # installs from $SELF_BIN instead of silently vanishing. The probe's stderr is
   # suppressed (it is speculative and handled); the fallback runs unmuted. Without
   # this, snippet generation could fail and the runtime resolver can't help once the
   # snippet itself was never produced. The emitted snippet keeps its `auto` shell
   # detection, so the line works in bash+zsh.
   abs=$(sh_squote "$SELF_BIN")
-  line="eval \"\$(_agi=; command -v agent-guard >/dev/null 2>&1 && _agi=\$(agent-guard shell-init${bang} 2>/dev/null); if [ -n \"\$_agi\" ]; then printf '%s\\n' \"\$_agi\"; else $abs shell-init${bang}; fi)\""
+  line="eval \"\$(_agi=; command -v agent-guard >/dev/null 2>&1 && _agi=\$(agent-guard shell-init${wrapping} 2>/dev/null); if [ -n \"\$_agi\" ]; then printf '%s\\n' \"\$_agi\"; else $abs shell-init${wrapping}; fi)\""
 
   begin='# >>> agent-guard shell-init >>>'
   end='# <<< agent-guard shell-init <<<'

--- a/plugins/agent-guard/commands/setup-shell.md
+++ b/plugins/agent-guard/commands/setup-shell.md
@@ -1,0 +1,19 @@
+---
+allowed-tools: Bash
+description: Install Agent Guard's default-on Claude command wrapping into the current user's shell rc.
+---
+
+# /agent-guard:setup-shell
+
+Install or refresh the managed Agent Guard shell integration for Claude Code.
+Command wrapping is enabled by default in Agent Guard 2.x.
+
+## Run
+
+!`"${CLAUDE_PLUGIN_ROOT}/bin/agent-guard" setup-shell`
+
+## Report
+
+- On success, tell the user to restart the shell and every Claude Code session.
+- On failure, relay the exact error and leave the shell rc unchanged.
+- To opt out later, tell the user to set `AGENT_GUARD_COMMAND_WRAPPING=off` for a runtime opt-out or run the plugin-local binary with `setup-shell --no-command-wrapping` for a persistent opt-out.

--- a/plugins/agent-guard/skills/setup-agent-guard/SKILL.md
+++ b/plugins/agent-guard/skills/setup-agent-guard/SKILL.md
@@ -71,12 +71,12 @@ Make Agent Guard operational without silently changing the machine. Diagnose fir
      The raw marker must not reach the model; expect `[REDACTED]` in a masked or sanitized replacement. These sentinels prove host dispatch without reading a sensitive file or printing a credential-shaped value; the plugin-local smoke test separately proves the real detection rules.
    - If Codex exposes only a wrapping/orchestration tool such as `functions.exec`, test that exact route. Agent Guard cannot replace or wrap Codex's host executor; it can protect only nested calls that Codex exposes to plugin hooks. If either probe bypasses the hook, report the route as unsupported in the current host instead of claiming successful setup.
 
-8. After dependency, enablement, or trust changes, restart Codex and run both live probes again in a new task. In Codex, plugin hooks provide the supported command boundary; do not configure the Claude-specific bang-command shell wrapper as a Codex setup step.
+8. After dependency, enablement, or trust changes, restart Codex and run both live probes again in a new task. In Codex, plugin hooks provide the supported command boundary; do not configure Claude-specific command wrapping as a Codex setup step.
 
 ## Safety And Host Boundaries
 
 - Dependency setup is intentionally approval-gated. A SessionStart hook may diagnose and recommend this skill, but it must never install software itself.
 - If installation is declined, leave the machine unchanged and state that Agent Guard is in degraded mode.
 - Codex protects only hook surfaces that the current host actually dispatches, such as supported `Bash`, `apply_patch`, and MCP calls. Do not claim that Codex hooks intercept arbitrary read, grep, web-search, or opaque wrapping-tool calls.
-- `agent-guard setup-shell`, `agx`, and the bang-command guard are optional Claude Code shell-snapshot integrations. Only configure them when the user explicitly asks for Claude Code coverage.
+- `agent-guard setup-shell`, `agx`, and command wrapping are Claude Code shell-snapshot integrations. `setup-shell` enables command wrapping by default; `--no-command-wrapping` is the persistent opt-out and `AGENT_GUARD_COMMAND_WRAPPING=off` is the runtime opt-out. Only configure them when the user explicitly asks for Claude Code coverage.
 - If plugin hooks are not trusted, enabled, or reached by both live probes, explain that dependencies alone do not activate runtime protection. Never report Agent Guard as operational based only on `check` and `smoke-test`.

--- a/scripts/validate-plugin-layout.sh
+++ b/scripts/validate-plugin-layout.sh
@@ -135,6 +135,27 @@ validate_setup_skill() {
   fi
 }
 
+validate_versions() {
+  cli_version=$(sed -n 's/^VERSION=//p' "$PLUGIN_ROOT/bin/agent-guard")
+  claude_version=$(jq -r '.version // ""' "$PLUGIN_ROOT/.claude-plugin/plugin.json")
+  codex_version=$(jq -r '.version // ""' "$PLUGIN_ROOT/.codex-plugin/plugin.json")
+  marketplace_version=$(jq -r '.plugins[] | select(.name == "agent-guard") | .version // ""' "$ROOT/.claude-plugin/marketplace.json")
+
+  if printf '%s\n' "$cli_version" | grep -Eq '^2\.[0-9]+\.[0-9]+$'; then
+    ok "Agent Guard CLI is on the 2.x release line"
+  else
+    fail "Agent Guard CLI is on the 2.x release line"
+  fi
+  if [ -n "$cli_version" ] \
+     && [ "$claude_version" = "$cli_version" ] \
+     && [ "$codex_version" = "$cli_version" ] \
+     && [ "$marketplace_version" = "$cli_version" ]; then
+    ok "CLI, Claude, Codex, and marketplace versions match ($cli_version)"
+  else
+    fail "CLI, Claude, Codex, and marketplace versions match"
+  fi
+}
+
 validate_codex() {
   require_json "$PLUGIN_ROOT/.codex-plugin/plugin.json"
   require_json "$PLUGIN_ROOT/hooks.json"
@@ -174,6 +195,7 @@ validate_claude() {
 validate_marketplace() {
   require_json "$ROOT/.agents/plugins/marketplace.json"
   require_json "$ROOT/.claude-plugin/marketplace.json"
+  validate_versions
 
   if jq -e '.plugins[] | select(.name == "agent-guard" and .source.path == "./plugins/agent-guard")' "$ROOT/.agents/plugins/marketplace.json" >/dev/null; then
     ok "Codex marketplace points to ./plugins/agent-guard"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -3021,22 +3021,33 @@ else
   sed 's/^/  stdout: /' "$OUT"
   sed 's/^/  stderr: /' "$ERR"
 fi
-# Regression: a pre-existing `alias cat=...` must NOT stop the override from
-# installing. Without the per-name `unalias` before each `eval`, the alias
-# expands the function name at parse time and the guard is never defined,
-# leaving `!cat` unguarded. Only reproducible in shells that expand aliases.
+# Regression: preserve a pre-existing alias in the normal shell, while keeping
+# the wrapper function underneath it for Claude Code's `unalias -a` snapshot.
+# Only reproducible in shells that expand aliases.
 for bg_sh in bash zsh; do
   command -v "$bg_sh" >/dev/null 2>&1 || continue
-  bg_alias=$(PATH="$bg_dir/bin:$PATH" CLAUDECODE=1 "$bg_sh" -c '
+  bg_alias_normal=$(PATH="$bg_dir/bin:$PATH" "$bg_sh" -c '
     [ -n "$BASH_VERSION" ] && shopt -s expand_aliases
-    alias cat="cat -n"
+    alias cat="printf ALIASED"
     . "$1"
+    eval "cat \"\$2\""
+  ' _ "$bg_dir/guard.sh" "$bg_dir/file.txt" 2>/dev/null)
+  if [ "$bg_alias_normal" = ALIASED ]; then
+    ok "command wrapping preserves a pre-existing cat alias under $bg_sh"
+  else
+    not_ok "command wrapping preserves a pre-existing cat alias under $bg_sh (got: $bg_alias_normal)"
+  fi
+  bg_alias_snapshot=$(PATH="$bg_dir/bin:$PATH" CLAUDECODE=1 "$bg_sh" -c '
+    [ -n "$BASH_VERSION" ] && shopt -s expand_aliases
+    alias cat="printf ALIASED"
+    . "$1"
+    unalias -a
     cat "$2"
   ' _ "$bg_dir/guard.sh" "$bg_dir/file.txt" 2>/dev/null)
-  if [ "$bg_alias" = ROUTED ]; then
-    ok "command wrapping defeats a pre-existing cat alias under $bg_sh"
+  if [ "$bg_alias_snapshot" = ROUTED ]; then
+    ok "command wrapping survives Claude alias cleanup under $bg_sh"
   else
-    not_ok "command wrapping vs pre-existing cat alias under $bg_sh (got: $bg_alias)"
+    not_ok "command wrapping after Claude alias cleanup under $bg_sh (got: $bg_alias_snapshot)"
   fi
 done
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -102,6 +102,70 @@ for file in \
   run_expect 0 "shell syntax: $file" sh -n "$file"
 done
 
+# The direct installer must leave command wrapping active on a fresh install,
+# while AGENT_GUARD_COMMAND_WRAPPING=off is a persistent install-time opt-out.
+# Stub only the release downloads; archive verification, extraction, linking,
+# setup-shell, and rc generation all run through the real implementation.
+bootstrap_fixture="$TESTTMP/bootstrap-fixture"
+mkdir -p "$bootstrap_fixture/bin"
+"$ROOT/scripts/build-release-tarball.sh" 2.0.0 "$bootstrap_fixture/agent-guard-2.0.0.tar.gz"
+(
+  cd "$bootstrap_fixture" || exit 1
+  shasum -a 256 agent-guard-2.0.0.tar.gz >agent-guard-2.0.0.tar.gz.sha256
+)
+cat >"$bootstrap_fixture/bin/curl" <<'STUB'
+#!/bin/sh
+out=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) shift; out=${1:-} ;;
+  esac
+  shift
+done
+case "$out" in
+  *.tar.gz) cp "$BOOTSTRAP_FIXTURE/agent-guard-2.0.0.tar.gz" "$out" ;;
+  *.tar.gz.sha256) cp "$BOOTSTRAP_FIXTURE/agent-guard-2.0.0.tar.gz.sha256" "$out" ;;
+  *) exit 2 ;;
+esac
+STUB
+chmod +x "$bootstrap_fixture/bin/curl"
+
+for bootstrap_mode in on off; do
+  bootstrap_home="$TESTTMP/bootstrap-$bootstrap_mode"
+  mkdir -p "$bootstrap_home"
+  if [ "$bootstrap_mode" = off ]; then
+    bootstrap_toggle=off
+  else
+    bootstrap_toggle=on
+  fi
+  BOOTSTRAP_FIXTURE="$bootstrap_fixture" \
+  AGENT_GUARD_VERSION=2.0.0 \
+  AGENT_GUARD_HOME="$bootstrap_home/agent-guard" \
+  AGENT_GUARD_BIN_DIR="$bootstrap_home/bin" \
+  AGENT_GUARD_COMMAND_WRAPPING="$bootstrap_toggle" \
+  HOME="$bootstrap_home" SHELL=/bin/zsh \
+  PATH="$bootstrap_fixture/bin:/usr/bin:/bin" \
+    sh "$ROOT/bootstrap.sh" >"$OUT" 2>"$ERR"
+  status=$?
+  if [ "$status" -eq 0 ] && [ -x "$bootstrap_home/bin/agent-guard" ]; then
+    ok "bootstrap installs Agent Guard with command wrapping $bootstrap_mode"
+  else
+    not_ok "bootstrap installs Agent Guard with command wrapping $bootstrap_mode (status $status)"
+  fi
+  if [ "$bootstrap_mode" = on ]; then
+    if grep -q 'agent-guard shell-init' "$bootstrap_home/.zshrc" 2>/dev/null \
+       && ! grep -q -- '--no-command-wrapping' "$bootstrap_home/.zshrc" 2>/dev/null; then
+      ok "bootstrap enables command wrapping by default"
+    else
+      not_ok "bootstrap enables command wrapping by default"
+    fi
+  elif grep -q 'shell-init --no-command-wrapping' "$bootstrap_home/.zshrc" 2>/dev/null; then
+    ok "bootstrap persists AGENT_GUARD_COMMAND_WRAPPING=off"
+  else
+    not_ok "bootstrap persists AGENT_GUARD_COMMAND_WRAPPING=off"
+  fi
+done
+
 for file in \
   "$PLUGIN_ROOT/hooks.json" \
   "$PLUGIN_ROOT/hooks/hooks.json" \
@@ -113,6 +177,14 @@ for file in \
   "$ROOT/examples/codex/hooks.json"; do
   run_expect 0 "json syntax: $file" jq -e . "$file"
 done
+
+if grep -Fq 'legacy_v1_before=$(git ls-remote origin refs/tags/v1' "$ROOT/.github/workflows/release.yml" \
+   && grep -Fq 'legacy_v1_after=$(git ls-remote origin refs/tags/v1' "$ROOT/.github/workflows/release.yml" \
+   && grep -Fq 'if [ "$legacy_v1_after" != "$legacy_v1_before" ]' "$ROOT/.github/workflows/release.yml"; then
+  ok "release automation preserves the v1 moving tag when publishing v2+"
+else
+  not_ok "release automation preserves the v1 moving tag when publishing v2+"
+fi
 
 if jq -e '.hooks == "./hooks.json" and .skills == "./skills/"' "$PLUGIN_ROOT/.codex-plugin/plugin.json" >/dev/null; then
   ok "Codex plugin manifest explicitly declares hook and skill paths"
@@ -215,7 +287,7 @@ for event in PreToolUse PostToolUse Stop; do
 done
 
 # SessionStart reports dependency readiness on both hosts and version drift for
-# the optional Claude shell integration.
+# the Claude shell integration.
 ss_hook_matcher=$(jq -r '.hooks.SessionStart[0].matcher' "$PLUGIN_ROOT/hooks/hooks.json")
 ss_hook_command=$(jq -r '.hooks.SessionStart[0].hooks[0].command' "$PLUGIN_ROOT/hooks/hooks.json")
 ss_hook_timeout=$(jq -r '.hooks.SessionStart[0].hooks[0].timeout' "$PLUGIN_ROOT/hooks/hooks.json")
@@ -2675,7 +2747,7 @@ fi
 
 # `printenv NAME` emits a bare value. Preserve the variable-name context so a
 # low-entropy or documented fake value under a secret-bearing key is still
-# masked by exec and by the Claude bang-command wrapper.
+# masked by exec and by the Claude command wrapper.
 PRINTENV_KEY='DEMO_TOKEN'
 # Keep the value deliberately non-vendor-shaped: this regression proves that
 # the variable name supplies the missing secret context for bare printenv output.
@@ -2849,37 +2921,48 @@ else
   not_ok "shell-init nudge stays silent on a benign command"
 fi
 
-# --- shell-init Claude bang guard (supported opt-in function overrides) -------
-# Emitted ONLY with --claude-bang-guard; overrides cat/head/printenv
-# to route through `agent-guard exec` (mask) but ONLY inside Claude Code
-# ($CLAUDECODE), staying inert in a normal terminal.
-if printf '%s' "$shellinit_auto" | grep -q '__agentguard_guard'; then
-  not_ok "shell-init omits the bang guard without the opt-in flag"
+# --- shell-init Claude command wrapping (stable, default-on overrides) --------
+# The default snippet overrides cat/head/printenv inside Claude Code. A durable
+# opt-out omits those functions, while both 1.x flags remain hidden compatibility
+# shims so an existing managed rc keeps working during upgrade.
+shellinit_wrap=$shellinit_auto
+if printf '%s' "$shellinit_wrap" | grep -q '__agentguard_wrap_command'; then
+  ok "shell-init enables Claude command wrapping by default"
 else
-  ok "shell-init omits the bang guard without the opt-in flag"
+  not_ok "shell-init enables Claude command wrapping by default"
 fi
-shellinit_bg=$("$PLUGIN_ROOT/bin/agent-guard" shell-init --claude-bang-guard 2>/dev/null)
-if printf '%s' "$shellinit_bg" | grep -q '__agentguard_guard'; then
-  ok "shell-init --claude-bang-guard emits the guard functions"
+shellinit_no_wrap=$("$PLUGIN_ROOT/bin/agent-guard" shell-init --no-command-wrapping 2>/dev/null)
+if printf '%s' "$shellinit_no_wrap" | grep -q '__agentguard_wrap_command'; then
+  not_ok "shell-init --no-command-wrapping omits automatic command overrides"
 else
-  not_ok "shell-init --claude-bang-guard emits the guard functions"
+  ok "shell-init --no-command-wrapping omits automatic command overrides"
 fi
-shellinit_bg_legacy=$("$PLUGIN_ROOT/bin/agent-guard" shell-init --experimental-bang-guard 2>/dev/null)
-if printf '%s' "$shellinit_bg_legacy" | grep -q '__agentguard_guard'; then
-  ok "shell-init accepts the deprecated --experimental-bang-guard alias"
+shellinit_v1_stable=$("$PLUGIN_ROOT/bin/agent-guard" shell-init --claude-bang-guard 2>/dev/null)
+shellinit_v1_experimental=$("$PLUGIN_ROOT/bin/agent-guard" shell-init --experimental-bang-guard 2>/dev/null)
+if printf '%s' "$shellinit_v1_stable" | grep -q '__agentguard_wrap_command' \
+   && printf '%s' "$shellinit_v1_experimental" | grep -q '__agentguard_wrap_command'; then
+  ok "shell-init keeps hidden compatibility for 1.x command-wrapper flags"
 else
-  not_ok "shell-init accepts the deprecated --experimental-bang-guard alias"
+  not_ok "shell-init keeps hidden compatibility for 1.x command-wrapper flags"
 fi
-if printf '%s\n' "$shellinit_bg" | sh -n - 2>"$ERR"; then
-  ok "bang guard snippet parses under sh -n"
+shellinit_help=$("$PLUGIN_ROOT/bin/agent-guard" shell-init --help 2>&1)
+if printf '%s' "$shellinit_help" | grep -q -- '--no-command-wrapping' \
+   && ! printf '%s' "$shellinit_help" | grep -q -- '--claude-bang-guard' \
+   && ! printf '%s' "$shellinit_help" | grep -q -- '--experimental-bang-guard'; then
+  ok "shell-init help exposes only the 2.x command-wrapping option"
 else
-  not_ok "bang guard snippet parses under sh -n"; sed 's/^/  stderr: /' "$ERR"
+  not_ok "shell-init help exposes only the 2.x command-wrapping option"
+fi
+if printf '%s\n' "$shellinit_wrap" | sh -n - 2>"$ERR"; then
+  ok "command-wrapping snippet parses under sh -n"
+else
+  not_ok "command-wrapping snippet parses under sh -n"; sed 's/^/  stderr: /' "$ERR"
 fi
 if command -v zsh >/dev/null 2>&1; then
-  if printf '%s\n' "$shellinit_bg" | zsh -n - 2>"$ERR"; then
-    ok "bang guard snippet parses under zsh -n"
+  if printf '%s\n' "$shellinit_wrap" | zsh -n - 2>"$ERR"; then
+    ok "command-wrapping snippet parses under zsh -n"
   else
-    not_ok "bang guard snippet parses under zsh -n"; sed 's/^/  stderr: /' "$ERR"
+    not_ok "command-wrapping snippet parses under zsh -n"; sed 's/^/  stderr: /' "$ERR"
   fi
 fi
 
@@ -2895,27 +2978,34 @@ exit 0
 STUB
 chmod +x "$bg_dir/bin/agent-guard"
 printf 'hello-plain\n' >"$bg_dir/file.txt"
-printf '%s\n' "$shellinit_bg" >"$bg_dir/guard.sh"
+printf '%s\n' "$shellinit_wrap" >"$bg_dir/guard.sh"
 bg_in_cc=$(PATH="$bg_dir/bin:$PATH" CLAUDECODE=1 sh -c '. "$1"; cat "$2"' _ "$bg_dir/guard.sh" "$bg_dir/file.txt" 2>/dev/null)
 if [ "$bg_in_cc" = ROUTED ]; then
-  ok "bang guard routes dump commands through agent-guard exec inside Claude Code"
+  ok "command wrapping routes dump commands through agent-guard exec inside Claude Code"
 else
-  not_ok "bang guard routes through exec inside Claude Code (got: $bg_in_cc)"
+  not_ok "command wrapping routes through exec inside Claude Code (got: $bg_in_cc)"
 fi
 bg_out_cc=$(PATH="$bg_dir/bin:$PATH" sh -c 'unset CLAUDECODE; . "$1"; cat "$2"' _ "$bg_dir/guard.sh" "$bg_dir/file.txt" 2>/dev/null)
 if [ "$bg_out_cc" = hello-plain ]; then
-  ok "bang guard is inert (passthrough) outside Claude Code"
+  ok "command wrapping is inert (passthrough) outside Claude Code"
 else
-  not_ok "bang guard passthrough outside Claude Code (got: $bg_out_cc)"
+  not_ok "command-wrapping passthrough outside Claude Code (got: $bg_out_cc)"
+fi
+bg_disabled=$(PATH="$bg_dir/bin:$PATH" CLAUDECODE=1 AGENT_GUARD_COMMAND_WRAPPING=off \
+  sh -c '. "$1"; cat "$2"' _ "$bg_dir/guard.sh" "$bg_dir/file.txt" 2>/dev/null)
+if [ "$bg_disabled" = hello-plain ]; then
+  ok "AGENT_GUARD_COMMAND_WRAPPING=off disables wrapping at runtime"
+else
+  not_ok "runtime command-wrapping opt-out (got: $bg_disabled)"
 fi
 
 bg_printenv=$(DEMO_TOKEN="${PRINTENV_VAL}" AGENT_GUARD_BIN="$PLUGIN_ROOT/bin/agent-guard" \
   CLAUDECODE=1 sh -c '. "$1"; printenv DEMO_TOKEN' _ "$bg_dir/guard.sh" 2>/dev/null)
 if printf '%s' "$bg_printenv" | grep -q '\[REDACTED\]' \
    && ! printf '%s' "$bg_printenv" | grep -q "$PRINTENV_VAL"; then
-  ok "Claude bang guard masks a bare printenv value"
+  ok "Claude command wrapping masks a bare printenv value"
 else
-  not_ok "Claude bang guard masks a bare printenv value"
+  not_ok "Claude command wrapping masks a bare printenv value"
   printf '%s\n' "  out: $bg_printenv"
 fi
 
@@ -2925,9 +3015,9 @@ CLAUDECODE=1 sh -c '. "$1"; cat "$2"' _ "$bg_dir/guard.sh" "$bg_dir/file.txt" >"
 status=$?
 if [ "$status" -eq 0 ] && [ "$(cat "$OUT")" = hello-plain ] \
    && grep -q 'dependencies are not ready' "$ERR"; then
-  ok "transparent bang guard fails open with a loud warning when masking is unavailable"
+  ok "transparent command wrapping fails open with a loud warning when masking is unavailable"
 else
-  not_ok "transparent bang guard degraded mode preserves command behavior with a warning (status $status)"
+  not_ok "transparent command wrapping degraded mode preserves command behavior with a warning (status $status)"
   sed 's/^/  stdout: /' "$OUT"
   sed 's/^/  stderr: /' "$ERR"
 fi
@@ -2944,9 +3034,9 @@ for bg_sh in bash zsh; do
     cat "$2"
   ' _ "$bg_dir/guard.sh" "$bg_dir/file.txt" 2>/dev/null)
   if [ "$bg_alias" = ROUTED ]; then
-    ok "bang guard defeats a pre-existing cat alias under $bg_sh"
+    ok "command wrapping defeats a pre-existing cat alias under $bg_sh"
   else
-    not_ok "bang guard vs pre-existing cat alias under $bg_sh (got: $bg_alias)"
+    not_ok "command wrapping vs pre-existing cat alias under $bg_sh (got: $bg_alias)"
   fi
 done
 
@@ -2954,12 +3044,12 @@ done
 # A plugin-only install never symlinks agent-guard onto $PATH, so the wrappers
 # must resolve it via the absolute path baked into the snippet. These tests strip
 # $PATH down to a minimal set (no agent-guard) to prove that fallback.
-if printf '%s' "$shellinit_bg" | grep -q '^__agentguard_bin='; then
+if printf '%s' "$shellinit_wrap" | grep -q '^__agentguard_bin='; then
   ok "shell-init bakes the absolute binary path (__agentguard_bin)"
 else
   not_ok "shell-init bakes the absolute binary path (__agentguard_bin)"
 fi
-if printf '%s' "$shellinit_bg" | grep -q '__agentguard_exe()'; then
+if printf '%s' "$shellinit_wrap" | grep -q '__agentguard_exe()'; then
   ok "shell-init emits the __agentguard_exe resolver"
 else
   not_ok "shell-init emits the __agentguard_exe resolver"
@@ -2971,9 +3061,9 @@ bg_baked="$bg_dir/guard-baked.sh"
 sed "s#^__agentguard_bin=.*#__agentguard_bin='$bg_dir/bin/agent-guard'#" "$bg_dir/guard.sh" >"$bg_baked"
 bg_nopath=$(PATH=/usr/bin:/bin CLAUDECODE=1 sh -c '. "$1"; cat "$2"' _ "$bg_baked" "$bg_dir/file.txt" 2>/dev/null)
 if [ "$bg_nopath" = ROUTED ]; then
-  ok "bang guard routes via the baked path when agent-guard is off \$PATH"
+  ok "command wrapping routes via the baked path when agent-guard is off \$PATH"
 else
-  not_ok "bang guard routes via baked path off \$PATH (got: $bg_nopath)"
+  not_ok "command wrapping routes via baked path off \$PATH (got: $bg_nopath)"
 fi
 
 # $AGENT_GUARD_BIN wins over both $PATH and the baked path.
@@ -2992,19 +3082,19 @@ else
 fi
 
 # When NO binary resolves (stale baked path, nothing on $PATH), the TRANSPARENT
-# bang guard fails OPEN — it still runs the command — but warns loudly on stderr.
+# command wrapping fails OPEN — it still runs the command — but warns loudly on stderr.
 bg_none="$bg_dir/guard-none.sh"
 sed "s#^__agentguard_bin=.*#__agentguard_bin='/nonexistent/agent-guard'#" "$bg_dir/guard.sh" >"$bg_none"
 bg_open=$(PATH=/usr/bin:/bin CLAUDECODE=1 sh -c '. "$1"; cat "$2"' _ "$bg_none" "$bg_dir/file.txt" 2>"$ERR")
 if [ "$bg_open" = hello-plain ]; then
-  ok "bang guard fails OPEN (runs the command) when no binary resolves"
+  ok "command wrapping fails OPEN (runs the command) when no binary resolves"
 else
-  not_ok "bang guard fail-open passthrough when no binary resolves (got: $bg_open)"
+  not_ok "command wrapping fail-open passthrough when no binary resolves (got: $bg_open)"
 fi
 if grep -q 'NOT masked' "$ERR"; then
-  ok "bang guard warns loudly on stderr when it cannot mask"
+  ok "command wrapping warns loudly on stderr when it cannot mask"
 else
-  not_ok "bang guard warns loudly on stderr when it cannot mask"
+  not_ok "command wrapping warns loudly on stderr when it cannot mask"
 fi
 
 # agx is an EXPLICIT mask request, so it fails CLOSED — it must NOT run the
@@ -3051,10 +3141,19 @@ else
 fi
 
 vd_out=$(run_session_start "" 2>"$ERR")
-if [ $? -eq 0 ] && [ -z "$vd_out" ]; then
-  ok "hook-session-start is silent when the marker is absent (integration not loaded)"
+if [ $? -eq 0 ] \
+   && printf '%s' "$vd_out" | jq -e '.systemMessage | contains("/agent-guard:setup-shell")' >/dev/null 2>&1; then
+  ok "Claude SessionStart guides default command-wrapping setup when the marker is absent"
 else
-  not_ok "hook-session-start silent with no marker (got: $vd_out)"
+  not_ok "Claude SessionStart guides command-wrapping setup with no marker (got: $vd_out)"
+fi
+
+vd_out=$(AGENT_GUARD_HOOK_HOST=codex AGENT_GUARD_GITLEAKS_BIN="$MOCK_BIN/gitleaks" \
+  PATH="$MOCK_BIN:$ORIGINAL_PATH" "$PLUGIN_ROOT/bin/agent-guard" hook-session-start 2>"$ERR")
+if [ $? -eq 0 ] && [ -z "$vd_out" ]; then
+  ok "Codex SessionStart does not request Claude command-wrapping setup"
+else
+  not_ok "Codex SessionStart stays scoped to Codex setup (got: $vd_out)"
 fi
 
 vd_out=$(run_session_start 'not a version' 2>"$ERR")
@@ -3179,25 +3278,43 @@ if grep -q 'export AG_TEST_KEEP=1' "$ss_rc" 2>/dev/null; then
 else
   not_ok "setup-shell preserves unrelated rc lines"
 fi
-"$PLUGIN_ROOT/bin/agent-guard" setup-shell --rc "$ss_rc" --claude-bang-guard >/dev/null 2>&1
-if grep -q 'shell-init --claude-bang-guard' "$ss_rc" 2>/dev/null; then
-  ok "setup-shell threads --claude-bang-guard into the rc line"
+if grep -q 'agent-guard shell-init' "$ss_rc" 2>/dev/null \
+   && ! grep -q -- '--no-command-wrapping' "$ss_rc" 2>/dev/null; then
+  ok "setup-shell enables command wrapping by default"
 else
-  not_ok "setup-shell threads --claude-bang-guard into the rc line"
+  not_ok "setup-shell enables command wrapping by default"
 fi
-ss_legacy="$TESTTMP/setup-legacy.rc"
-"$PLUGIN_ROOT/bin/agent-guard" setup-shell --rc "$ss_legacy" --experimental-bang-guard >/dev/null 2>&1
-if grep -q 'shell-init --claude-bang-guard' "$ss_legacy" 2>/dev/null \
-   && ! grep -q 'shell-init --experimental-bang-guard' "$ss_legacy" 2>/dev/null; then
-  ok "setup-shell normalizes the deprecated bang-guard alias to the stable option"
+ss_off="$TESTTMP/setup-off.rc"
+"$PLUGIN_ROOT/bin/agent-guard" setup-shell --rc "$ss_off" --no-command-wrapping >/dev/null 2>&1
+if grep -q 'shell-init --no-command-wrapping' "$ss_off" 2>/dev/null; then
+  ok "setup-shell persists the command-wrapping opt-out"
 else
-  not_ok "setup-shell normalizes the deprecated bang-guard alias to the stable option"
+  not_ok "setup-shell persists the command-wrapping opt-out"
+fi
+for ss_v1_flag in --claude-bang-guard --experimental-bang-guard; do
+  ss_v1="$TESTTMP/setup-v1-${ss_v1_flag#--}.rc"
+  "$PLUGIN_ROOT/bin/agent-guard" setup-shell --rc "$ss_v1" "$ss_v1_flag" >/dev/null 2>&1
+  if ! grep -q -- '--claude-bang-guard' "$ss_v1" 2>/dev/null \
+     && ! grep -q -- '--experimental-bang-guard' "$ss_v1" 2>/dev/null \
+     && ! grep -q -- '--no-command-wrapping' "$ss_v1" 2>/dev/null; then
+    ok "setup-shell normalizes the 1.x flag $ss_v1_flag to the 2.x default"
+  else
+    not_ok "setup-shell normalizes the 1.x flag $ss_v1_flag to the 2.x default"
+  fi
+done
+setup_shell_help=$("$PLUGIN_ROOT/bin/agent-guard" setup-shell --help 2>&1)
+if printf '%s' "$setup_shell_help" | grep -q -- '--no-command-wrapping' \
+   && ! printf '%s' "$setup_shell_help" | grep -q -- '--claude-bang-guard' \
+   && ! printf '%s' "$setup_shell_help" | grep -q -- '--experimental-bang-guard'; then
+  ok "setup-shell help exposes only the 2.x command-wrapping option"
+else
+  not_ok "setup-shell help exposes only the 2.x command-wrapping option"
 fi
 # Self-healing invocation: the rc line prefers `agent-guard` on $PATH but bakes an
 # absolute-path fallback keyed on OUTPUT (not mere presence), so it stays a valid
 # generator even if the bare name later leaves $PATH or a stale binary emits nothing.
 ss_heal="$TESTTMP/setup-heal.rc"
-"$PLUGIN_ROOT/bin/agent-guard" setup-shell --rc "$ss_heal" --claude-bang-guard >/dev/null 2>&1
+"$PLUGIN_ROOT/bin/agent-guard" setup-shell --rc "$ss_heal" >/dev/null 2>&1
 if grep -q '_agi=$(agent-guard shell-init' "$ss_heal" 2>/dev/null \
    && grep -q 'if \[ -n "$_agi" \]' "$ss_heal" 2>/dev/null; then
   ok "setup-shell bakes a self-healing invocation (output probe + absolute fallback)"


### PR DESCRIPTION
## Summary

- promote command wrapping to a stable v2 feature that is enabled by default
- add runtime and persistent opt-out controls through `AGENT_GUARD_COMMAND_WRAPPING=off` and `setup-shell --no-command-wrapping`
- retain `agent-guard exec`, `agx`, and hidden compatibility shims for the v1 experimental flags
- add the 1.x to 2.x migration guide and update manifests, hooks, docs, tests, examples, and release automation
- publish future v2 releases through the `v2` moving tag while explicitly preserving the existing `v1` tag

## Why

v1.10.1 already shipped stable opt-in command wrapping, but the legacy experimental flag remained public and newly installed users were not protected by command wrapping by default. v2 makes the stable behavior the default while keeping a simple opt-out and a narrow compatibility path for existing shell setup.

## Impact and breaking changes

- `shell-init`, `setup-shell`, and bootstrap installation now enable command wrapping by default.
- Users who need raw shell behavior can set `AGENT_GUARD_COMMAND_WRAPPING=off` or run `setup-shell --no-command-wrapping`.
- `--claude-bang-guard` and `--experimental-bang-guard` remain accepted as hidden migration shims, but are no longer documented and are normalized away on the next shell setup.
- GitHub Action examples move from `@v1` to `@v2`; the existing `v1` moving tag remains unchanged for 1.x users.

## Verification

Repository checks:

- `make test` — 430 passed, 0 failed
- `scripts/validate-plugin-layout.sh --all`
- `make check`
- `make smoke-test`
- `sh -n plugins/agent-guard/bin/agent-guard`
- `sh -n bootstrap.sh`
- `sh -n tests/run.sh`
- `sh -n scripts/validate-plugin-layout.sh`
- parsed `.github/workflows/release.yml` with Ruby YAML
- `git diff --check`
- `agent-guard scan-staged`

Runtime checks:

- fresh Codex CLI 0.133.0 installation of plugin version 2.0.0
- fresh Claude Code 2.1.207 installation of plugin version 2.0.0
- plugin-local `version`, `check`, and `smoke-test` in both installed caches
- command wrapping masks by default
- `AGENT_GUARD_COMMAND_WRAPPING=off` bypasses wrapping at runtime
- `setup-shell --no-command-wrapping` persists the opt-out
- direct Claude PreToolUse command payload is blocked
- direct Claude PostToolUse output payload is masked
- isolated Codex and Claude upgrades from 1.10.1 to 2.0.0
- legacy `--experimental-bang-guard` managed shell setup is normalized to flagless default-on v2 setup
- pre-existing bash and zsh aliases are preserved outside Claude while the wrapper survives Claude's alias cleanup
- live current-host Codex PreToolUse and PostToolUse dispatcher probes
- GitHub reports commit `eb8c103` as verified
- confirmed the existing `v1` tag remains at `a795c72`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent Guard 2.0 enables Claude command wrapping by default, with runtime and persistent opt-out options.
  * Added `setup-shell` guidance and improved shell integration for direct and plugin installations.
  * Added migration guidance for upgrading from 1.x to 2.x.

* **Documentation**
  * Updated GitHub Actions examples and security guidance to use the 2.x release line.
  * Expanded documentation on command wrapping, limitations, opt-outs, and shell integration.

* **Bug Fixes**
  * Release publishing now verifies that the existing v1 compatibility tag is not moved.

* **Tests**
  * Expanded coverage for installation, shell wrapping, compatibility options, and release safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
