### PR TITLE
docs: prepare Claude marketplace submission review

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-guard",
-  "description": "Real-time secret-leak guardrails for AI coding agents (Claude Code, Codex), Git hooks, and CI.",
+  "description": "Local-by-default, no-telemetry guardrails that inspect supported agent tool calls and changed files to prevent secret leaks.",
   "owner": {
     "name": "Agent Guard contributors"
   },
@@ -8,7 +8,7 @@
     {
       "name": "agent-guard",
       "source": "./plugins/agent-guard",
-      "description": "Real-time secret-leak guardrails for AI coding agents (Claude Code, Codex), Git hooks, and CI.",
+      "description": "Local-by-default, no-telemetry hooks inspect supported tool inputs, outputs, and changed files in every enabled Claude Code or Codex session to block or mask secret leaks. Includes opt-in PII filtering and Git/CI backstops.",
       "version": "2.0.1"
     }
   ]

--- a/.github/workflows/plugin-validation.yml
+++ b/.github/workflows/plugin-validation.yml
@@ -31,3 +31,6 @@ jobs:
 
       - name: Validate Release Archive Layout
         run: scripts/validate-plugin-layout.sh --archive
+
+      - name: Validate Marketplace Submission Readiness
+        run: make submission-check

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Agent Guard — discoverability layer for the existing scripts.
 # Each target is a thin pass-through to install.sh or plugins/agent-guard/bin/agent-guard.
 
-.PHONY: help check install test smoke-test bench scan scan-staged checksum
+.PHONY: help check install test smoke-test bench scan scan-staged checksum submission-check
 
 help:
 	@printf 'Agent Guard — make targets\n'
@@ -15,6 +15,7 @@ help:
 	@printf '  make scan          Scan the working tree for secrets.\n'
 	@printf '  make scan-staged   Scan staged changes only.\n'
 	@printf '  make checksum [VERSION=X.Y.Z]   Fetch gitleaks-checksum for every supported OS/arch (CI typically picks linux/x64).\n'
+	@printf '  make submission-check  Validate marketplace submission documentation and metadata.\n'
 
 check:
 	@./install.sh check
@@ -39,3 +40,6 @@ scan-staged:
 
 checksum:
 	@sh plugins/agent-guard/scripts/gitleaks-checksum.sh $(VERSION)
+
+submission-check:
+	@scripts/validate-submission-readiness.sh

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,66 @@
+# Privacy and Data Handling
+
+Last updated: 2026-07-18
+
+Agent Guard is local by default. The project does not operate an Agent Guard
+service, account system, telemetry collector, crash reporter, or analytics
+endpoint. Default hook processing does not transmit inspected data and does not
+retain it after the hook or command finishes.
+
+## What the plugin processes
+
+When enabled, Agent Guard registers hooks for `SessionStart`, `PreToolUse`,
+`PostToolUse`, and `Stop`.
+
+| Surface | Data inspected | Purpose | Persistent storage |
+|---|---|---|---|
+| `PreToolUse` | Matched tool names and inputs, including paths, proposed content, shell commands, URLs/search queries, and MCP arguments | Block deny-listed reads, credential-dumping commands, secret-like input, and opt-in PII classes before execution | None |
+| `PostToolUse` | Matched tool outputs; after mutation tools, changed and untracked files in the current Git work tree | Mask secret-like output and opt-in PII; detect secrets written to the work tree | None |
+| `Stop` | Changed and untracked files in the current Git work tree | Final working-tree secret scan | None |
+| `SessionStart` | Dependency availability and Agent Guard shell-integration version marker | Report degraded setup or version drift | None |
+| CLI and shell wrappers | Only stdin, paths, or command output explicitly passed by the user | On-demand scan or masking | None |
+
+Temporary scan reports and provider responses are created under the operating
+system temporary directory and removed when the operation exits. Agent Guard
+does not write inspected tool content to its own log or database. The host
+application may independently retain tool inputs and outputs under its own
+privacy policy.
+
+## Network behavior
+
+Normal lifecycle hooks and the built-in `regex` PII provider make no outbound
+network calls. Web and MCP tool inputs are inspected locally before the host
+decides whether to execute those tools; Agent Guard does not forward them.
+
+The following explicit actions use the network:
+
+- `agent-guard checksum` fetches the published gitleaks checksum list from
+  GitHub Releases. It sends no project or tool content.
+- Approval-gated `agent-guard setup --install` downloads a versioned gitleaks
+  archive from GitHub Releases and requires its SHA-256. It sends no project or
+  tool content.
+- The standalone `bootstrap.sh` install path downloads Agent Guard's release
+  archive and checksum from this project's GitHub Releases page.
+- If the user selects `AGENT_GUARD_PII_PROVIDER=pleno` or `http`,
+  `agent-guard pii-filter` sends the complete text provided on stdin to the
+  exact URL in `AGENT_GUARD_PII_REDACT_URL`. In
+  `AGENT_GUARD_PII_HOOK_MODE=block`, supported tool-input text is sent to that
+  same endpoint to determine whether it contains PII. The endpoint's operator,
+  not Agent Guard, controls its collection, retention, and deletion practices.
+
+PII hook handling defaults to `off`; the default provider is the local `regex`
+adapter. `mask` mode performs input Tier-2 detection and output masking locally,
+even if an HTTP provider is configured. Agent Guard never chooses or enables a
+remote PII endpoint on the user's behalf.
+
+## User controls
+
+- Disable or uninstall the plugin to stop all Agent Guard lifecycle hooks.
+- Keep `AGENT_GUARD_PII_HOOK_MODE=off` to disable PII processing in hooks.
+- Use `AGENT_GUARD_PII_PROVIDER=regex` to keep `pii-filter` local.
+- Set `AGENT_GUARD_OUTPUT_REDACT=off` to disable secret-like output masking.
+  This reduces protection and is not recommended.
+- Decline the guided setup installation prompt to prevent software downloads.
+
+For vulnerabilities, use the private channel in [SECURITY.md](SECURITY.md).
+For questions and support, see [SUPPORT.md](SUPPORT.md).

--- a/README.md
+++ b/README.md
@@ -109,6 +109,25 @@ brew install jq gitleaks
 
 On Debian / Ubuntu or Fedora, install `jq` with the system package manager and download `gitleaks` from its release page.
 
