### PR TITLE
fix(hooks): scan NotebookEdit cell content for secrets and PII

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- fix(hooks): scan `NotebookEdit` cell content so secrets written to notebook cells are blocked (and PII when `AGENT_GUARD_PII_HOOK_MODE=block`) (#112)
+
 ## v2.0.0 - 2026-07-14
 
 - feat(shell)!: make Claude command wrapping stable and default-on, with `--no-command-wrapping` and `AGENT_GUARD_COMMAND_WRAPPING=off` opt-outs

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ AGENT_GUARD_PII_HOOK_MODE=block   # block tool INPUTS that contain any PII
 AGENT_GUARD_PII_HOOK_MODE=mask    # mask PII in tool OUTPUTS; hard-block Tier-2 inputs
 ```
 
-In **block** mode, proposed `Write`, `Edit`, `MultiEdit`, `apply_patch`, `Bash`, `WebFetch`, `WebSearch`, and MCP inputs are blocked when any PII is detected, with guidance to run `agent-guard pii-filter` first.
+In **block** mode, proposed `Write`, `Edit`, `MultiEdit`, `NotebookEdit`, `apply_patch`, `Bash`, `WebFetch`, `WebSearch`, and MCP inputs are blocked when any PII is detected, with guidance to run `agent-guard pii-filter` first.
 
 In **mask** mode, PII is masked in a tool's *output* (`PostToolUse`, the same path as secret redaction) so the model never sees it. On the *input* side, mask mode hard-blocks only **Tier-2** PII — credit card, US SSN, and Korean resident registration number, which must never reach a tool — and lets **Tier-1** PII (email, phone, IPv4) through to be masked on the way out. Hooks cannot rewrite a *pending* input payload, so Tier-1 input is allowed rather than masked in place; use `agent-guard pii-filter` for input-side masking.
 
@@ -250,7 +250,7 @@ To enable it, add an Actions secret named `OPENAI_API_KEY` in the GitHub reposit
 
 ## What Gets Blocked
 
-- On Claude Code: `Read`, `NotebookRead`, `Grep`, and `Glob` access to deny-listed paths; `Write`, `Edit`, and `MultiEdit` secret-like content; and sensitive web/MCP inputs
+- On Claude Code: `Read`, `NotebookRead`, `Grep`, and `Glob` access to deny-listed paths; `Write`, `Edit`, `MultiEdit`, and `NotebookEdit` secret-like content; and sensitive web/MCP inputs
 - On Codex: supported hook surfaces (`Bash`, `apply_patch`, and MCP tools). Current Codex hooks do not intercept arbitrary Read/Grep/WebSearch calls, so Agent Guard does not claim coverage for them.
 - risky shell commands such as `printenv`, `op read`, `vault kv get`, `aws secretsmanager get-secret-value`, `cat .env`, and `git commit --no-verify`
 - PII in proposed write, shell, web, or MCP inputs — all PII when `AGENT_GUARD_PII_HOOK_MODE=block`, or only Tier-2 PII (credit card, US SSN, Korean resident registration number) when `AGENT_GUARD_PII_HOOK_MODE=mask`

--- a/examples/claude/settings.project.json
+++ b/examples/claude/settings.project.json
@@ -2,7 +2,7 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Write|Edit|MultiEdit|Read|NotebookRead|Grep|Glob|Bash|WebFetch|WebSearch|apply_patch|mcp__.*",
+        "matcher": "Write|Edit|MultiEdit|NotebookEdit|Read|NotebookRead|Grep|Glob|Bash|WebFetch|WebSearch|apply_patch|mcp__.*",
         "hooks": [
           {
             "type": "command",
@@ -14,7 +14,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Write|Edit|MultiEdit|Bash|apply_patch|Read|NotebookRead|Grep|Glob|WebFetch|WebSearch|mcp__.*",
+        "matcher": "Write|Edit|MultiEdit|NotebookEdit|Bash|apply_patch|Read|NotebookRead|Grep|Glob|WebFetch|WebSearch|mcp__.*",
         "hooks": [
           {
             "type": "command",

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -621,6 +621,10 @@ check_pii_hook_input() {
       content=$(printf '%s' "$input" | jq -r '[.tool_input.edits[]?.new_string // empty] | join("\n")')
       block_on_pii_text "proposed MultiEdit content" "$content"
       ;;
+    NotebookEdit)
+      content=$(json_value '.tool_input.new_source // empty' "$input")
+      block_on_pii_text "proposed NotebookEdit content" "$content"
+      ;;
     apply_patch)
       patch=$(printf '%s' "$input" | jq -r '
         .tool_input.command // .tool_input.patch // .tool_input.input // .tool_input.diff // .tool_input.content // empty
@@ -1534,6 +1538,11 @@ scan_proposed_write() {
       scan_text_direct "proposed MultiEdit content" "$content"
       block_on_scan_status "$?" "proposed MultiEdit contains secret-like values"
       ;;
+    NotebookEdit)
+      content=$(json_value '.tool_input.new_source // empty' "$input")
+      scan_text_direct "proposed NotebookEdit content" "$content"
+      block_on_scan_status "$?" "proposed NotebookEdit contains secret-like values"
+      ;;
     apply_patch)
       patch=$(printf '%s' "$input" | jq -r '
         .tool_input.command // .tool_input.patch // .tool_input.input // .tool_input.diff // .tool_input.content // empty
@@ -1622,7 +1631,7 @@ hook_pre_tool() {
   tool=$(json_value '.tool_name // .tool // .name // empty' "$input")
 
   case "$tool" in
-    Write|Edit|MultiEdit|apply_patch)
+    Write|Edit|MultiEdit|NotebookEdit|apply_patch)
       scan_proposed_write "$input" "$tool"
       ;;
     Read|NotebookRead|Grep|Glob)
@@ -1647,7 +1656,7 @@ hook_pre_tool() {
 
 is_mutation_tool() {
   case "$1" in
-    Write|Edit|MultiEdit|apply_patch|Bash|mcp__*) return 0 ;;
+    Write|Edit|MultiEdit|NotebookEdit|apply_patch|Bash|mcp__*) return 0 ;;
     *) return 1 ;;
   esac
 }

--- a/plugins/agent-guard/hooks/hooks.json
+++ b/plugins/agent-guard/hooks/hooks.json
@@ -2,7 +2,7 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Write|Edit|MultiEdit|Read|NotebookRead|Grep|Glob|Bash|WebFetch|WebSearch|apply_patch|mcp__.*",
+        "matcher": "Write|Edit|MultiEdit|NotebookEdit|Read|NotebookRead|Grep|Glob|Bash|WebFetch|WebSearch|apply_patch|mcp__.*",
         "hooks": [
           {
             "type": "command",
@@ -14,7 +14,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Write|Edit|MultiEdit|Bash|apply_patch|Read|NotebookRead|Grep|Glob|WebFetch|WebSearch|mcp__.*",
+        "matcher": "Write|Edit|MultiEdit|NotebookEdit|Bash|apply_patch|Read|NotebookRead|Grep|Glob|WebFetch|WebSearch|mcp__.*",
         "hooks": [
           {
             "type": "command",

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -912,6 +912,17 @@ else
   sed 's/^/  stderr: /' "$ERR"
 fi
 
+printf '%s' '{"tool_name":"NotebookEdit","tool_input":{"notebook_path":"nb.ipynb","new_source":"contact jane@example.com"}}' \
+  | AGENT_GUARD_PII_HOOK_MODE=block "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool \
+    >"$OUT" 2>"$ERR"
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "PII hook block mode blocks proposed NotebookEdit content"
+else
+  not_ok "PII hook block mode blocks proposed NotebookEdit content (expected 2, got $status)"
+  sed 's/^/  stderr: /' "$ERR"
+fi
+
 printf '%s' '{"tool_name":"WebSearch","tool_input":{"query":"look up 203.0.113.42"}}' \
   | AGENT_GUARD_PII_HOOK_MODE=block "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool \
     >"$OUT" 2>"$ERR"
@@ -1570,6 +1581,14 @@ expect_json_status 0 "Write with no content key passes" \
 
 expect_json_status 0 "Edit with clean new_string passes" \
   '{"tool_name":"Edit","tool_input":{"new_string":"const x = 1"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "NotebookEdit with secret new_source is blocked" \
+  '{"tool_name":"NotebookEdit","tool_input":{"notebook_path":"nb.ipynb","new_source":"AGENT_GUARD_TEST_SECRET"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "NotebookEdit with clean new_source passes" \
+  '{"tool_name":"NotebookEdit","tool_input":{"notebook_path":"nb.ipynb","new_source":"print(1)"}}' \
   hook-pre-tool
 
 # --- hook_post_tool routing -----------------------------------------------


### PR DESCRIPTION
## What

Closes #112.

`NotebookEdit` was missing from Agent Guard's Claude hook coverage, so a secret or PII written into a Jupyter notebook cell was never scanned, blocked, or masked — while `Write` / `Edit` / `MultiEdit` all were. `NotebookRead` was already covered on the read side, so the write-side omission was an asymmetric gap.

## Changes

- **`plugins/agent-guard/hooks/hooks.json`** — add `NotebookEdit` to the PreToolUse and PostToolUse matchers (the hook never fired for it before).
- **`plugins/agent-guard/bin/agent-guard`** — add `NotebookEdit` to:
  - the `hook_pre_tool` dispatcher (`Write|Edit|MultiEdit|NotebookEdit|apply_patch`)
  - `scan_proposed_write` (secret scan) — extract `.tool_input.new_source`
  - `check_pii_hook_input` (PII block) — extract `.tool_input.new_source`
  - `is_mutation_tool` — so the PostToolUse working-tree backstop runs after a `.ipynb` write
- **`examples/claude/settings.project.json`** — keep the example matcher in sync (enforced by an existing test).
- **`tests/run.sh`** — add secret-block, clean-pass, and PII-block cases for `NotebookEdit`.
- **README / CHANGELOG** — document the added coverage.

`new_source` is the only content-bearing field of the Claude Code `NotebookEdit` tool; `cell_type` / `edit_mode` are metadata and `notebook_path` is the path. Codex hooks are intentionally unchanged (Codex has no `NotebookEdit` tool).

## Verification

Automated (this branch):

- `bash tests/run.sh` → **420 passed / 0 failed**, including the 3 new `NotebookEdit` cases.
- Local review trio (built-in code-review + security + CodeRabbit): no findings ≥ Medium. Confirmed `new_source` is the correct field, all three enforcement paths (Pre secret scan, PII block, Post working-tree backstop) are closed, and no fail-open regression.

Manual check for the reviewer (automation can't fully exercise a live host):

1. In a real Claude Code session with Agent Guard active, ask the agent to write a fake API key into a notebook cell via `NotebookEdit` (e.g. target a scratch `*.ipynb`, `new_source` containing a secret-shaped token).
2. Expected: the PreToolUse hook blocks the call with a secret-detected message, same as an equivalent `Write`.
3. Repeat with `AGENT_GUARD_PII_HOOK_MODE=block` and PII (e.g. an email) in the cell → expected block.
4. Clean cell content (`print(1)`) → expected pass.


<!-- code-flow-usage-json:start -->
<details>
<summary>code-flow usage JSON</summary>

```json
{
  "commits": [
    {
      "confidence": "best_effort",
      "model_totals": [],
      "participants": [],
      "sha": "8e09ac1bc6ab593eef11ff833b9a0983aa3d0ec8",
      "status": "unmetered",
      "subject": "fix(hooks): scan NotebookEdit cell content for secrets and PII",
      "totals": {
        "cache_creation_input_tokens": 0,
        "cache_read_input_tokens": 0,
        "input_tokens": 0,
        "output_tokens": 0,
        "total_context_tokens": 0
      }
    }
  ],
  "confidence": "best_effort",
  "metered_commits": 0,
  "pr": {
    "base": "main",
    "head": "fix/notebookedit-hook-coverage",
    "number": 113
  },
  "schema": "code-flow-usage/1",
  "scope": "current_branch_pr",
  "source": "claude_code_hooks",
  "total_commits": 1,
  "totals": {
    "cache_creation_input_tokens": 0,
    "cache_read_input_tokens": 0,
    "input_tokens": 0,
    "output_tokens": 0,
    "total_context_tokens": 0
  },
  "totals_by_model": [],
  "updated_at": "2026-07-17T11:15:08Z"
}
```

</details>
<!-- code-flow-usage-json:end -->
