### PR TITLE
docs: pin community submission source

### DIFF
--- a/docs/claude-marketplace-readiness.md
+++ b/docs/claude-marketplace-readiness.md
@@ -30,6 +30,9 @@ source repository that already backs a live marketplace entry.
   which includes merged PR
   [#54](https://github.com/JeongJaeSoon/agent-guard/pull/54) and its shared
   Claude Code/Codex Quick Start.
+- Submission-ready plugin payload: `bdf51638652db846e1b19aa28f99cfa2d3f337e3`,
+  merged through Agent Guard
+  [PR #115](https://github.com/JeongJaeSoon/agent-guard/pull/115).
 - Official repository: `anthropics/claude-plugins-official` at
   `f9cb226d81172f53a1787cc3ba90dc9ab51aa169`.
 - The official repository has no root `CONTRIBUTING.md` or `SECURITY.md` at that
@@ -42,7 +45,7 @@ source repository that already backs a live marketplace entry.
 |---|---|---|
 | Registration path | The repository README still links a plugin submission form, but current Claude Code docs clarify that the form targets the community marketplace and that official inclusion has no application process. | **Blocker outside the repo.** Prepare artifacts, but seek curator contact or use the community route. |
 | External PRs | Non-member PRs are closed unless they only add marketplace entries from a repository that already has a live entry. | **Blocker.** `JeongJaeSoon/agent-guard` is not already listed. |
-| Source pinning | External sources use `url` or `git-subdir` and a full commit SHA. Automated jobs later bump the SHA and re-scan. | **Ready after push.** Use `git-subdir` with `path: plugins/agent-guard`; fill the template SHA only after the prepared commit is reachable on GitHub. |
+| Source pinning | External sources use `url` or `git-subdir` and a full commit SHA. Automated jobs later bump the SHA and re-scan. | **Ready.** The `git-subdir` template uses `path: plugins/agent-guard` and pins reachable commit `bdf51638652db846e1b19aa28f99cfa2d3f337e3`. |
 | Name | Marketplace names are immutable kebab-case slugs. | **Ready.** `agent-guard` is stable and kebab-case. |
 | Manifest | Plugin root contains `.claude-plugin/plugin.json`; components stay at plugin root. New work prefers `skills/`, while `commands/` remains supported as legacy. | **Ready with legacy note.** Manifest is valid; Claude commands remain legacy-compatible and the Codex setup workflow is a skill. |
 | Hook review | External scan enumerates every hook and fails ungated `PreToolUse` or `PostToolUse` hooks. Descriptions must disclose hook scope and data access. | **Blocker.** Agent Guard's broad hooks are core behavior. Descriptions and privacy docs now disclose the scope, but disclosure does not override the scanner's broad-hook failure rule. |
@@ -74,13 +77,11 @@ catalog, not from an unpinned upstream branch.
 - No public application or direct PR path to `claude-plugins-official`.
 - Current official policy scan treats Agent Guard's ungated `PreToolUse` and
   `PostToolUse` hooks as a failure.
-- The catalog SHA cannot be finalized until this preparation commit is pushed
-  to a public ref. Do not pin an unreachable local commit.
 
 ### Recommended before any review request
 
-- Merge and release the manifest/documentation payload, then replace the SHA
-  placeholder in the entry template with the reachable 40-character commit.
+- Keep the pinned commit synchronized with any future plugin-payload change and
+  re-run submission validation before each submission or curator request.
 - Ask Anthropic whether an always-on local security guard can receive an
   explicit policy exception or whether a per-project activation gate is
   required. Do not silently weaken the product to satisfy the scanner.

--- a/docs/submission/README.md
+++ b/docs/submission/README.md
@@ -7,9 +7,13 @@
    the Agent Guard repository, then publish a release if the manifest version
    changed.
 3. Resolve the reachable 40-character GitHub commit SHA that contains the exact
-   plugin payload under `plugins/agent-guard`.
-4. Replace `<40-character-commit-sha-after-push>` in the official entry template
-   and re-run `make submission-check` with `AGENT_GUARD_SUBMISSION_SHA=<sha>`.
+   plugin payload under `plugins/agent-guard`. The prepared submission pins
+   `bdf51638652db846e1b19aa28f99cfa2d3f337e3`, merged through Agent Guard
+   [PR #115](https://github.com/JeongJaeSoon/agent-guard/pull/115).
+4. Re-run `make submission-check` with
+   `AGENT_GUARD_SUBMISSION_SHA=bdf51638652db846e1b19aa28f99cfa2d3f337e3`.
+   If the plugin payload changes, replace the pinned SHA in both submission
+   drafts and validate the new reachable commit before submitting.
 5. For the public community route, submit the form draft through the Console
    form (available to individual authors) or the claude.ai Team/Enterprise form.
    Do not open a PR against the community mirror.

--- a/docs/submission/claude-community/form-draft.md
+++ b/docs/submission/claude-community/form-draft.md
@@ -8,7 +8,7 @@
 
 - Repository: `https://github.com/JeongJaeSoon/agent-guard`
 - Plugin path: `plugins/agent-guard`
-- Commit SHA: `<40-character-commit-sha-after-push>`
+- Commit SHA: `bdf51638652db846e1b19aa28f99cfa2d3f337e3`
 
 ## Short description
 

--- a/docs/submission/claude-plugins-official/marketplace-entry.template.json
+++ b/docs/submission/claude-plugins-official/marketplace-entry.template.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/JeongJaeSoon/agent-guard.git",
     "path": "plugins/agent-guard",
     "ref": "main",
-    "sha": "<40-character-commit-sha-after-push>"
+    "sha": "bdf51638652db846e1b19aa28f99cfa2d3f337e3"
   },
   "homepage": "https://github.com/JeongJaeSoon/agent-guard"
 }


### PR DESCRIPTION
## Summary

- pin the marketplace source to the public plugin payload merged by #115
- update the community submission draft with the same reachable 40-character SHA
- record the completed preparation PR and make the validation command reproducible
- remove the now-resolved “unreachable SHA” blocker from the readiness report

## Source commit

`bdf51638652db846e1b19aa28f99cfa2d3f337e3`

This commit contains the exact plugin payload under `plugins/agent-guard`. This follow-up only updates submission documentation, so the pinned payload remains stable.

## Validation

- `AGENT_GUARD_SUBMISSION_SHA=bdf51638652db846e1b19aa28f99cfa2d3f337e3 make submission-check`
- `git diff --check`