+## Trust, privacy, and support
+
+When the plugin is enabled, its `PreToolUse` and `PostToolUse` hooks run for every
+matched tool call in the session. They inspect supported tool inputs and outputs
+in memory, and mutation/stop backstops scan changed files in the current Git work
+tree. Default hook processing is local: Agent Guard has no telemetry, developer
+service, account, or analytics endpoint, and it does not retain inspected data.
+
+PII hook handling is off by default. The built-in `regex` provider stays local.
+If you explicitly select the `pleno` or `http` provider, text passed to
+`pii-filter`—and supported tool-input text in PII `block` mode—is sent to the
+exact endpoint in `AGENT_GUARD_PII_REDACT_URL`. Review that endpoint's privacy
+and retention terms before enabling it.
+
+Dependency downloads never happen from a lifecycle hook. The guided setup asks
+before installing anything and requires a published SHA-256 for the gitleaks
+archive. See [Privacy and data handling](PRIVACY.md), [Security](SECURITY.md),
+[Support](SUPPORT.md), and [Third-party notices](THIRD_PARTY_NOTICES.md).
+
 ## Claude Code Plugin
 
 Install and verify in the [Claude Code quick start](#claude-code). Useful slash commands once installed:

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,25 @@
+# Support
+
+## Getting help
+
+- Usage questions, bug reports, and feature requests:
+  [GitHub Issues](https://github.com/JeongJaeSoon/agent-guard/issues)
+- Maintainer contact and project ownership:
+  [JeongJaeSoon on GitHub](https://github.com/JeongJaeSoon)
+- Sensitive security reports: follow the private process in
+  [SECURITY.md](SECURITY.md). Do not disclose a vulnerability in a public issue.
+
+When reporting a problem, include the Agent Guard version, host (Claude Code,
+Codex, CLI, Git hook, or GitHub Actions), operating system and architecture,
+the command or hook event involved, and sanitized output. Never include live
+credentials, private keys, or unredacted personal data.
+
+## Supported environments
+
+Agent Guard supports macOS and Linux on x64 and arm64. Runtime hooks require
+`sh`, `awk`, `git`, `jq`, and gitleaks. Windows is not currently supported.
+Host support and known coverage boundaries are documented in the main README.
+
+The latest 2.x release is the actively supported line. The 1.x moving tag
+receives security fixes only. General support is best effort; security reports
+are acknowledged on the timeline stated in `SECURITY.md`.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,20 @@
+# Third-Party Notices
+
+Agent Guard's source and bundled plugin payload are licensed under the MIT
+License in [LICENSE](LICENSE).
+
+Agent Guard integrates with, but does not vendor, the following independently
+installed software:
+
+- [gitleaks](https://github.com/gitleaks/gitleaks), used for secret detection.
+  Agent Guard's approval-gated installer downloads the versioned upstream
+  release archive and verifies a user-supplied published SHA-256. gitleaks is
+  distributed under its own
+  [MIT License](https://github.com/gitleaks/gitleaks/blob/v8.30.1/LICENSE).
+- [jq](https://github.com/jqlang/jq), used for JSON processing. Agent Guard does
+  not install jq automatically; users obtain it from their operating system or
+  another trusted distributor under jq's own license terms.
+
+No gitleaks or jq executable is included in the Agent Guard repository, plugin,
+or release archive. Their names and links are provided for attribution and do
+not imply endorsement.

--- a/docs/claude-marketplace-readiness.md
+++ b/docs/claude-marketplace-readiness.md
@@ -1,0 +1,120 @@
+# Claude Marketplace Readiness Review
+
+Review date: 2026-07-18
+
+## Decision
+
+**Official marketplace feasibility: conditional, but not currently
+submittable.** Agent Guard's packaging, documentation, local validation,
+license, support, and supply-chain disclosure can be made review-ready. Two
+external blockers remain:
+
+1. Anthropic's current Claude Code documentation says there is **no application
+   process** for `claude-plugins-official`; inclusion is at Anthropic's
+   discretion. The public submission forms feed `claude-plugins-community`, not
+   the official marketplace.
+2. The official repository's policy scanner fails an external plugin when any
+   ungated `PreToolUse` or `PostToolUse` hook runs broadly. Agent Guard
+   intentionally registers both across every enabled coding session. Changing
+   that behavior would require a product decision (for example, a per-project
+   enable marker), not a documentation-only submission patch.
+
+Do not open a pull request against `anthropics/claude-plugins-official` unless an
+Anthropic maintainer explicitly supplies a path. The repository automatically
+closes normal external PRs; its narrow exception only permits additions from a
+source repository that already backs a live marketplace entry.
+
+## Verified source snapshot
+
+- Agent Guard baseline: `origin/main` at `d0ad75415a36992a8e502eaaf48757f7f13074ff`,
+  which includes merged PR
+  [#54](https://github.com/JeongJaeSoon/agent-guard/pull/54) and its shared
+  Claude Code/Codex Quick Start.
+- Official repository: `anthropics/claude-plugins-official` at
+  `f9cb226d81172f53a1787cc3ba90dc9ab51aa169`.
+- The official repository has no root `CONTRIBUTING.md` or `SECURITY.md` at that
+  snapshot. Its README, CI workflows, policy prompt, and Claude Code
+  documentation are the operative public sources.
+
+## Policy and repository findings
+
+| Area | Current official behavior | Agent Guard fit |
+|---|---|---|
+| Registration path | The repository README still links a plugin submission form, but current Claude Code docs clarify that the form targets the community marketplace and that official inclusion has no application process. | **Blocker outside the repo.** Prepare artifacts, but seek curator contact or use the community route. |
+| External PRs | Non-member PRs are closed unless they only add marketplace entries from a repository that already has a live entry. | **Blocker.** `JeongJaeSoon/agent-guard` is not already listed. |
+| Source pinning | External sources use `url` or `git-subdir` and a full commit SHA. Automated jobs later bump the SHA and re-scan. | **Ready after push.** Use `git-subdir` with `path: plugins/agent-guard`; fill the template SHA only after the prepared commit is reachable on GitHub. |
+| Name | Marketplace names are immutable kebab-case slugs. | **Ready.** `agent-guard` is stable and kebab-case. |
+| Manifest | Plugin root contains `.claude-plugin/plugin.json`; components stay at plugin root. New work prefers `skills/`, while `commands/` remains supported as legacy. | **Ready with legacy note.** Manifest is valid; Claude commands remain legacy-compatible and the Codex setup workflow is a skill. |
+| Hook review | External scan enumerates every hook and fails ungated `PreToolUse` or `PostToolUse` hooks. Descriptions must disclose hook scope and data access. | **Blocker.** Agent Guard's broad hooks are core behavior. Descriptions and privacy docs now disclose the scope, but disclosure does not override the scanner's broad-hook failure rule. |
+| Network and telemetry | Undisclosed non-MCP outbound calls or default-on telemetry fail review. Downloads must be visible to the reviewer. | **Ready with declared flags.** Normal hooks are local and there is no telemetry. Checksum/install calls go only to GitHub Releases; the optional HTTP PII provider is off by default and fully disclosed. Expected scan flags: `may_make_external_network_calls=true`, `may_download_additional_software=true`. |
+| Data and PII | Collect only data necessary for the function; remote data processing requires an accessible privacy policy. | **Ready for local mode.** Hook input/output and work-tree scope, ephemeral handling, remote PII behavior, and controls are documented in the shipped plugin payload. |
+| Binary bootstrap | Review covers every shipped script. Remote software and trust boundaries must match the install description. | **Recommended improvement remains.** gitleaks install is approval-gated, versioned, and SHA-256 verified. Agent Guard release bootstrap verifies an archive checksum published beside the archive; neither path currently verifies an independent signature or provenance attestation. |
+| Permissions | Workflows and integrations should use the least permissions needed. | **Ready.** Runtime hooks use local process/file access only. CI workflows declare read-only defaults except narrowly scoped release/comment jobs; third-party actions are pinned to full SHAs. |
+| Platforms | Platform limitations must be disclosed. | **Ready.** macOS/Linux x64 and arm64 are supported; Windows is explicitly unsupported. |
+| Tests and CI | Validate manifest/layout and behavior; official entries also receive CLI validation and policy scanning. | **Ready locally.** Deterministic tests, real gitleaks smoke tests, layout validation, marketplace validation, and a submission-readiness check are available. Broad-hook policy still fails independently. |
+| License and notices | The official repo requires Apache-2.0 for vendored Anthropic plugins, while external entries retain their own linked licenses. | **Ready.** Agent Guard is MIT. Aikido demonstrates an MIT-licensed external listing. The shipped plugin now includes LICENSE and third-party notices; gitleaks/jq are not vendored. |
+| Security and support | Directory policy requires verified contact, support channels, maintenance, documentation, troubleshooting, and private security reporting. | **Ready.** Maintainer URL, GitHub Issues, private vulnerability reporting, supported versions, and platform/dependency information are shipped with the plugin. |
+| Listing copy | Install description must match hooks, data access, network behavior, and delivered functionality. | **Ready.** The template is concise enough for the catalog and explicitly says the hooks are broad, local by default, and no-telemetry. |
+
+## Comparison with listed plugins
+
+All marketplace observations below are from the pinned entries in the official
+catalog, not from an unpinned upstream branch.
+
+| Plugin | Official source form | Components and trust model | Comparison with Agent Guard |
+|---|---|---|---|
+| [SonarQube](https://github.com/SonarSource/sonarqube-agent-plugins) | `url`, full repository, SHA pinned | Shipped plugin hook is an unconditional `SessionStart` diagnostic. The Sonar CLI performs auth and installs project/global analysis hooks after an explicit integration step; README discloses CLI, container, MCP, and keychain requirements. | Closest hook/security peer. Its marketplace payload avoids shipped broad `PreToolUse`/`PostToolUse`; Agent Guard ships those directly, creating the main policy mismatch. |
+| [Aikido](https://github.com/AikidoSec/aikido-claude-plugin) | `url`, full repository, SHA pinned | Manifest + `.mcp.json`; no hooks. Runs a version-pinned npm MCP package and connects to Aikido. MIT license and concise setup documentation. | Confirms MIT is acceptable for an external entry. Agent Guard has a larger local hook/data surface but no required account or remote service. |
+| [42Crunch API Security Testing](https://github.com/42Crunch-AI/claude-plugins/tree/main/plugins/api-security-testing) | `git-subdir`, SHA pinned | Skills and documentation; no shipped lifecycle hooks. Setup downloads and verifies an external `42c-ast` binary and stores service credentials with restricted permissions. Apache-2.0. | Confirms `git-subdir` is the correct form and verified binary bootstrap is reviewable when disclosed. Agent Guard's installer is more approval-gated, but its broad hooks remain the difference. |
+
+## Classification
+
+### Blockers
+
+- No public application or direct PR path to `claude-plugins-official`.
+- Current official policy scan treats Agent Guard's ungated `PreToolUse` and
+  `PostToolUse` hooks as a failure.
+- The catalog SHA cannot be finalized until this preparation commit is pushed
+  to a public ref. Do not pin an unreachable local commit.
+
+### Recommended before any review request
+
+- Merge and release the manifest/documentation payload, then replace the SHA
+  placeholder in the entry template with the reachable 40-character commit.
+- Ask Anthropic whether an always-on local security guard can receive an
+  explicit policy exception or whether a per-project activation gate is
+  required. Do not silently weaken the product to satisfy the scanner.
+- Add independent GitHub artifact attestations or signing for Agent Guard
+  release archives. Current same-release checksum verification is useful but
+  does not protect against a compromised release publisher.
+- Obtain at least one external macOS and one Linux plugin-install verification
+  and retain sanitized results for a reviewer.
+
+### Optional
+
+- Add native Windows support.
+- Migrate legacy Claude `commands/*.md` to user-invoked `skills/` in a separate,
+  compatibility-tested release.
+- Publish an SBOM for release archives.
+
+## Submission artifacts
+
+- Official curator entry template:
+  `docs/submission/claude-plugins-official/marketplace-entry.template.json`
+- Curator PR/changeset description draft:
+  `docs/submission/claude-plugins-official/curator-change-description.md`
+- Community form draft and realistic alternative:
+  `docs/submission/claude-community/form-draft.md`
+- Submission sequence: `docs/submission/README.md`
+
+## Official sources
+
+- [Official marketplace README](https://github.com/anthropics/claude-plugins-official)
+- [External PR auto-close policy](https://github.com/anthropics/claude-plugins-official/blob/main/.github/workflows/close-external-prs.yml)
+- [External PR scope logic](https://github.com/anthropics/claude-plugins-official/blob/main/.github/scripts/external-pr-scope.js)
+- [Official policy scanner prompt](https://github.com/anthropics/claude-plugins-official/blob/main/.github/policy/prompt.md)
+- [Official validation workflow](https://github.com/anthropics/claude-plugins-official/blob/main/.github/workflows/validate-plugins.yml)
+- [Claude Code plugin submission guidance](https://code.claude.com/docs/en/plugins#submit-your-plugin-to-the-community-marketplace)
+- [Plugin marketplace source and strict-mode reference](https://code.claude.com/docs/en/plugin-marketplaces)
+- [Anthropic Software Directory Policy](https://support.claude.com/en/articles/13145358-anthropic-software-directory-policy)
+- [Community marketplace mirror](https://github.com/anthropics/claude-plugins-community)

--- a/docs/submission/README.md
+++ b/docs/submission/README.md
@@ -1,0 +1,22 @@
+# Claude Marketplace Submission Sequence
+
+1. Run `make test`, `make smoke-test`, `scripts/validate-plugin-layout.sh --all`,
+   `make submission-check`, `claude plugin validate ./plugins/agent-guard`, and
+   `claude plugin validate .`.
+2. Commit the preparation changes in Agent Guard. Push and merge them only in
+   the Agent Guard repository, then publish a release if the manifest version
+   changed.
+3. Resolve the reachable 40-character GitHub commit SHA that contains the exact
+   plugin payload under `plugins/agent-guard`.
+4. Replace `<40-character-commit-sha-after-push>` in the official entry template
+   and re-run `make submission-check` with `AGENT_GUARD_SUBMISSION_SHA=<sha>`.
+5. For the public community route, submit the form draft through the Console
+   form (available to individual authors) or the claude.ai Team/Enterprise form.
+   Do not open a PR against the community mirror.
+6. For `claude-plugins-official`, proceed only if Anthropic explicitly invites
+   the plugin or provides a curator path. Send the entry and change-description
+   drafts, and resolve the broad-hook policy question before requesting a
+   catalog change.
+
+No fork, push, issue, submission, or pull request against an Anthropic
+repository is part of this preparation bundle.

--- a/docs/submission/claude-community/form-draft.md
+++ b/docs/submission/claude-community/form-draft.md
@@ -1,0 +1,78 @@
+# Claude Community Submission Form Draft
+
+## Plugin name
+
+`agent-guard`
+
+## Repository and plugin path
+
+- Repository: `https://github.com/JeongJaeSoon/agent-guard`
+- Plugin path: `plugins/agent-guard`
+- Commit SHA: `<40-character-commit-sha-after-push>`
+
+## Short description
+
+Local-by-default, no-telemetry hooks inspect supported Claude Code tool inputs,
+outputs, and changed files on macOS and Linux to block or mask secret leaks.
+Optional HTTP PII processing is off by default.
+
+## Category
+
+Security
+
+## Privacy policy
+
+`https://github.com/JeongJaeSoon/agent-guard/blob/main/PRIVACY.md`
+
+## Support and security
+
+- Support: `https://github.com/JeongJaeSoon/agent-guard/issues`
+- Private security reporting:
+  `https://github.com/JeongJaeSoon/agent-guard/security/advisories/new`
+
+## Data and network disclosure
+
+Hooks process matched tool inputs and outputs in memory and scan changed and
+untracked files in the current Git work tree. Default processing is local, has
+no telemetry, and retains no inspected data. `agent-guard checksum` and explicit,
+approval-gated setup contact GitHub Releases without sending project content.
+If the user opts into `AGENT_GUARD_PII_PROVIDER=pleno|http`, documented text is
+sent to the exact user-configured endpoint. PII hooks default to off.
+
+## Additional software
+
+Requires jq and gitleaks. Agent Guard never installs from a lifecycle hook. The
+guided setup asks for approval and requires a published SHA-256 before it can
+download a versioned gitleaks release archive.
+
+## Platforms
+
+macOS and Linux, x64 and arm64. Windows is not supported.
+
+## Three test prompts or use cases
+
+1. `Please read .env` — expected: blocked before file access.
+2. Ask Claude Code to write a synthetic private-key fixture — expected: the
+   proposed write is blocked.
+3. `/agent-guard:verify` in a fixture repository — expected: clean tree passes;
+   a synthetic gitleaks-detectable addition fails.
+
+## Test account
+
+Not applicable. Agent Guard's core plugin is local and has no account or
+developer-operated service. Review uses synthetic fixture data. An optional
+user-configured PII endpoint is not needed to verify core functionality.
+
+## Known review risk
+
+The plugin intentionally registers broad `PreToolUse` and `PostToolUse` hooks
+in every enabled session. This matches the security purpose and is disclosed,
+but it may conflict with Anthropic's automated broad-hook policy. Request a
+clear reviewer decision; do not imply the hook is project-gated.
+
+## Submission route
+
+Use `https://platform.claude.com/plugins/submit` for an individual author, or
+the claude.ai directory form for a Team/Enterprise organization with directory
+management access. The public community repository is a read-only mirror; do
+not open a pull request there.

--- a/docs/submission/claude-plugins-official/curator-change-description.md
+++ b/docs/submission/claude-plugins-official/curator-change-description.md
@@ -1,0 +1,58 @@
+# Curator change description draft
+
+> Use only after an Anthropic maintainer provides an official-marketplace
+> inclusion path. This is not a request to bypass the submission policy.
+
+## Summary
+
+- add `agent-guard` as a SHA-pinned `git-subdir` external plugin
+- provide local, deterministic secret-leak protection at the Claude Code tool
+  boundary, with Git-hook and CI backstops
+- support macOS and Linux on x64 and arm64
+
+## User-visible behavior
+
+Agent Guard registers `SessionStart`, `PreToolUse`, `PostToolUse`, and `Stop`
+hooks. The pre/post hooks inspect every matched tool call in each enabled
+session. They block deny-listed sensitive reads, secret-bearing writes and
+commands, mask secret-like tool output, and scan current work-tree changes.
+
+Normal hooks are local and have no telemetry. PII hook handling is off by
+default. Users who explicitly select the HTTP PII provider send documented text
+to their own configured endpoint. Lifecycle hooks never install software.
+Approval-gated setup can download a versioned gitleaks archive only with a
+published SHA-256.
+
+## Security and privacy review notes
+
+- expected flags: `may_make_external_network_calls=true` and
+  `may_download_additional_software=true`
+- no default outbound hook calls, analytics, crash reporting, or developer
+  service
+- full hook/data scope, optional PII transport, retention, and opt-outs are in
+  the shipped `PRIVACY.md`
+- known blocker requiring curator decision: the current marketplace scan policy
+  rejects ungated `PreToolUse`/`PostToolUse`, while always-on coverage is Agent
+  Guard's stated purpose
+- MIT license; gitleaks and jq are separately installed and not vendored
+- private vulnerability reporting and public support channels are documented
+
+## Validation
+
+- `make test`
+- `make smoke-test`
+- `scripts/validate-plugin-layout.sh --all`
+- `make submission-check`
+- `claude plugin validate ./plugins/agent-guard`
+- `claude plugin validate .`
+- `git diff --check`
+
+## Reviewer examples
+
+1. Ask Claude Code to read `.env`; Agent Guard should block before the read.
+2. Ask Claude Code to write a synthetic private-key fixture; Agent Guard should
+   block the proposed write.
+3. Run `/agent-guard:verify` in a clean fixture repository, then add a synthetic
+   gitleaks-detectable fixture and verify that the second scan fails.
+
+Use only synthetic fixtures. Never expose a real credential during review.

--- a/docs/submission/claude-plugins-official/marketplace-entry.template.json
+++ b/docs/submission/claude-plugins-official/marketplace-entry.template.json
@@ -1,0 +1,16 @@
+{
+  "name": "agent-guard",
+  "description": "Local-by-default, no-telemetry hooks inspect supported tool inputs, outputs, and changed files in every enabled Claude Code session on macOS and Linux to block or mask secret leaks. Optional HTTP PII processing is off by default.",
+  "author": {
+    "name": "Agent Guard contributors"
+  },
+  "category": "security",
+  "source": {
+    "source": "git-subdir",
+    "url": "https://github.com/JeongJaeSoon/agent-guard.git",
+    "path": "plugins/agent-guard",
+    "ref": "main",
+    "sha": "<40-character-commit-sha-after-push>"
+  },
+  "homepage": "https://github.com/JeongJaeSoon/agent-guard"
+}

--- a/plugins/agent-guard/.claude-plugin/plugin.json
+++ b/plugins/agent-guard/.claude-plugin/plugin.json
@@ -1,8 +1,19 @@
 {
   "name": "agent-guard",
-  "description": "Real-time secret-leak guardrails for AI coding agents (Claude Code, Codex), Git hooks, and CI.",
+  "description": "Local-by-default, no-telemetry hooks inspect supported tool inputs, outputs, and changed files in every enabled Claude Code or Codex session to block or mask secret leaks. Includes opt-in PII filtering and Git/CI backstops.",
   "version": "2.0.1",
   "author": {
-    "name": "Agent Guard contributors"
-  }
+    "name": "Agent Guard contributors",
+    "url": "https://github.com/JeongJaeSoon"
+  },
+  "homepage": "https://github.com/JeongJaeSoon/agent-guard",
+  "repository": "https://github.com/JeongJaeSoon/agent-guard",
+  "license": "MIT",
+  "keywords": [
+    "secrets",
+    "gitleaks",
+    "hooks",
+    "security",
+    "privacy"
+  ]
 }

--- a/plugins/agent-guard/.codex-plugin/plugin.json
+++ b/plugins/agent-guard/.codex-plugin/plugin.json
@@ -1,9 +1,10 @@
 {
   "name": "agent-guard",
   "version": "2.0.1",
-  "description": "Real-time secret-leak guardrails for AI coding agents (Claude Code, Codex), Git hooks, and CI.",
+  "description": "Local-by-default, no-telemetry hooks inspect supported tool inputs, outputs, and changed files in every enabled Claude Code or Codex session to block or mask secret leaks. Includes opt-in PII filtering and Git/CI backstops.",
   "author": {
-    "name": "Agent Guard contributors"
+    "name": "Agent Guard contributors",
+    "url": "https://github.com/JeongJaeSoon"
   },
   "homepage": "https://github.com/JeongJaeSoon/agent-guard",
   "repository": "https://github.com/JeongJaeSoon/agent-guard",
@@ -20,7 +21,7 @@
   "interface": {
     "displayName": "Agent Guard",
     "shortDescription": "Real-time secret-leak guardrails for AI coding agents",
-    "longDescription": "Real-time secret-leak guardrails for AI coding agents (Claude Code, Codex), Git hooks, and CI. Blocks `.env` reads, secret writes, and credential-dumping shell commands at the agent's tool boundary, with native Git-hook and GitHub Actions backstops.",
+    "longDescription": "Local-by-default, no-telemetry hooks inspect supported tool-call inputs, outputs, and changed files in every enabled Claude Code or Codex session. Agent Guard blocks risky `.env` reads, secret writes, and credential-dumping commands; masks secret-like tool output; and adds native Git-hook and GitHub Actions backstops. PII hook processing and HTTP providers are opt-in.",
     "developerName": "Agent Guard contributors",
     "category": "Developer Tools",
     "capabilities": [

--- a/plugins/agent-guard/LICENSE
+++ b/plugins/agent-guard/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Agent Guard contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/agent-guard/PRIVACY.md
+++ b/plugins/agent-guard/PRIVACY.md
@@ -1,0 +1,66 @@
+# Privacy and Data Handling
+
+Last updated: 2026-07-18
+
+Agent Guard is local by default. The project does not operate an Agent Guard
+service, account system, telemetry collector, crash reporter, or analytics
+endpoint. Default hook processing does not transmit inspected data and does not
+retain it after the hook or command finishes.
+
+## What the plugin processes
+
+When enabled, Agent Guard registers hooks for `SessionStart`, `PreToolUse`,
+`PostToolUse`, and `Stop`.
+
+| Surface | Data inspected | Purpose | Persistent storage |
+|---|---|---|---|
+| `PreToolUse` | Matched tool names and inputs, including paths, proposed content, shell commands, URLs/search queries, and MCP arguments | Block deny-listed reads, credential-dumping commands, secret-like input, and opt-in PII classes before execution | None |
+| `PostToolUse` | Matched tool outputs; after mutation tools, changed and untracked files in the current Git work tree | Mask secret-like output and opt-in PII; detect secrets written to the work tree | None |
+| `Stop` | Changed and untracked files in the current Git work tree | Final working-tree secret scan | None |
+| `SessionStart` | Dependency availability and Agent Guard shell-integration version marker | Report degraded setup or version drift | None |
+| CLI and shell wrappers | Only stdin, paths, or command output explicitly passed by the user | On-demand scan or masking | None |
+
+Temporary scan reports and provider responses are created under the operating
+system temporary directory and removed when the operation exits. Agent Guard
+does not write inspected tool content to its own log or database. The host
+application may independently retain tool inputs and outputs under its own
+privacy policy.
+
+## Network behavior
+
+Normal lifecycle hooks and the built-in `regex` PII provider make no outbound
+network calls. Web and MCP tool inputs are inspected locally before the host
+decides whether to execute those tools; Agent Guard does not forward them.
+
+The following explicit actions use the network:
+
+- `agent-guard checksum` fetches the published gitleaks checksum list from
+  GitHub Releases. It sends no project or tool content.
+- Approval-gated `agent-guard setup --install` downloads a versioned gitleaks
+  archive from GitHub Releases and requires its SHA-256. It sends no project or
+  tool content.
+- The standalone `bootstrap.sh` install path downloads Agent Guard's release
+  archive and checksum from this project's GitHub Releases page.
+- If the user selects `AGENT_GUARD_PII_PROVIDER=pleno` or `http`,
+  `agent-guard pii-filter` sends the complete text provided on stdin to the
+  exact URL in `AGENT_GUARD_PII_REDACT_URL`. In
+  `AGENT_GUARD_PII_HOOK_MODE=block`, supported tool-input text is sent to that
+  same endpoint to determine whether it contains PII. The endpoint's operator,
+  not Agent Guard, controls its collection, retention, and deletion practices.
+
+PII hook handling defaults to `off`; the default provider is the local `regex`
+adapter. `mask` mode performs input Tier-2 detection and output masking locally,
+even if an HTTP provider is configured. Agent Guard never chooses or enables a
+remote PII endpoint on the user's behalf.
+
+## User controls
+
+- Disable or uninstall the plugin to stop all Agent Guard lifecycle hooks.
+- Keep `AGENT_GUARD_PII_HOOK_MODE=off` to disable PII processing in hooks.
+- Use `AGENT_GUARD_PII_PROVIDER=regex` to keep `pii-filter` local.
+- Set `AGENT_GUARD_OUTPUT_REDACT=off` to disable secret-like output masking.
+  This reduces protection and is not recommended.
+- Decline the guided setup installation prompt to prevent software downloads.
+
+For vulnerabilities, use the private channel in [SECURITY.md](SECURITY.md).
+For questions and support, see [SUPPORT.md](SUPPORT.md).

--- a/plugins/agent-guard/README.md
+++ b/plugins/agent-guard/README.md
@@ -1,0 +1,78 @@
+# Agent Guard
+
+Agent Guard is a local-by-default, no-telemetry secret-leak guardrail for AI
+coding agents. Its hooks inspect supported tool-call inputs and outputs in every
+enabled session, block common credential exposure paths before execution, mask
+secret-like output, and scan changed files after mutations and before stop.
+
+It is a defense-in-depth control, not a vault, DLP system, credential rotator,
+or replacement for GitHub Secret Scanning and Push Protection.
+
+## Install in Claude Code
+
+```text
+/plugin install agent-guard@claude-plugins-official
+/reload-plugins
+```
+
+The official-marketplace command above applies only after Anthropic lists the
+plugin. Until then, install from the project's marketplace:
+
+```text
+/plugin marketplace add JeongJaeSoon/agent-guard
+/plugin install agent-guard@agent-guard
+/reload-plugins
+```
+
+Install `jq` and gitleaks, then verify:
+
+```text
+/agent-guard:verify
+```
+
+Optional Claude shell command wrapping requires an explicit shell-rc change:
+
+```text
+/agent-guard:setup-shell
+```
+
+Restart the shell and Claude Code after setup. Dependency downloads never run
+from a lifecycle hook. The guided setup path asks before installing software and
+requires the published SHA-256 for the selected gitleaks archive.
+
+## Hooks and data scope
+
+The Claude plugin registers:
+
+- `PreToolUse` for supported read, search, write, shell, web, patch, and MCP
+  tools. It inspects paths and proposed tool input before execution.
+- `PostToolUse` for supported tools. It scans output for secret-like values and,
+  after mutations, scans changed files in the current Git work tree.
+- `Stop` to scan changed files in the current Git work tree.
+- `SessionStart` to report missing dependencies and shell-integration version
+  drift. It never installs software.
+
+Default processing is local, ephemeral, and has no telemetry. PII hook handling
+is off by default. Selecting the optional `pleno` or `http` PII provider sends
+the text described in [PRIVACY.md](PRIVACY.md) to the user-configured endpoint.
+
+## Requirements and platforms
+
+Supported platforms are macOS and Linux on x64 and arm64. Windows is not
+currently supported. Runtime requirements are `sh`, `awk`, `git`, `jq`, and
+gitleaks 8.30 or newer (recommended).
+
+## Commands
+
+- `/agent-guard:verify` — scan staged, unstaged, and untracked work-tree data.
+- `/agent-guard:checksum [VERSION]` — print published gitleaks checksums.
+- `/agent-guard:setup-shell` — install or refresh Claude command wrapping.
+
+## Policies and support
+
+- [Privacy and data handling](PRIVACY.md)
+- [Security reporting](SECURITY.md)
+- [Support and platform policy](SUPPORT.md)
+- [License](LICENSE)
+- [Third-party notices](THIRD_PARTY_NOTICES.md)
+- [Full documentation and known limitations](https://github.com/JeongJaeSoon/agent-guard)

--- a/plugins/agent-guard/SECURITY.md
+++ b/plugins/agent-guard/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+## Supported versions
+
+Agent Guard ships fixes on the latest release line. Use the most recent tag:
+`@v2` for the GitHub Action, and the latest release for CLI and plugin installs.
+
+| Version | Supported |
+|---|---|
+| Latest release (2.x) | ✅ |
+| 1.x / `@v1` | Security fixes only |
+| Older 1.x tags | Best effort |
+
+## Reporting a vulnerability
+
+Please report security issues **privately** — do not open a public issue for a
+sensitive report.
+
+- Preferred: GitHub [private vulnerability reporting](https://github.com/JeongJaeSoon/agent-guard/security/advisories/new).
+  This keeps the details private until a fix ships.
+
+We aim to acknowledge reports within a few days and to coordinate disclosure
+once a fix or mitigation is available.
+
+## Scope
+
+Agent Guard is a deterministic, thin guardrail — not a DLP system, EDR, or
+vault. It has documented blind spots by design (see
+[Known Limitations](https://github.com/JeongJaeSoon/agent-guard#known-limitations)):
+gitignored files are not scanned, only the git work tree is covered,
+path/command blocking uses fixed lists, tool-output masking is best-effort,
+Bash detection is pattern-based, and commands a user runs through the host's
+interactive shell escape (for example, a `!`-prefixed command) never reach a
+tool hook and so are not scanned or masked.
+
+Behavior that falls within those documented limitations is expected, not a
+vulnerability. Suggestions to narrow a blind spot are welcome as regular
+issues or pull requests. Reports of a bypass that defeats a control the project
+claims to enforce are in scope — please report those privately as above.

--- a/plugins/agent-guard/SUPPORT.md
+++ b/plugins/agent-guard/SUPPORT.md
@@ -1,0 +1,25 @@
+# Support
+
+## Getting help
+
+- Usage questions, bug reports, and feature requests:
+  [GitHub Issues](https://github.com/JeongJaeSoon/agent-guard/issues)
+- Maintainer contact and project ownership:
+  [JeongJaeSoon on GitHub](https://github.com/JeongJaeSoon)
+- Sensitive security reports: follow the private process in
+  [SECURITY.md](SECURITY.md). Do not disclose a vulnerability in a public issue.
+
+When reporting a problem, include the Agent Guard version, host (Claude Code,
+Codex, CLI, Git hook, or GitHub Actions), operating system and architecture,
+the command or hook event involved, and sanitized output. Never include live
+credentials, private keys, or unredacted personal data.
+
+## Supported environments
+
+Agent Guard supports macOS and Linux on x64 and arm64. Runtime hooks require
+`sh`, `awk`, `git`, `jq`, and gitleaks. Windows is not currently supported.
+Host support and known coverage boundaries are documented in the main README.
+
+The latest 2.x release is the actively supported line. The 1.x moving tag
+receives security fixes only. General support is best effort; security reports
+are acknowledged on the timeline stated in `SECURITY.md`.

--- a/plugins/agent-guard/THIRD_PARTY_NOTICES.md
+++ b/plugins/agent-guard/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,20 @@
+# Third-Party Notices
+
+Agent Guard's source and bundled plugin payload are licensed under the MIT
+License in [LICENSE](LICENSE).
+
+Agent Guard integrates with, but does not vendor, the following independently
+installed software:
+
+- [gitleaks](https://github.com/gitleaks/gitleaks), used for secret detection.
+  Agent Guard's approval-gated installer downloads the versioned upstream
+  release archive and verifies a user-supplied published SHA-256. gitleaks is
+  distributed under its own
+  [MIT License](https://github.com/gitleaks/gitleaks/blob/v8.30.1/LICENSE).
+- [jq](https://github.com/jqlang/jq), used for JSON processing. Agent Guard does
+  not install jq automatically; users obtain it from their operating system or
+  another trusted distributor under jq's own license terms.
+
+No gitleaks or jq executable is included in the Agent Guard repository, plugin,
+or release archive. Their names and links are provided for attribution and do
+not imply endorsement.

--- a/scripts/validate-plugin-layout.sh
+++ b/scripts/validate-plugin-layout.sh
@@ -220,6 +220,12 @@ validate_archive() {
   validate_archive_contains "$archive" ".claude-plugin/plugin.json"
   validate_archive_contains "$archive" "hooks.json"
   validate_archive_contains "$archive" "hooks/hooks.json"
+  validate_archive_contains "$archive" "README.md"
+  validate_archive_contains "$archive" "LICENSE"
+  validate_archive_contains "$archive" "PRIVACY.md"
+  validate_archive_contains "$archive" "SECURITY.md"
+  validate_archive_contains "$archive" "SUPPORT.md"
+  validate_archive_contains "$archive" "THIRD_PARTY_NOTICES.md"
   validate_archive_contains "$archive" "skills/setup-agent-guard/SKILL.md"
   validate_archive_contains "$archive" "skills/setup-agent-guard/agents/openai.yaml"
 

--- a/scripts/validate-submission-readiness.sh
+++ b/scripts/validate-submission-readiness.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd -P)
+PLUGIN="$ROOT/plugins/agent-guard"
+ENTRY="$ROOT/docs/submission/claude-plugins-official/marketplace-entry.template.json"
+REPORT="$ROOT/docs/claude-marketplace-readiness.md"
+
+failures=0
+
+ok() {
+  printf 'ok: %s\n' "$1"
+}
+
+fail() {
+  printf 'not ok: %s\n' "$1" >&2
+  failures=$((failures + 1))
+}
+
+require_file() {
+  if [ -f "$1" ]; then
+    ok "$1 exists"
+  else
+    fail "$1 exists"
+  fi
+}
+
+require_json() {
+  require_file "$1"
+  if [ -f "$1" ] && jq -e . "$1" >/dev/null; then
+    ok "$1 is valid JSON"
+  else
+    fail "$1 is valid JSON"
+  fi
+}
+
+contains() {
+  file=$1
+  pattern=$2
+  label=$3
+  if grep -Fq "$pattern" "$file"; then
+    ok "$label"
+  else
+    fail "$label"
+  fi
+}
+
+for file in README.md LICENSE PRIVACY.md SECURITY.md SUPPORT.md THIRD_PARTY_NOTICES.md; do
+  require_file "$ROOT/$file"
+  require_file "$PLUGIN/$file"
+done
+
+require_json "$PLUGIN/.claude-plugin/plugin.json"
+require_json "$PLUGIN/hooks/hooks.json"
+require_json "$ENTRY"
+require_file "$REPORT"
+require_file "$ROOT/docs/submission/claude-plugins-official/curator-change-description.md"
+require_file "$ROOT/docs/submission/claude-community/form-draft.md"
+
+for file in LICENSE PRIVACY.md SUPPORT.md THIRD_PARTY_NOTICES.md; do
+  if cmp -s "$ROOT/$file" "$PLUGIN/$file"; then
+    ok "plugin payload $file matches repository policy"
+  else
+    fail "plugin payload $file matches repository policy"
+  fi
+done
+
+manifest="$PLUGIN/.claude-plugin/plugin.json"
+if jq -e '
+  .name == "agent-guard"
+  and .license == "MIT"
+  and .homepage == "https://github.com/JeongJaeSoon/agent-guard"
+  and .repository == "https://github.com/JeongJaeSoon/agent-guard"
+  and .author.url == "https://github.com/JeongJaeSoon"
+  and (.description | test("no-telemetry"))
+  and (.description | test("hooks inspect"))
+  and (.description | test("every enabled"))
+  and (.description | test("PII"))
+' "$manifest" >/dev/null; then
+  ok "Claude manifest discloses identity, maintainer, license, broad hooks, telemetry, and PII"
+else
+  fail "Claude manifest discloses identity, maintainer, license, broad hooks, telemetry, and PII"
+fi
+
+events=$(jq -r '.hooks | keys[]' "$PLUGIN/hooks/hooks.json")
+for event in $events; do
+  contains "$PLUGIN/PRIVACY.md" "\`$event\`" "privacy policy enumerates $event"
+done
+
+contains "$PLUGIN/PRIVACY.md" 'no outbound' 'privacy policy discloses default network behavior'
+contains "$PLUGIN/PRIVACY.md" 'retain it after the hook or command finishes' 'privacy policy discloses retention'
+contains "$PLUGIN/PRIVACY.md" 'AGENT_GUARD_PII_REDACT_URL' 'privacy policy discloses the optional PII endpoint'
+contains "$PLUGIN/PRIVACY.md" 'defaults to `off`' 'privacy policy discloses PII hook default'
+contains "$PLUGIN/SECURITY.md" '/security/advisories/new' 'plugin payload provides private security reporting'
+contains "$PLUGIN/SUPPORT.md" 'GitHub Issues' 'plugin payload provides a public support channel'
+contains "$PLUGIN/SUPPORT.md" 'Windows is not currently supported' 'plugin payload discloses platform limits'
+contains "$PLUGIN/README.md" 'enabled session' 'plugin README discloses broad hook scope'
+contains "$PLUGIN/README.md" 'never run' 'plugin README discloses lifecycle download behavior'
+
+if jq -e '
+  .name == "agent-guard"
+  and .category == "security"
+  and (.description | test("no-telemetry"))
+  and (.description | test("every enabled"))
+  and (.description | test("PII"))
+  and .source.source == "git-subdir"
+  and .source.url == "https://github.com/JeongJaeSoon/agent-guard.git"
+  and .source.path == "plugins/agent-guard"
+  and .source.ref == "main"
+  and .homepage == "https://github.com/JeongJaeSoon/agent-guard"
+' "$ENTRY" >/dev/null; then
+  ok "official marketplace entry template uses the pinned git-subdir form and discloses material behavior"
+else
+  fail "official marketplace entry template uses the pinned git-subdir form and discloses material behavior"
+fi
+
+entry_sha=$(jq -r '.source.sha // ""' "$ENTRY")
+expected_sha=${AGENT_GUARD_SUBMISSION_SHA:-}
+if [ -n "$expected_sha" ]; then
+  if printf '%s\n' "$expected_sha" | grep -Eq '^[0-9a-f]{40}$'; then
+    ok "AGENT_GUARD_SUBMISSION_SHA is a full commit SHA"
+  else
+    fail "AGENT_GUARD_SUBMISSION_SHA is a full commit SHA"
+  fi
+  if [ "$entry_sha" = "$expected_sha" ]; then
+    ok "entry template is finalized at AGENT_GUARD_SUBMISSION_SHA"
+  else
+    fail "entry template is finalized at AGENT_GUARD_SUBMISSION_SHA"
+  fi
+else
+  case "$entry_sha" in
+    '<40-character-commit-sha-after-push>')
+      ok "entry template keeps an explicit post-push SHA placeholder"
+      ;;
+    *)
+      if printf '%s\n' "$entry_sha" | grep -Eq '^[0-9a-f]{40}$'; then
+        ok "entry template contains a full commit SHA"
+      else
+        fail "entry template contains a full commit SHA or the documented placeholder"
+      fi
+      ;;
+  esac
+fi
+
+contains "$REPORT" 'No public application or direct PR path' 'readiness report records the official submission blocker'
+contains "$REPORT" 'ungated `PreToolUse` or `PostToolUse`' 'readiness report records the broad-hook blocker'
+contains "$REPORT" 'f9cb226d81172f53a1787cc3ba90dc9ab51aa169' 'readiness report pins the reviewed official snapshot'
+
+if [ "$failures" -eq 0 ]; then
+  printf 'submission readiness validation passed\n'
+else
+  printf 'submission readiness validation failed: %s issue(s)\n' "$failures" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- document Agent Guard's broad hook scope, local-by-default processing, optional PII transport, platform support, and supply-chain boundaries
- ship LICENSE, PRIVACY, SECURITY, SUPPORT, and third-party notices inside the plugin payload
- add a submission-readiness validator and enforce it in CI
- record the current Claude marketplace feasibility decision, compare three listed plugins, and prepare SHA-pinned official/community submission drafts

## Why

Anthropic's current official marketplace review policy requires clear disclosure of hook scope, data handling, network behavior, support, licensing, and external software. Agent Guard's existing plugin payload did not carry all of those policies when installed from a subdirectory.

The review also identifies two upstream constraints without weakening the product: the official marketplace has no public application path, and its current scanner rejects ungated PreToolUse/PostToolUse hooks.

## User impact

Runtime behavior is unchanged. Users get clearer install-time documentation and an auditable privacy/security/support bundle. Maintainers get deterministic submission checks and reusable marketplace artifacts.

## Validation

- `make test` — 433 passed, 0 failed
- `make smoke-test` — passed with gitleaks 8.30.1
- `scripts/validate-plugin-layout.sh --all`
- `make submission-check`
- `claude plugin validate ./plugins/agent-guard`
- `claude plugin validate .`
- `git diff --check`
