### PR TITLE
feat: add managed deployment for Claude Code and Codex

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,6 +138,15 @@ jobs:
             jq --arg v "$v" '(.plugins[] | select(.name=="agent-guard") | .version) = $v' \
               "$mp" > "$mp.tmp" && mv "$mp.tmp" "$mp"
           fi
+          # Keep the copy-pasteable managed Claude settings pinned to the same
+          # release as the plugin manifests and marketplace catalog.
+          managed=deployment/claude-managed-settings.example.json
+          if [ -f "$managed" ]; then
+            jq --arg ref "v${v}" '
+              .extraKnownMarketplaces["agent-guard"].source.ref = $ref
+              | (.strictKnownMarketplaces[] | select(.source == "github" and .repo == "JeongJaeSoon/agent-guard") | .ref) = $ref
+            ' "$managed" > "$managed.tmp" && mv "$managed.tmp" "$managed"
+          fi
           # Replace any pinned semver in README install snippets (no-op if none).
           sed -i -E "s|agent-guard@[0-9]+\.[0-9]+\.[0-9]+|agent-guard@${v}|g" README.md
           # Bump the VERSION constant the CLI reports via 'agent-guard version'.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Both plugins need `jq` and `gitleaks` on your machine (`brew install jq gitleaks
 | Claude Code agent guardrails | [Claude Code quick start](#claude-code) | Ask the agent to read `.env`; it should be blocked. |
 | Codex plugin guardrails | [Codex quick start](#codex) | Run `$setup-agent-guard` and require both live hook probes to pass. |
 | Codex CLI + Git backstop | [Direct CLI](#direct-cli) + [Native Git hook](#native-git-hook) | Run `agent-guard smoke-test`; commit a staged fixture secret, and it should fail. |
+| Centrally managed machines | [Managed deployment](#managed-deployment) | Install the managed payload, merge the Codex requirements fragment, and run both host live probes. |
 | Local commits | [Native Git hook](#native-git-hook) | Commit a staged fixture secret; commit should fail. |
 | CI / PRs | [GitHub Actions](#github-actions) | Push a test PR with a gitleaks-detectable fixture; workflow should fail. |
 | Manual scans | [Direct CLI](#direct-cli) | Run `agent-guard smoke-test`. |
@@ -188,6 +189,42 @@ agent-guard checksum
 ```
 
 Override install defaults with `AGENT_GUARD_VERSION`, `AGENT_GUARD_HOME`, `AGENT_GUARD_BIN_DIR`, or `AGENT_GUARD_COMMAND_WRAPPING`.
+
+## Managed deployment
+
+Agent Guard ships a host-aware [`managed-install.sh`](managed-install.sh) for
+MDM, fleet-management, shared development images, and team-managed machines.
+It is not tied to an Enterprise subscription. The entrypoint keeps privileged
+and user-owned changes separate:
+
+```sh
+# Administrator or device-management phase. Dependencies may be supplied from
+# the organization's already-approved packages.
+sudo ./managed-install.sh system \
+  --prefix /opt/agent-guard \
+  --jq-bin /path/to/approved/jq \
+  --gitleaks-bin /path/to/approved/gitleaks
+
+# Render for review and merge; the script never overwrites requirements.toml.
+./managed-install.sh render-codex --prefix /opt/agent-guard
+
+# Run as the actual login user, never as root.
+/opt/agent-guard/managed-install.sh user --prefix /opt/agent-guard
+
+# Verify the installed payload and dependencies.
+/opt/agent-guard/managed-install.sh verify --prefix /opt/agent-guard
+```
+
+For Codex, the rendered `requirements.toml` fragment enables administrator-
+managed hooks and uses the installed absolute hook dispatcher. This avoids a
+per-user hook-trust step. For Claude Code, managed settings force-enable the
+plugin while the user phase installs the default-on `cat`/`head`/`printenv`
+shell wrapping. PII hooks remain at their built-in default (`off`) unless the
+organization explicitly selects a mode.
+
+See [Managed deployment for Claude Code and Codex](docs/managed-deployment.md)
+for settings examples, MDM locations, update strategy, and remaining host
+coverage limits.
 
 ## PII Filtering
 

--- a/deployment/claude-managed-settings.example.json
+++ b/deployment/claude-managed-settings.example.json
@@ -1,0 +1,22 @@
+{
+  "extraKnownMarketplaces": {
+    "agent-guard": {
+      "source": {
+        "source": "github",
+        "repo": "JeongJaeSoon/agent-guard",
+        "ref": "v2.0.1"
+      },
+      "autoUpdate": false
+    }
+  },
+  "enabledPlugins": {
+    "agent-guard@agent-guard": true
+  },
+  "strictKnownMarketplaces": [
+    {
+      "source": "github",
+      "repo": "JeongJaeSoon/agent-guard",
+      "ref": "v2.0.1"
+    }
+  ]
+}

--- a/deployment/codex-hook
+++ b/deployment/codex-hook
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+# Stable Codex managed-hook dispatcher installed by managed-install.sh.
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd -P)
+PATH="$ROOT/bin:$PATH"
+AGENT_GUARD_GITLEAKS_BIN_DIR="$ROOT/bin"
+AGENT_GUARD_HOOK_HOST=codex
+export PATH AGENT_GUARD_GITLEAKS_BIN_DIR AGENT_GUARD_HOOK_HOST
+
+exec "$ROOT/bin/agent-guard" "$@"

--- a/deployment/codex-requirements.toml.template
+++ b/deployment/codex-requirements.toml.template
@@ -1,0 +1,47 @@
+# Merge this fragment into the organization's composed Codex requirements.toml.
+# Do not append it blindly when [features] or [hooks] already exists.
+# `allow_managed_hooks_only = true` is intentionally omitted because it disables
+# every user, project, session, and plugin hook; add it only as a separate,
+# organization-wide decision.
+
+[features]
+hooks = true
+
+[hooks]
+managed_dir = "@@AGENT_GUARD_PREFIX@@"
+
+[[hooks.PreToolUse]]
+matcher = "^(Bash|apply_patch|mcp__.*)$"
+
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = "@@AGENT_GUARD_PREFIX@@/deployment/codex-hook hook-pre-tool"
+timeout = 10
+statusMessage = "Agent Guard is checking tool input"
+
+[[hooks.PostToolUse]]
+matcher = "^(Bash|apply_patch|mcp__.*)$"
+
+[[hooks.PostToolUse.hooks]]
+type = "command"
+command = "@@AGENT_GUARD_PREFIX@@/deployment/codex-hook hook-post-tool"
+timeout = 20
+statusMessage = "Agent Guard is checking tool output"
+
+[[hooks.Stop]]
+matcher = ""
+
+[[hooks.Stop.hooks]]
+type = "command"
+command = "@@AGENT_GUARD_PREFIX@@/deployment/codex-hook hook-stop"
+timeout = 20
+statusMessage = "Agent Guard is checking changed files"
+
+[[hooks.SessionStart]]
+matcher = "^(startup|resume|clear|compact)$"
+
+[[hooks.SessionStart.hooks]]
+type = "command"
+command = "@@AGENT_GUARD_PREFIX@@/deployment/codex-hook hook-session-start"
+timeout = 5
+statusMessage = "Agent Guard is checking managed setup"

--- a/docs/managed-deployment.md
+++ b/docs/managed-deployment.md
@@ -1,0 +1,173 @@
+# Managed deployment for Claude Code and Codex
+
+`managed-install.sh` packages Agent Guard for centrally managed machines. It is
+usable with MDM, configuration management, shared development images, or a team
+bootstrap repository; it does not require an Enterprise subscription by itself.
+
+The deployment has two ownership boundaries:
+
+| Phase | Runs as | Purpose |
+|---|---|---|
+| System | administrator or device manager | Put the reviewed Agent Guard payload and optional approved dependency binaries at a stable absolute path. |
+| User | the actual login user | Add the Claude Code shell integration to that user's shell rc without creating root-owned user files. |
+
+Codex does not use Claude Code's shell snapshot or its `!` command wrapper.
+Codex protection is delivered through managed hooks. Claude Code uses its
+managed plugin hooks plus the user-scoped shell integration for the otherwise
+unhooked `!cat`/`!head`/`!printenv` path.
+
+## 1. Pin and stage the release
+
+Use a reviewed Agent Guard release and approved `jq` and `gitleaks` binaries.
+Do not fetch an unpinned `latest` installer from a privileged MDM job. Either
+vendor the release archive in the organization's deployment repository or
+verify it against an independently recorded checksum before extraction.
+
+From an extracted release or a source checkout:
+
+```sh
+sudo ./managed-install.sh system \
+  --prefix /opt/agent-guard \
+  --jq-bin /path/to/approved/jq \
+  --gitleaks-bin /path/to/approved/gitleaks
+```
+
+The command is update-safe and does not remove unrelated files from the managed
+prefix. It does not download software and does not edit either product's managed
+configuration. Omitting the dependency options is supported when `jq` and
+`gitleaks` are already available in the hosts' runtime `PATH`.
+
+## 2. Enforce Codex managed hooks
+
+Render the versioned configuration fragment:
+
+```sh
+/opt/agent-guard/managed-install.sh render-codex \
+  --prefix /opt/agent-guard \
+  --output /tmp/agent-guard-requirements.toml
+```
+
+Review and merge that fragment into the organization's single composed
+`requirements.toml`; do not append it blindly when `[features]` or `[hooks]`
+already exists. On macOS and Linux, the system location is
+`/etc/codex/requirements.toml`. macOS MDM can instead deliver the composed TOML
+through the `com.openai.codex:requirements_toml_base64` managed preference.
+
+The fragment sets `[features].hooks = true`, registers `/opt/agent-guard` as the
+managed hook directory, and defines Agent Guard's `SessionStart`, `PreToolUse`,
+`PostToolUse`, and `Stop` handlers with absolute commands. Codex does not
+distribute the scripts in `managed_dir`; the system phase above does that.
+
+The template intentionally omits:
+
+```toml
+allow_managed_hooks_only = true
+```
+
+That option is useful for a locked-down fleet but suppresses every user,
+project, session, and plugin hook. Add it only after reviewing the effect on all
+other Codex integrations. Agent Guard's managed hooks work without it.
+
+Installing the Agent Guard Codex plugin remains useful for its setup skill and
+UI metadata, but is not required for the managed hook enforcement path. If both
+managed and plugin hooks are loaded, avoid duplicate hook execution by deciding
+which source owns hooks for the fleet.
+
+## 3. Force-enable the Claude Code plugin
+
+Start from [`deployment/claude-managed-settings.example.json`](../deployment/claude-managed-settings.example.json).
+It pins the Agent Guard marketplace ref, force-enables the plugin, and restricts
+that marketplace source. It also disables automatic marketplace refreshes so a
+CSIRT-controlled version bump is required. Merge its keys into the
+organization's existing managed settings instead of replacing unrelated
+settings.
+
+Claude Code marketplace sources accept a branch or tag in `ref`, but do not
+accept an exact commit in `sha`. Do not add `sha` beside `ref` in
+`extraKnownMarketplaces` and describe the result as commit-pinned. For a
+cryptographically immutable rollout, build a reviewed plugin seed at the exact
+commit with `CLAUDE_CODE_PLUGIN_CACHE_DIR`, distribute it read-only, and set
+`CLAUDE_CODE_PLUGIN_SEED_DIR` on the fleet. The managed `enabledPlugins` entry
+composes with that seed. A release-tag deployment is simpler, but its integrity
+still depends on repository tag controls.
+
+Managed settings locations include:
+
+- macOS: `/Library/Application Support/ClaudeCode/managed-settings.json`
+- Linux and WSL: `/etc/claude-code/managed-settings.json`
+
+Agent Guard supports macOS and Linux. WSL is supported through its Linux
+environment; native Windows is not currently supported. The PowerShell or
+Intune side of a mixed fleet may distribute Claude Code settings, but it must
+not report the Agent Guard runtime or Codex hooks as fully installed unless the
+supported WSL phase has also completed.
+
+The example deliberately omits `AGENT_GUARD_PII_HOOK_MODE`. PII hooks already
+default to `off`; setting it in managed environment policy would also prevent
+users or pilot groups from selecting `mask` or `block`.
+
+`allowManagedHooksOnly: true` is also omitted. Claude Code exempts plugins that
+are force-enabled in managed `enabledPlugins`, but the option blocks other user
+and project hooks and therefore requires a separate organization-wide decision.
+
+## 4. Install Claude shell wrapping for each user
+
+Run the user phase in the login user's context:
+
+```sh
+/opt/agent-guard/managed-install.sh user --prefix /opt/agent-guard
+```
+
+The command refuses to run as root. It uses Agent Guard's idempotent
+`setup-shell`, prepends `/opt/agent-guard/bin` in the managed rc block, and
+enables command wrapping by default. This makes the managed `agent-guard`, `jq`,
+and `gitleaks` binaries visible before loading the shell integration.
+
+Restart the shell and Claude Code afterward. On managed macOS devices, schedule
+this phase as a login-user action rather than running it in a root-only MDM
+script; otherwise the wrong home directory or file ownership would result.
+
+## 5. Verify every layer
+
+Run the deterministic local checks:
+
+```sh
+/opt/agent-guard/managed-install.sh verify --prefix /opt/agent-guard
+```
+
+Then restart both hosts and run the live probes documented in the main README.
+The binary smoke test proves the rules work; it does not prove that a particular
+host version dispatches the current tool route to hooks.
+
+- Claude Code: verify the managed plugin is active, ask it to read `.env`, and
+  test a `!printenv` output path after restarting the shell.
+- Codex: verify the managed requirements source is loaded and run the harmless
+  PreToolUse and PostToolUse sentinels against the exact execution route in use.
+
+Codex currently exposes a narrower hook boundary than Claude Code. Managed
+hooks do not turn unsupported arbitrary reads or opaque host executors into
+hooked tools. Keep native Git hooks and CI secret scanning as backstops.
+
+## 6. Update and compliance loop
+
+Deploy Agent Guard and its managed configuration as one versioned unit:
+
+1. Stage and verify the new release and dependency artifacts.
+2. Re-run `managed-install.sh system` at the same prefix.
+3. Re-render and review the Codex fragment for schema changes.
+4. Re-run the user phase so the Claude rc block resolves the current binary.
+5. Restart both hosts and repeat the live probes.
+
+Agent Guard's `SessionStart` hook continues to report missing dependencies and
+Claude shell-integration version drift. Device management can periodically run
+the non-interactive system and verify phases, while rc mutation stays scoped to
+the login-user phase.
+
+## Product documentation used by this deployment model
+
+- [Codex managed hooks from `requirements.toml`](https://learn.chatgpt.com/docs/hooks#managed-hooks-from-requirementstoml)
+- [Codex managed configuration locations and precedence](https://learn.chatgpt.com/docs/enterprise/managed-configuration#locations-and-precedence)
+- [Claude Code managed marketplace restrictions](https://code.claude.com/docs/en/plugin-marketplaces#managed-marketplace-restrictions)
+- [Claude Code managed settings and `enabledPlugins`](https://code.claude.com/docs/en/settings)
+- [Claude Code marketplace and plugin source pinning](https://code.claude.com/docs/en/plugin-marketplaces#plugin-sources)
+- [Claude Code plugin seed directories](https://code.claude.com/docs/en/plugin-marketplaces#pre-populate-plugins-for-containers)

--- a/managed-install.sh
+++ b/managed-install.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env sh
+# Agent Guard managed deployment helper.
+#
+# This script deliberately separates the administrator-owned system install
+# from the user-owned Claude shell-rc update. It never downloads dependencies,
+# edits Codex requirements.toml, or edits Claude managed-settings.json.
+
+set -eu
+
+prog=agent-guard-managed-install
+DEFAULT_PREFIX=/opt/agent-guard
+
+info() { printf '%s\n' "$*" >&2; }
+die() { info "$prog: $*"; exit 2; }
+
+script_dir() {
+  CDPATH= cd -- "$(dirname -- "$0")" && pwd -P
+}
+
+SELF_DIR=$(script_dir)
+ASSET_DIR="$SELF_DIR/deployment"
+
+payload_root() {
+  if [ -x "$SELF_DIR/plugins/agent-guard/bin/agent-guard" ]; then
+    CDPATH= cd -- "$SELF_DIR/plugins/agent-guard" && pwd -P
+  elif [ -x "$SELF_DIR/bin/agent-guard" ]; then
+    printf '%s\n' "$SELF_DIR"
+  else
+    die "cannot locate the Agent Guard payload beside $0"
+  fi
+}
+
+validate_prefix() {
+  case "$1" in
+    /|''|*[!A-Za-z0-9_./-]*)
+      die "unsafe prefix (use an absolute path containing only letters, digits, _, ., /, or -): $1"
+      ;;
+    /*) ;;
+    *) die "prefix must be an absolute path: $1" ;;
+  esac
+}
+
+copy_binary() {
+  source_path=$1
+  target_name=$2
+  [ -f "$source_path" ] && [ -x "$source_path" ] \
+    || die "$target_name binary is not executable: $source_path"
+  cp "$source_path" "$prefix/bin/$target_name"
+  chmod 0755 "$prefix/bin/$target_name"
+  case "$target_name" in
+    jq)
+      "$prefix/bin/jq" -n '.' >/dev/null 2>&1 \
+        || die "copied jq binary cannot run from the managed prefix: $source_path"
+      ;;
+    gitleaks)
+      "$prefix/bin/gitleaks" version >/dev/null 2>&1 \
+        || die "copied gitleaks binary cannot run from the managed prefix: $source_path"
+      ;;
+  esac
+}
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  managed-install.sh system [--prefix DIR] [--jq-bin FILE] [--gitleaks-bin FILE]
+  managed-install.sh user [--prefix DIR] [--bash|--zsh|--rc FILE]
+  managed-install.sh render-codex [--prefix DIR] [--output FILE]
+  managed-install.sh verify [--prefix DIR]
+
+system        Install the versioned Agent Guard payload into a managed prefix.
+              Optional approved jq/gitleaks binaries are copied into prefix/bin.
+user          Install default-on Claude Code shell wrapping for the current user.
+              This refuses to run as root so an MDM job cannot edit root's rc.
+render-codex  Render, but never merge, the Codex requirements.toml fragment.
+verify        Run dependency and smoke checks against the managed installation.
+EOF
+}
+
+command_system() {
+  prefix=$DEFAULT_PREFIX
+  jq_bin=
+  gitleaks_bin=
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --prefix) shift; prefix=${1:-}; [ -n "$prefix" ] || die "--prefix requires a directory" ;;
+      --jq-bin) shift; jq_bin=${1:-}; [ -n "$jq_bin" ] || die "--jq-bin requires a file" ;;
+      --gitleaks-bin) shift; gitleaks_bin=${1:-}; [ -n "$gitleaks_bin" ] || die "--gitleaks-bin requires a file" ;;
+      -h|--help) usage; return 0 ;;
+      *) die "system: unknown option: $1" ;;
+    esac
+    shift
+  done
+  validate_prefix "$prefix"
+  source_root=$(payload_root)
+
+  mkdir -p "$prefix" "$prefix/bin" "$prefix/deployment"
+  prefix_real=$(CDPATH= cd -- "$prefix" && pwd -P)
+  if [ "$source_root" != "$prefix_real" ]; then
+    cp -R "$source_root/." "$prefix/"
+    cp "$SELF_DIR/managed-install.sh" "$prefix/managed-install.sh"
+    cp "$ASSET_DIR/codex-hook" "$prefix/deployment/codex-hook"
+    cp "$ASSET_DIR/codex-requirements.toml.template" \
+      "$prefix/deployment/codex-requirements.toml.template"
+    cp "$ASSET_DIR/claude-managed-settings.example.json" \
+      "$prefix/deployment/claude-managed-settings.example.json"
+  fi
+  chmod 0755 "$prefix/bin/agent-guard" "$prefix/managed-install.sh" \
+    "$prefix/deployment/codex-hook"
+
+  [ -z "$jq_bin" ] || copy_binary "$jq_bin" jq
+  [ -z "$gitleaks_bin" ] || copy_binary "$gitleaks_bin" gitleaks
+
+  info "$prog: installed Agent Guard into $prefix"
+  info "$prog: next: merge the output of '$prefix/managed-install.sh render-codex --prefix $prefix' into the managed Codex requirements.toml"
+  info "$prog: next: run '$prefix/managed-install.sh user --prefix $prefix' as each Claude Code user"
+}
+
+command_user() {
+  prefix=$DEFAULT_PREFIX
+  shell_arg=
+  rc_arg=
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --prefix) shift; prefix=${1:-}; [ -n "$prefix" ] || die "--prefix requires a directory" ;;
+      --bash|--zsh) shell_arg=$1 ;;
+      --rc) shift; rc_arg=${1:-}; [ -n "$rc_arg" ] || die "--rc requires a file" ;;
+      -h|--help) usage; return 0 ;;
+      *) die "user: unknown option: $1" ;;
+    esac
+    shift
+  done
+  validate_prefix "$prefix"
+  [ "$(id -u)" -ne 0 ] \
+    || die "user setup must run as the target login user, not root"
+  [ -x "$prefix/bin/agent-guard" ] \
+    || die "managed Agent Guard binary not found: $prefix/bin/agent-guard"
+
+  set -- --prepend-path "$prefix/bin"
+  [ -z "$shell_arg" ] || set -- "$@" "$shell_arg"
+  [ -z "$rc_arg" ] || set -- "$@" --rc "$rc_arg"
+  "$prefix/bin/agent-guard" setup-shell "$@"
+  info "$prog: Claude Code shell wrapping is installed for the current user"
+  info "$prog: restart the shell and Claude Code to load it"
+}
+
+render_template() {
+  template=$1
+  awk -v prefix="$prefix" '{ gsub(/@@AGENT_GUARD_PREFIX@@/, prefix); print }' "$template"
+}
+
+command_render_codex() {
+  prefix=$DEFAULT_PREFIX
+  output=
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --prefix) shift; prefix=${1:-}; [ -n "$prefix" ] || die "--prefix requires a directory" ;;
+      --output) shift; output=${1:-}; [ -n "$output" ] || die "--output requires a file" ;;
+      -h|--help) usage; return 0 ;;
+      *) die "render-codex: unknown option: $1" ;;
+    esac
+    shift
+  done
+  validate_prefix "$prefix"
+  template="$ASSET_DIR/codex-requirements.toml.template"
+  [ -f "$template" ] || die "Codex requirements template not found: $template"
+  if [ -z "$output" ]; then
+    render_template "$template"
+    return 0
+  fi
+  [ ! -e "$output" ] || die "refusing to overwrite existing file: $output"
+  output_dir=$(dirname -- "$output")
+  [ -d "$output_dir" ] || die "output directory does not exist: $output_dir"
+  tmp=$(mktemp "$output_dir/.agent-guard-requirements.XXXXXX") \
+    || die "failed to create temporary output"
+  if render_template "$template" >"$tmp"; then
+    chmod 0644 "$tmp"
+    mv "$tmp" "$output"
+  else
+    rm -f "$tmp"
+    die "failed to render Codex requirements"
+  fi
+  info "$prog: rendered Codex requirements fragment to $output"
+  info "$prog: review and merge it; Codex reads one composed requirements.toml, not arbitrary fragment files"
+}
+
+command_verify() {
+  prefix=$DEFAULT_PREFIX
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --prefix) shift; prefix=${1:-}; [ -n "$prefix" ] || die "--prefix requires a directory" ;;
+      -h|--help) usage; return 0 ;;
+      *) die "verify: unknown option: $1" ;;
+    esac
+    shift
+  done
+  validate_prefix "$prefix"
+  [ -x "$prefix/bin/agent-guard" ] \
+    || die "managed Agent Guard binary not found: $prefix/bin/agent-guard"
+  PATH="$prefix/bin:$PATH" \
+    AGENT_GUARD_GITLEAKS_BIN_DIR="$prefix/bin" \
+    "$prefix/bin/agent-guard" check
+  PATH="$prefix/bin:$PATH" \
+    AGENT_GUARD_GITLEAKS_BIN_DIR="$prefix/bin" \
+    "$prefix/bin/agent-guard" smoke-test
+  info "$prog: managed installation verification passed"
+  info "$prog: restart each host and run its documented live hook probes before declaring rollout complete"
+}
+
+cmd=${1:-}
+[ -n "$cmd" ] || { usage; exit 2; }
+shift
+case "$cmd" in
+  system) command_system "$@" ;;
+  user) command_user "$@" ;;
+  render-codex) command_render_codex "$@" ;;
+  verify) command_verify "$@" ;;
+  -h|--help|help) usage ;;
+  *) die "unknown command: $cmd" ;;
+esac

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -65,6 +65,7 @@ Usage:
   agent-guard exec [--] <cmd> [args...]
   agent-guard shell-init [--bash|--zsh] [--no-command-wrapping]
   agent-guard setup-shell [--bash|--zsh|--rc FILE] [--no-command-wrapping]
+                          [--prepend-path DIR]
   agent-guard pii-filter [--check]
   agent-guard scan-staged
   agent-guard scan-working-tree
@@ -2409,23 +2410,36 @@ EOF
 # cannot edit your rc, so run this once (by absolute path if agent-guard is not
 # yet on $PATH). Idempotent — re-running replaces the managed block in place.
 do_setup_shell() {
-  sh_target= rc= wrapping=
+  sh_target= rc= wrapping= prepend_path=
   while [ "$#" -gt 0 ]; do
     case "$1" in
       --bash) sh_target=bash ;;
       --zsh) sh_target=zsh ;;
       --rc) shift; rc=${1:-}; [ -n "$rc" ] || die "setup-shell: --rc requires a path" ;;
       --no-command-wrapping) wrapping=' --no-command-wrapping' ;;
+      --prepend-path)
+        shift
+        prepend_path=${1:-}
+        [ -n "$prepend_path" ] || die "setup-shell: --prepend-path requires a directory"
+        case "$prepend_path" in
+          /*) ;;
+          *) die "setup-shell: --prepend-path requires an absolute directory" ;;
+        esac
+        ;;
       # Hidden compatibility shims for 1.x managed blocks. The 2.x default is
       # on, so accepting either option and writing no option normalizes the rc.
       --claude-bang-guard|--experimental-bang-guard) wrapping= ;;
       -h|--help)
         {
           printf '%s\n' "Usage: $PROGRAM setup-shell [--bash|--zsh|--rc FILE] [--no-command-wrapping]"
+          printf '%s\n' "       $PROGRAM setup-shell [--prepend-path DIR]"
           printf '%s\n' "Adds the shell-init line to your shell rc (idempotent). Restart your"
           printf '%s\n' "shell and any Claude Code session afterwards to apply."
           printf '%s\n' "Command wrapping is enabled by default. Use --no-command-wrapping for"
           printf '%s\n' "a persistent opt-out, or AGENT_GUARD_COMMAND_WRAPPING=off at runtime."
+          printf '%s\n' "--prepend-path writes an absolute managed binary directory before the"
+          printf '%s\n' "shell-init line; managed installs can place agent-guard, jq, and"
+          printf '%s\n' "gitleaks there without relying on each user's existing PATH."
         } >&2
         return 0 ;;
       *) die "setup-shell: unknown option: $1 (see: $PROGRAM setup-shell --help)" ;;
@@ -2456,7 +2470,12 @@ do_setup_shell() {
   # snippet itself was never produced. The emitted snippet keeps its `auto` shell
   # detection, so the line works in bash+zsh.
   abs=$(sh_squote "$SELF_BIN")
-  line="eval \"\$(_agi=; command -v agent-guard >/dev/null 2>&1 && _agi=\$(agent-guard shell-init${wrapping} 2>/dev/null); if [ -n \"\$_agi\" ]; then printf '%s\\n' \"\$_agi\"; else $abs shell-init${wrapping}; fi)\""
+  path_prefix=
+  if [ -n "$prepend_path" ]; then
+    quoted_path=$(sh_squote "$prepend_path")
+    path_prefix="PATH=$quoted_path:\$PATH; export PATH; "
+  fi
+  line="${path_prefix}eval \"\$(_agi=; command -v agent-guard >/dev/null 2>&1 && _agi=\$(agent-guard shell-init${wrapping} 2>/dev/null); if [ -n \"\$_agi\" ]; then printf '%s\\n' \"\$_agi\"; else $abs shell-init${wrapping}; fi)\""
 
   begin='# >>> agent-guard shell-init >>>'
   end='# <<< agent-guard shell-init <<<'

--- a/scripts/build-release-tarball.sh
+++ b/scripts/build-release-tarball.sh
@@ -10,4 +10,8 @@ trap 'rm -rf "$stage"' EXIT INT TERM
 
 cp -R "$ROOT/plugins/agent-guard/." "$stage/"
 cp "$ROOT/install.sh" "$stage/install.sh"
+cp "$ROOT/managed-install.sh" "$stage/managed-install.sh"
+cp -R "$ROOT/deployment" "$stage/deployment"
+mkdir -p "$stage/docs"
+cp "$ROOT/docs/managed-deployment.md" "$stage/docs/managed-deployment.md"
 tar -C "$stage" -czf "$output" .

--- a/scripts/validate-plugin-layout.sh
+++ b/scripts/validate-plugin-layout.sh
@@ -140,6 +140,7 @@ validate_versions() {
   claude_version=$(jq -r '.version // ""' "$PLUGIN_ROOT/.claude-plugin/plugin.json")
   codex_version=$(jq -r '.version // ""' "$PLUGIN_ROOT/.codex-plugin/plugin.json")
   marketplace_version=$(jq -r '.plugins[] | select(.name == "agent-guard") | .version // ""' "$ROOT/.claude-plugin/marketplace.json")
+  managed_claude_ref=$(jq -r '.extraKnownMarketplaces["agent-guard"].source.ref // ""' "$ROOT/deployment/claude-managed-settings.example.json")
 
   if printf '%s\n' "$cli_version" | grep -Eq '^2\.[0-9]+\.[0-9]+$'; then
     ok "Agent Guard CLI is on the 2.x release line"
@@ -149,10 +150,11 @@ validate_versions() {
   if [ -n "$cli_version" ] \
      && [ "$claude_version" = "$cli_version" ] \
      && [ "$codex_version" = "$cli_version" ] \
-     && [ "$marketplace_version" = "$cli_version" ]; then
-    ok "CLI, Claude, Codex, and marketplace versions match ($cli_version)"
+     && [ "$marketplace_version" = "$cli_version" ] \
+     && [ "$managed_claude_ref" = "v$cli_version" ]; then
+    ok "CLI, Claude, Codex, marketplace, and managed settings versions match ($cli_version)"
   else
-    fail "CLI, Claude, Codex, and marketplace versions match"
+    fail "CLI, Claude, Codex, marketplace, and managed settings versions match"
   fi
 }
 
@@ -228,6 +230,11 @@ validate_archive() {
   validate_archive_contains "$archive" "THIRD_PARTY_NOTICES.md"
   validate_archive_contains "$archive" "skills/setup-agent-guard/SKILL.md"
   validate_archive_contains "$archive" "skills/setup-agent-guard/agents/openai.yaml"
+  validate_archive_contains "$archive" "managed-install.sh"
+  validate_archive_contains "$archive" "deployment/codex-hook"
+  validate_archive_contains "$archive" "deployment/codex-requirements.toml.template"
+  validate_archive_contains "$archive" "deployment/claude-managed-settings.example.json"
+  validate_archive_contains "$archive" "docs/managed-deployment.md"
 
   if [ -d "$PLUGIN_ROOT/commands" ]; then
     archive_command_count=$(find "$PLUGIN_ROOT/commands" -type f -name '*.md' | wc -l | tr -d ' ')

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -95,12 +95,102 @@ for file in \
   "$PLUGIN_ROOT/bin/agent-guard" \
   "$ROOT/install.sh" \
   "$ROOT/bootstrap.sh" \
+  "$ROOT/managed-install.sh" \
+  "$ROOT/deployment/codex-hook" \
   "$ROOT/scripts/build-release-tarball.sh" \
   "$ROOT/githooks/pre-commit" \
   "$PLUGIN_ROOT/scripts/gitleaks-checksum.sh" \
   "$ROOT/tests/run.sh"; do
   run_expect 0 "shell syntax: $file" sh -n "$file"
 done
+
+# Managed deployment is a two-phase, host-aware install: the system phase
+# places a stable payload for Codex managed hooks, while the user phase writes
+# Claude shell integration without requiring each user to run setup manually.
+managed_root="$TESTTMP/managed-deployment"
+managed_prefix="$managed_root/prefix"
+managed_user="$managed_root/user"
+mkdir -p "$managed_root" "$managed_user"
+
+sh "$ROOT/managed-install.sh" system \
+  --prefix "$managed_prefix" \
+  --gitleaks-bin "$MOCK_BIN/gitleaks" >"$OUT" 2>"$ERR"
+status=$?
+if [ "$status" -eq 0 ] \
+   && [ -x "$managed_prefix/bin/agent-guard" ] \
+   && [ -x "$managed_prefix/bin/gitleaks" ] \
+   && [ -x "$managed_prefix/deployment/codex-hook" ] \
+   && [ -x "$managed_prefix/managed-install.sh" ]; then
+  ok "managed system install stages Agent Guard, dependencies, and Codex dispatcher"
+else
+  not_ok "managed system install stages Agent Guard, dependencies, and Codex dispatcher (status $status)"
+  sed 's/^/  stderr: /' "$ERR"
+fi
+
+run_expect 0 "managed system install is idempotent from the installed prefix" \
+  sh "$managed_prefix/managed-install.sh" system --prefix "$managed_prefix"
+
+managed_fragment="$managed_root/agent-guard-requirements.toml"
+sh "$managed_prefix/managed-install.sh" render-codex \
+  --prefix "$managed_prefix" --output "$managed_fragment" >"$OUT" 2>"$ERR"
+status=$?
+if [ "$status" -eq 0 ] \
+   && grep -Fq 'hooks = true' "$managed_fragment" \
+   && grep -Fq "managed_dir = \"$managed_prefix\"" "$managed_fragment" \
+   && grep -Fq "$managed_prefix/deployment/codex-hook hook-pre-tool" "$managed_fragment" \
+   && ! grep -Eq '^[[:space:]]*allow_managed_hooks_only' "$managed_fragment"; then
+  ok "managed install renders an enforceable, non-exclusive Codex requirements fragment"
+else
+  not_ok "managed install renders an enforceable, non-exclusive Codex requirements fragment"
+fi
+
+if sh "$managed_prefix/managed-install.sh" render-codex \
+  --prefix "$managed_prefix" --output "$managed_fragment" >/dev/null 2>&1; then
+  not_ok "managed Codex renderer refuses to overwrite an existing requirements file"
+else
+  ok "managed Codex renderer refuses to overwrite an existing requirements file"
+fi
+
+printf '%s' '{"cwd":"/tmp","hook_event_name":"PreToolUse","model":"gpt-5","permission_mode":"default","session_id":"managed-test","tool_input":{"command":"cat .env"},"tool_name":"Bash","tool_use_id":"managed-use","transcript_path":null,"turn_id":"managed-turn"}' \
+  | "$managed_prefix/deployment/codex-hook" hook-pre-tool >"$OUT" 2>"$ERR"
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "managed Codex dispatcher blocks a deny-listed Bash input"
+else
+  not_ok "managed Codex dispatcher blocks a deny-listed Bash input (expected 2, got $status)"
+  sed 's/^/  stderr: /' "$ERR"
+fi
+
+HOME="$managed_user" SHELL=/bin/zsh \
+  sh "$managed_prefix/managed-install.sh" user \
+    --prefix "$managed_prefix" --rc "$managed_user/.zshrc" >"$OUT" 2>"$ERR"
+status=$?
+if [ "$status" -eq 0 ] \
+   && grep -Fq "PATH='$managed_prefix/bin':\$PATH; export PATH;" "$managed_user/.zshrc" \
+   && grep -Fq 'agent-guard shell-init' "$managed_user/.zshrc" \
+   && ! grep -Fq -- '--no-command-wrapping' "$managed_user/.zshrc"; then
+  ok "managed user install enables Claude wrapping with the managed bin directory"
+else
+  not_ok "managed user install enables Claude wrapping with the managed bin directory (status $status)"
+  sed 's/^/  stderr: /' "$ERR"
+fi
+
+if grep -Fq 'AGENT_GUARD_PII_HOOK_MODE' "$ROOT/deployment/claude-managed-settings.example.json"; then
+  not_ok "managed Claude settings do not force the opt-in PII hook mode"
+else
+  ok "managed Claude settings do not force the opt-in PII hook mode"
+fi
+
+if [ "$(jq -r '.extraKnownMarketplaces["agent-guard"].autoUpdate' "$ROOT/deployment/claude-managed-settings.example.json")" = "false" ]; then
+  ok "managed Claude settings require an intentional marketplace update"
+else
+  not_ok "managed Claude settings require an intentional marketplace update"
+fi
+if [ "$(jq -r '.extraKnownMarketplaces["agent-guard"].source.sha // "missing"' "$ROOT/deployment/claude-managed-settings.example.json")" = "missing" ]; then
+  ok "managed Claude settings do not claim unsupported marketplace SHA pinning"
+else
+  not_ok "managed Claude settings do not claim unsupported marketplace SHA pinning"
+fi
 
 # The direct installer must leave command wrapping active on a fresh install,
 # while AGENT_GUARD_COMMAND_WRAPPING=off is a persistent install-time opt-out.
@@ -174,7 +264,8 @@ for file in \
   "$PLUGIN_ROOT/.codex-plugin/plugin.json" \
   "$ROOT/.agents/plugins/marketplace.json" \
   "$ROOT/examples/claude/settings.project.json" \
-  "$ROOT/examples/codex/hooks.json"; do
+  "$ROOT/examples/codex/hooks.json" \
+  "$ROOT/deployment/claude-managed-settings.example.json"; do
   run_expect 0 "json syntax: $file" jq -e . "$file"
 done
 
@@ -469,13 +560,15 @@ plugin_ver=$(awk -F= '/^VERSION=/ {print $2; exit}' "$PLUGIN_ROOT/bin/agent-guar
 claude_ver=$(jq -r '.version' "$PLUGIN_ROOT/.claude-plugin/plugin.json")
 codex_ver=$(jq -r '.version' "$PLUGIN_ROOT/.codex-plugin/plugin.json")
 market_ver=$(jq -r '.plugins[] | select(.name == "agent-guard") | .version' "$ROOT/.claude-plugin/marketplace.json")
+managed_claude_ref=$(jq -r '.extraKnownMarketplaces["agent-guard"].source.ref' "$ROOT/deployment/claude-managed-settings.example.json")
 changelog_ver=$(sed -n 's/^## v\([^ ]*\) .*/\1/p' "$ROOT/CHANGELOG.md" | head -n1)
 if [ -n "$plugin_ver" ] && [ "$plugin_ver" = "$claude_ver" ] \
    && [ "$plugin_ver" = "$codex_ver" ] && [ "$plugin_ver" = "$market_ver" ] \
+   && [ "v$plugin_ver" = "$managed_claude_ref" ] \
    && [ "$plugin_ver" = "$changelog_ver" ]; then
-  ok "release version in sync across binary, plugin manifests, marketplace, and changelog ($plugin_ver)"
+  ok "release version in sync across binary, plugin manifests, marketplace, managed settings, and changelog ($plugin_ver)"
 else
-  not_ok "release version drift: bin=$plugin_ver claude=$claude_ver codex=$codex_ver marketplace=$market_ver changelog=$changelog_ver"
+  not_ok "release version drift: bin=$plugin_ver claude=$claude_ver codex=$codex_ver marketplace=$market_ver managed=$managed_claude_ref changelog=$changelog_ver"
 fi
 
 expect_json_status 2 "Claude Write secret is blocked" \
@@ -2125,10 +2218,13 @@ mkdir -p "$RELEASE_TARBALL_DIR/out"
 run_expect 0 "release tarball builder succeeds" \
   "$ROOT/scripts/build-release-tarball.sh" test "$RELEASE_TARBALL_DIR/agent-guard-test.tar.gz"
 tar -xzf "$RELEASE_TARBALL_DIR/agent-guard-test.tar.gz" -C "$RELEASE_TARBALL_DIR/out"
-if [ -x "$RELEASE_TARBALL_DIR/out/bin/agent-guard" ] && [ -x "$RELEASE_TARBALL_DIR/out/install.sh" ]; then
-  ok "release tarball contains bin/agent-guard and install.sh"
+if [ -x "$RELEASE_TARBALL_DIR/out/bin/agent-guard" ] \
+   && [ -x "$RELEASE_TARBALL_DIR/out/install.sh" ] \
+   && [ -x "$RELEASE_TARBALL_DIR/out/managed-install.sh" ] \
+   && [ -x "$RELEASE_TARBALL_DIR/out/deployment/codex-hook" ]; then
+  ok "release tarball contains direct and managed install entrypoints"
 else
-  not_ok "release tarball contains bin/agent-guard and install.sh"
+  not_ok "release tarball contains direct and managed install entrypoints"
 fi
 
 # --- githooks/pre-commit invokes scan-staged ------------------------------


### PR DESCRIPTION
## Summary

- add a reusable `managed-install.sh` entrypoint with separate administrator and login-user phases
- ship Codex `requirements.toml` managed-hook templates and an absolute dispatcher
- ship a Claude Code managed-settings example with intentional update control and default-on shell wrapping
- include the managed deployment assets in release archives and version-bump validation
- document MDM/configuration-management rollout, platform boundaries, plugin seed pinning, and verification

## Why

Managed settings alone can enable the Claude Code plugin, but they do not install Agent Guard's dependencies, protect Claude Code's unhooked shell-output route, or configure Codex administrator-managed hooks. Organizations need a versioned, testable entrypoint that can be invoked by MDM or configuration management without asking every developer to run setup commands.

## Safety and behavior

- no privileged network downloads
- no blind overwrite or merge of Claude/Codex managed configuration
- the user phase refuses to run as root
- PII hook mode remains opt-in and is not forced by the managed example
- `allowManagedHooksOnly` / `allow_managed_hooks_only` remain separate fleet-wide policy decisions
- native Windows remains unsupported; WSL uses the Linux path

## Validation

- `make test` — 445 passed, 0 failed
- `scripts/validate-plugin-layout.sh --all`
- `make submission-check`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added managed deployment support for centrally managed machines and shared environments.
  - Added installation workflows for system-wide Agent Guard setup and per-user Claude Code shell integration.
  - Added managed Codex hooks for pre-tool, post-tool, stop, and session-start events.
  - Added verification and configuration rendering commands for managed installations.
  - Added managed deployment files and documentation to release archives.

- **Documentation**
  - Added comprehensive guidance for managed Claude Code and Codex deployments, updates, and verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->