### PR TITLE
chore(release): v2.0.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "agent-guard",
       "source": "./plugins/agent-guard",
       "description": "Real-time secret-leak guardrails for AI coding agents (Claude Code, Codex), Git hooks, and CI.",
-      "version": "2.0.0"
+      "version": "2.0.1"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## v2.0.1 - 2026-07-17
 
 - fix(hooks): scan `NotebookEdit` cell content so secrets written to notebook cells are blocked (and PII when `AGENT_GUARD_PII_HOOK_MODE=block`) (#112)
 

--- a/plugins/agent-guard/.claude-plugin/plugin.json
+++ b/plugins/agent-guard/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-guard",
   "description": "Real-time secret-leak guardrails for AI coding agents (Claude Code, Codex), Git hooks, and CI.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": {
     "name": "Agent Guard contributors"
   }

--- a/plugins/agent-guard/.codex-plugin/plugin.json
+++ b/plugins/agent-guard/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-guard",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Real-time secret-leak guardrails for AI coding agents (Claude Code, Codex), Git hooks, and CI.",
   "author": {
     "name": "Agent Guard contributors"

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -2,7 +2,7 @@
 set -u
 
 PROGRAM=agent-guard
-VERSION=2.0.0
+VERSION=2.0.1
 
 # Resolve the script's own path, following symlinks. The bootstrap installer
 # drops a symlink at ~/.local/bin/agent-guard that points into ~/.agent-guard/


### PR DESCRIPTION
## Release v2.0.1

Patch release to ship the `NotebookEdit` hook coverage fix that merged after v2.0.0.

### Included

- **fix(hooks): scan `NotebookEdit` cell content** (#112, merged in #113) — secrets written into a Jupyter notebook cell (`.tool_input.new_source`) are now scanned and blocked in `PreToolUse`, PII is blocked under `AGENT_GUARD_PII_HOOK_MODE=block`, and the `PostToolUse` working-tree backstop runs after a notebook write. Previously `NotebookEdit` was absent from the hook matcher and the tool-dispatch case blocks, so it was an uncovered leak path versus `Write` / `Edit` / `MultiEdit`.

### Version bumps (2.0.0 → 2.0.1)

- `plugins/agent-guard/.claude-plugin/plugin.json`
- `plugins/agent-guard/.codex-plugin/plugin.json`
- `.claude-plugin/marketplace.json`
- `plugins/agent-guard/bin/agent-guard` (`VERSION=` — the standalone shell-integration CLI, bumped in lockstep so `/plugin update` and `agent-guard setup-shell` stay drift-free)
- `CHANGELOG.md` (`## Unreleased` → `## v2.0.1`)

### Why a release is needed

The plugin manager resolves the cached plugin by its declared version. Because the `NotebookEdit` fix landed under `## Unreleased` with the manifest still at `2.0.0`, `/plugin update` reported "already at 2.0.0" and did not re-fetch it — the fix was on `main` but not in any installed hook. This bump makes it installable.

### Verification

- `bash tests/run.sh` → **432 passed**. The single local failure (`Codex SessionStart stays scoped to Codex setup`) is an environment artifact: the runner's standalone shell integration is still `1.10.1`, so the version-drift warning (#104) fires; that test does not pin the marker. In CI's clean environment the marker is absent and the suite is fully green.

### Manual step for the maintainer

After merge, publish the release / push the `v2.0.1` tag per the usual release workflow so the marketplace serves 2.0.1. Users then get the fix via `/plugin update`; anyone using command wrapping should re-run `/agent-guard:setup-shell` to move the standalone CLI to 2.0.1 and clear the drift warning.


<!-- code-flow-usage-json:start -->
<details>
<summary>code-flow usage JSON</summary>

```json
{
  "commits": [
    {
      "confidence": "best_effort",
      "model_totals": [],
      "participants": [],
      "sha": "f58ec0ff965e72c3af0b8f27e05ed821db9f3d0c",
      "status": "unmetered",
      "subject": "chore(release): v2.0.1",
      "totals": {
        "cache_creation_input_tokens": 0,
        "cache_read_input_tokens": 0,
        "input_tokens": 0,
        "output_tokens": 0,
        "total_context_tokens": 0
      }
    }
  ],
  "confidence": "best_effort",
  "metered_commits": 0,
  "pr": {
    "base": "main",
    "head": "chore/release-v2.0.1",
    "number": 114
  },
  "schema": "code-flow-usage/1",
  "scope": "current_branch_pr",
  "source": "claude_code_hooks",
  "total_commits": 1,
  "totals": {
    "cache_creation_input_tokens": 0,
    "cache_read_input_tokens": 0,
    "input_tokens": 0,
    "output_tokens": 0,
    "total_context_tokens": 0
  },
  "totals_by_model": [],
  "updated_at": "2026-07-17T12:19:21Z"
}
```

</details>
<!-- code-flow-usage-json:end -->
