### PR TITLE
feat: add self-contained managed bootstrap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -294,6 +294,7 @@ jobs:
           scripts/build-release-tarball.sh "$v" "$tarball_tmp"
           mv "$tarball_tmp" "agent-guard-${v}.tar.gz"
           sha256sum "agent-guard-${v}.tar.gz" > "agent-guard-${v}.tar.gz.sha256"
+          sha256sum managed-bootstrap.sh > managed-bootstrap.sh.sha256
 
           # Idempotent release publish: if a release object already exists
           # (recovery path from a previous half-finished dispatch), upload the
@@ -307,6 +308,8 @@ jobs:
               "agent-guard-${v}.tar.gz.sha256" \
               install.sh \
               bootstrap.sh \
+              managed-bootstrap.sh \
+              managed-bootstrap.sh.sha256 \
               --clobber
           else
             gh release create "v${v}" \
@@ -315,5 +318,7 @@ jobs:
               "agent-guard-${v}.tar.gz" \
               "agent-guard-${v}.tar.gz.sha256" \
               install.sh \
-              bootstrap.sh
+              bootstrap.sh \
+              managed-bootstrap.sh \
+              managed-bootstrap.sh.sha256
           fi

--- a/README.md
+++ b/README.md
@@ -197,6 +197,27 @@ MDM, fleet-management, shared development images, and team-managed machines.
 It is not tied to an Enterprise subscription. The entrypoint keeps privileged
 and user-owned changes separate:
 
+For the smallest organization-owned deployment, use the release-provided
+[`managed-bootstrap.sh`](managed-bootstrap.sh). The organization keeps only the
+reviewed version/digest and its Claude/Codex policy; Agent Guard owns the
+platform-specific downloads, dependency checks, system install, verification,
+and default-on login-user shell phase:
+
+```sh
+sudo sh ./managed-bootstrap.sh \
+  --version X.Y.Z \
+  --archive-sha256 <independently-recorded-release-digest>
+```
+
+Download the bootstrap itself from that same versioned release, verify it with
+the adjacent `managed-bootstrap.sh.sha256` asset (and retain the reviewed digest
+in MDM), then schedule it at enrollment plus login/check-in.
+It never edits Claude managed settings or Codex TOML. A run with no login user
+still completes the system phase; the next login/check-in retries user setup.
+
+The lower-level entrypoint remains available when an organization already
+stages approved artifacts:
+
 ```sh
 # Administrator or device-management phase. Dependencies may be supplied from
 # the organization's already-approved packages.

--- a/docs/managed-deployment.md
+++ b/docs/managed-deployment.md
@@ -4,6 +4,37 @@
 usable with MDM, configuration management, shared development images, or a team
 bootstrap repository; it does not require an Enterprise subscription by itself.
 
+## Minimal organization-owned surface
+
+Use the release-provided `managed-bootstrap.sh` when the device manager should
+not maintain a copy of Agent Guard's installation logic. The organization owns
+only:
+
+- an explicitly approved Agent Guard version and independently recorded archive digest;
+- its Claude managed settings and composed Codex requirements;
+- the MDM schedule and rollout/pilot controls.
+
+Agent Guard owns release/dependency download and verification, system staging,
+verification, target-user detection, and default-on shell wrapping. Download
+the bootstrap from the same versioned release, verify it with the adjacent
+`managed-bootstrap.sh.sha256` asset, retain the reviewed digest in MDM, and run:
+
+```sh
+sudo sh ./managed-bootstrap.sh \
+  --version X.Y.Z \
+  --archive-sha256 <independently-recorded-release-digest>
+```
+
+The script accepts organization-provided `--jq-bin` and `--gitleaks-bin`
+artifacts, otherwise it downloads Agent Guard's pinned versions and verifies
+their platform-specific SHA-256 values. It records the installed release digest
+under the managed prefix, skips matching downloads on later check-ins, and
+retries the user phase at login. It does not own or overwrite either product's
+policy files.
+
+The remaining sections describe the lower-level/manual composition path and
+the policy that must accompany either installation entrypoint.
+
 The deployment has two ownership boundaries:
 
 | Phase | Runs as | Purpose |
@@ -16,7 +47,7 @@ Codex protection is delivered through managed hooks. Claude Code uses its
 managed plugin hooks plus the user-scoped shell integration for the otherwise
 unhooked `!cat`/`!head`/`!printenv` path.
 
-## 1. Pin and stage the release
+## 1. Pin and stage the release (lower-level path)
 
 Use a reviewed Agent Guard release and approved `jq` and `gitleaks` binaries.
 Do not fetch an unpinned `latest` installer from a privileged MDM job. Either

--- a/managed-bootstrap.sh
+++ b/managed-bootstrap.sh
@@ -118,7 +118,9 @@ require() {
 require curl
 require tar
 require awk
+require find
 require mktemp
+require sort
 require uname
 
 os=$(uname -s)
@@ -198,6 +200,53 @@ dependency_ready() {
     && [ "$(sha256_file "$PREFIX/bin/gitleaks")" = "$expected_gitleaks_sha256" ]
 }
 
+payload_ready() {
+  payload_manifest=$PREFIX/.managed-payload.sha256
+  [ -f "$payload_manifest" ] || return 1
+  payload_count=0
+  while IFS= read -r manifest_line; do
+    expected_payload_sha256=${manifest_line%% *}
+    relative_payload_path=${manifest_line#* }
+    case "$expected_payload_sha256" in
+      *[!0-9a-f]*|'') return 1 ;;
+    esac
+    [ "${#expected_payload_sha256}" -eq 64 ] || return 1
+    case "$relative_payload_path" in
+      /*|''|..|../*|*/../*|*/..) return 1 ;;
+    esac
+    payload_file=$PREFIX/$relative_payload_path
+    [ -f "$payload_file" ] \
+      && [ "$(sha256_file "$payload_file")" = "$expected_payload_sha256" ] \
+      || return 1
+    payload_count=$((payload_count + 1))
+  done <"$payload_manifest"
+  [ "$payload_count" -gt 0 ]
+}
+
+write_payload_manifest() {
+  payload_manifest=$PREFIX/.managed-payload.sha256
+  payload_manifest_tmp=$payload_manifest.tmp.$$
+  payload_files=$tmp/managed-payload-files
+  find "$PREFIX" -type f \
+    ! -path "$PREFIX/bin/jq" \
+    ! -path "$PREFIX/bin/gitleaks" \
+    ! -path "$PREFIX/.managed-release" \
+    ! -path "$PREFIX/.managed-release.tmp.*" \
+    ! -path "$PREFIX/.managed-payload.sha256" \
+    ! -path "$PREFIX/.managed-payload.sha256.tmp.*" \
+    -print | LC_ALL=C sort >"$payload_files"
+  umask 022
+  : >"$payload_manifest_tmp"
+  while IFS= read -r payload_file; do
+    relative_payload_path=${payload_file#"$PREFIX"/}
+    printf '%s %s\n' "$(sha256_file "$payload_file")" "$relative_payload_path" \
+      >>"$payload_manifest_tmp"
+  done <"$payload_files"
+  [ -s "$payload_manifest_tmp" ] || die "managed payload manifest would be empty"
+  chmod 0644 "$payload_manifest_tmp"
+  mv "$payload_manifest_tmp" "$payload_manifest"
+}
+
 managed_system_ready() {
   [ -x "$PREFIX/bin/agent-guard" ] \
     && [ -x "$PREFIX/managed-install.sh" ] \
@@ -206,6 +255,8 @@ managed_system_ready() {
     && [ -f "$PREFIX/.managed-release" ] \
     && [ "$(awk -F= '$1 == "version" {print $2; exit}' "$PREFIX/.managed-release")" = "$VERSION" ] \
     && dependency_ready \
+    && payload_ready \
+    && "$PREFIX/managed-install.sh" verify --prefix "$PREFIX" >/dev/null 2>&1 \
     || return 1
   [ -z "$EXPECTED_ARCHIVE_SHA256" ] \
     || [ "$(awk -F= '$1 == "archive_sha256" {print $2; exit}' "$PREFIX/.managed-release")" = "$EXPECTED_ARCHIVE_SHA256" ]
@@ -271,6 +322,7 @@ fi
 "$PREFIX/managed-install.sh" verify --prefix "$PREFIX"
 
 if [ -n "$metadata_archive_sha256" ]; then
+  write_payload_manifest
   metadata_tmp=$PREFIX/.managed-release.tmp.$$
   umask 022
   {

--- a/managed-bootstrap.sh
+++ b/managed-bootstrap.sh
@@ -9,7 +9,7 @@ set -eu
 
 PROGRAM=agent-guard-managed-bootstrap
 REPO=${AGENT_GUARD_REPO:-JeongJaeSoon/agent-guard}
-VERSION=${AGENT_GUARD_VERSION:-}
+VERSION=
 EXPECTED_ARCHIVE_SHA256=${AGENT_GUARD_ARCHIVE_SHA256:-}
 PREFIX=${AGENT_GUARD_PREFIX:-/opt/agent-guard}
 TARGET_USER=${AGENT_GUARD_TARGET_USER:-}
@@ -95,7 +95,7 @@ while [ "$#" -gt 0 ]; do
   shift
 done
 
-[ -n "$VERSION" ] || die "--version or AGENT_GUARD_VERSION is required for a managed install"
+[ -n "$VERSION" ] || die "--version is required for a managed install"
 printf '%s\n' "$VERSION" \
   | awk -F. 'NF == 3 && $1 ~ /^[0-9]+$/ && $2 ~ /^[0-9]+$/ && $3 ~ /^[0-9]+$/ { found = 1 } END { exit found ? 0 : 1 }' \
   || die "invalid version (expected X.Y.Z): $VERSION"
@@ -181,10 +181,21 @@ download() {
 }
 
 dependency_ready() {
+  [ -f "$PREFIX/.managed-release" ] || return 1
+  expected_jq_sha256=$(awk -F= '$1 == "jq_sha256" {print $2; exit}' "$PREFIX/.managed-release")
+  expected_gitleaks_sha256=$(awk -F= '$1 == "gitleaks_sha256" {print $2; exit}' "$PREFIX/.managed-release")
+  case "$expected_jq_sha256/$expected_gitleaks_sha256" in
+    *[!0-9a-f/]*|*/|/*) return 1 ;;
+  esac
+  [ "${#expected_jq_sha256}" -eq 64 ] \
+    && [ "${#expected_gitleaks_sha256}" -eq 64 ] \
+    || return 1
   [ -x "$PREFIX/bin/jq" ] \
     && "$PREFIX/bin/jq" -n '.' >/dev/null 2>&1 \
+    && [ "$(sha256_file "$PREFIX/bin/jq")" = "$expected_jq_sha256" ] \
     && [ -x "$PREFIX/bin/gitleaks" ] \
-    && "$PREFIX/bin/gitleaks" version >/dev/null 2>&1
+    && "$PREFIX/bin/gitleaks" version >/dev/null 2>&1 \
+    && [ "$(sha256_file "$PREFIX/bin/gitleaks")" = "$expected_gitleaks_sha256" ]
 }
 
 managed_system_ready() {
@@ -266,7 +277,9 @@ if [ -n "$metadata_archive_sha256" ]; then
     printf 'version=%s\n' "$VERSION"
     printf 'archive_sha256=%s\n' "$metadata_archive_sha256"
     printf 'jq_version=%s\n' "$JQ_VERSION"
+    printf 'jq_sha256=%s\n' "$(sha256_file "$PREFIX/bin/jq")"
     printf 'gitleaks_version=%s\n' "$GITLEAKS_VERSION"
+    printf 'gitleaks_sha256=%s\n' "$(sha256_file "$PREFIX/bin/gitleaks")"
   } >"$metadata_tmp"
   chmod 0644 "$metadata_tmp"
   mv "$metadata_tmp" "$PREFIX/.managed-release"
@@ -288,6 +301,20 @@ detect_target_user() {
     Linux)
       TARGET_USER=${SUDO_USER:-}
       [ "$TARGET_USER" = root ] && TARGET_USER=
+      if [ -z "$TARGET_USER" ] && command -v loginctl >/dev/null 2>&1; then
+        for session_id in $(loginctl list-sessions --no-legend 2>/dev/null | awk '{print $1}'); do
+          [ "$(loginctl show-session "$session_id" -p Active --value 2>/dev/null || true)" = yes ] \
+            || continue
+          candidate_user=$(loginctl show-session "$session_id" -p Name --value 2>/dev/null || true)
+          case "$candidate_user" in
+            ''|root) continue ;;
+            *) TARGET_USER=$candidate_user; break ;;
+          esac
+        done
+      fi
+      if [ -z "$TARGET_USER" ] && command -v who >/dev/null 2>&1; then
+        TARGET_USER=$(who 2>/dev/null | awk '$1 != "root" {print $1; exit}')
+      fi
       ;;
   esac
 }
@@ -335,6 +362,8 @@ resolve_target_identity() {
 run_user_phase() {
   command=$PREFIX/managed-install.sh
   if [ "$(id -u)" -ne 0 ]; then
+    [ "$(id -u "$TARGET_USER")" = "$(id -u)" ] \
+      || die "non-root execution can only configure the current user"
     HOME="$TARGET_HOME" SHELL="/bin/$TARGET_SHELL" \
       "$command" user --prefix "$PREFIX" "$shell_option" --rc "$rc_file"
     return
@@ -365,7 +394,7 @@ if [ "$skip_user" -eq 0 ]; then
     run_user_phase
     info "default-on shell wrapping installed for $TARGET_USER; it loads in the next shell/Claude session"
   else
-    info "no login user is available; system phase is complete and the next MDM login run must retry the user phase"
+    info "no login user is available; system phase is complete and the next MDM login run must retry the user phase (pass --target-user if automatic detection is unavailable)"
   fi
 fi
 

--- a/managed-bootstrap.sh
+++ b/managed-bootstrap.sh
@@ -1,0 +1,372 @@
+#!/usr/bin/env sh
+# Download and install a pinned Agent Guard release for managed endpoints.
+#
+# The bootstrap owns the generic runtime, dependencies, verification, and
+# login-user shell phase. Product policy remains owned by the organization:
+# this script does not edit Claude managed-settings.json or Codex TOML.
+
+set -eu
+
+PROGRAM=agent-guard-managed-bootstrap
+REPO=${AGENT_GUARD_REPO:-JeongJaeSoon/agent-guard}
+VERSION=${AGENT_GUARD_VERSION:-}
+EXPECTED_ARCHIVE_SHA256=${AGENT_GUARD_ARCHIVE_SHA256:-}
+PREFIX=${AGENT_GUARD_PREFIX:-/opt/agent-guard}
+TARGET_USER=${AGENT_GUARD_TARGET_USER:-}
+TARGET_HOME=${AGENT_GUARD_TARGET_HOME:-}
+TARGET_SHELL=${AGENT_GUARD_TARGET_SHELL:-}
+JQ_VERSION=1.8.1
+GITLEAKS_VERSION=8.30.1
+
+jq_bin=
+gitleaks_bin=
+skip_user=0
+force=0
+
+info() { printf '%s: %s\n' "$PROGRAM" "$*" >&2; }
+die() { info "$*"; exit 2; }
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: managed-bootstrap.sh --version X.Y.Z [options]
+
+Options:
+  --version X.Y.Z          Reviewed Agent Guard release to install (required)
+  --archive-sha256 SHA     Independently recorded release archive SHA-256
+  --prefix DIR             Managed runtime prefix (default: /opt/agent-guard)
+  --jq-bin FILE            Use an organization-provided jq binary
+  --gitleaks-bin FILE      Use an organization-provided gitleaks binary
+  --target-user USER       Login user that receives default-on shell wrapping
+  --target-home DIR        Home directory for --target-user
+  --target-shell bash|zsh  Shell rc to manage for --target-user
+  --skip-user              Install the system phase only
+  --force                  Re-download and reinstall the pinned runtime
+  -h, --help               Show this help
+
+The version must be explicit so privileged MDM jobs never follow "latest".
+The release archive is verified against its published .sha256 file. Supplying
+--archive-sha256 additionally requires that published value to match an
+independently recorded digest.
+
+This entrypoint installs runtime files and shell wrapping only. Distribute the
+organization's Claude managed settings and composed Codex requirements through
+the MDM/configuration system; they are not overwritten here.
+EOF
+}
+
+# Jamf calls scripts as: script / computer-name username [parameter4...].
+if [ "${1:-}" = / ]; then
+  shift
+  [ "$#" -eq 0 ] || shift
+  [ "$#" -eq 0 ] || shift
+fi
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --version)
+      shift; VERSION=${1:-}; [ -n "$VERSION" ] || die "--version requires X.Y.Z"
+      ;;
+    --archive-sha256)
+      shift; EXPECTED_ARCHIVE_SHA256=${1:-}; [ -n "$EXPECTED_ARCHIVE_SHA256" ] || die "--archive-sha256 requires SHA"
+      ;;
+    --prefix)
+      shift; PREFIX=${1:-}; [ -n "$PREFIX" ] || die "--prefix requires a directory"
+      ;;
+    --jq-bin)
+      shift; jq_bin=${1:-}; [ -n "$jq_bin" ] || die "--jq-bin requires a file"
+      ;;
+    --gitleaks-bin)
+      shift; gitleaks_bin=${1:-}; [ -n "$gitleaks_bin" ] || die "--gitleaks-bin requires a file"
+      ;;
+    --target-user)
+      shift; TARGET_USER=${1:-}; [ -n "$TARGET_USER" ] || die "--target-user requires a user"
+      ;;
+    --target-home)
+      shift; TARGET_HOME=${1:-}; [ -n "$TARGET_HOME" ] || die "--target-home requires a directory"
+      ;;
+    --target-shell)
+      shift; TARGET_SHELL=${1:-}; [ -n "$TARGET_SHELL" ] || die "--target-shell requires bash or zsh"
+      ;;
+    --skip-user) skip_user=1 ;;
+    --force) force=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *) die "unknown option: $1" ;;
+  esac
+  shift
+done
+
+[ -n "$VERSION" ] || die "--version or AGENT_GUARD_VERSION is required for a managed install"
+printf '%s\n' "$VERSION" \
+  | awk -F. 'NF == 3 && $1 ~ /^[0-9]+$/ && $2 ~ /^[0-9]+$/ && $3 ~ /^[0-9]+$/ { found = 1 } END { exit found ? 0 : 1 }' \
+  || die "invalid version (expected X.Y.Z): $VERSION"
+case "$PREFIX" in
+  /|''|*[!A-Za-z0-9_./-]*) die "unsafe managed prefix: $PREFIX" ;;
+  /*) ;;
+  *) die "managed prefix must be absolute: $PREFIX" ;;
+esac
+if [ -n "$EXPECTED_ARCHIVE_SHA256" ]; then
+  case "$EXPECTED_ARCHIVE_SHA256" in
+    *[!0-9a-f]*|'') die "archive checksum must be lowercase hexadecimal" ;;
+  esac
+  [ "${#EXPECTED_ARCHIVE_SHA256}" -eq 64 ] || die "archive checksum must be a full SHA-256"
+fi
+
+require() {
+  command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+require curl
+require tar
+require awk
+require mktemp
+require uname
+
+os=$(uname -s)
+machine=$(uname -m)
+case "$os/$machine" in
+  Darwin/arm64)
+    jq_asset=jq-macos-arm64
+    jq_sha256=a9fe3ea2f86dfc72f6728417521ec9067b343277152b114f4e98d8cb0e263603
+    gitleaks_asset=gitleaks_${GITLEAKS_VERSION}_darwin_arm64.tar.gz
+    gitleaks_sha256=b40ab0ae55c505963e365f271a8d3846efbc170aa17f2607f13df610a9aeb6a5
+    ;;
+  Darwin/x86_64)
+    jq_asset=jq-macos-amd64
+    jq_sha256=e80dbe0d2a2597e3c11c404f03337b981d74b4a8504b70586c354b7697a7c27f
+    gitleaks_asset=gitleaks_${GITLEAKS_VERSION}_darwin_x64.tar.gz
+    gitleaks_sha256=dfe101a4db2255fc85120ac7f3d25e4342c3c20cf749f2c20a18081af1952709
+    ;;
+  Linux/aarch64|Linux/arm64)
+    jq_asset=jq-linux-arm64
+    jq_sha256=6bc62f25981328edd3cfcfe6fe51b073f2d7e7710d7ef7fcdac28d4e384fc3d4
+    gitleaks_asset=gitleaks_${GITLEAKS_VERSION}_linux_arm64.tar.gz
+    gitleaks_sha256=e4a487ee7ccd7d3a7f7ec08657610aa3606637dab924210b3aee62570fb4b080
+    ;;
+  Linux/x86_64|Linux/amd64)
+    jq_asset=jq-linux-amd64
+    jq_sha256=020468de7539ce70ef1bceaf7cde2e8c4f2ca6c3afb84642aabc5c97d9fc2a0d
+    gitleaks_asset=gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz
+    gitleaks_sha256=551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
+    ;;
+  *) die "unsupported platform: $os/$machine" ;;
+esac
+
+sha256_file() {
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  elif command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    die "shasum or sha256sum is required"
+  fi
+}
+
+verify_sha256() {
+  file=$1
+  expected=$2
+  actual=$(sha256_file "$file")
+  [ "$actual" = "$expected" ] \
+    || die "checksum mismatch for $(basename "$file"): expected $expected, got $actual"
+}
+
+download() {
+  url=$1
+  output=$2
+  info "downloading $url"
+  curl --fail --location --silent --show-error \
+    --connect-timeout 10 --max-time 120 \
+    --retry 3 --retry-delay 2 --retry-max-time 300 --retry-connrefused \
+    "$url" --output "$output" \
+    || die "download failed: $url"
+}
+
+dependency_ready() {
+  [ -x "$PREFIX/bin/jq" ] \
+    && "$PREFIX/bin/jq" -n '.' >/dev/null 2>&1 \
+    && [ -x "$PREFIX/bin/gitleaks" ] \
+    && "$PREFIX/bin/gitleaks" version >/dev/null 2>&1
+}
+
+managed_system_ready() {
+  [ -x "$PREFIX/bin/agent-guard" ] \
+    && [ -x "$PREFIX/managed-install.sh" ] \
+    && [ -x "$PREFIX/deployment/codex-hook" ] \
+    && [ "$("$PREFIX/bin/agent-guard" version 2>/dev/null || true)" = "agent-guard $VERSION" ] \
+    && [ -f "$PREFIX/.managed-release" ] \
+    && [ "$(awk -F= '$1 == "version" {print $2; exit}' "$PREFIX/.managed-release")" = "$VERSION" ] \
+    && dependency_ready \
+    || return 1
+  [ -z "$EXPECTED_ARCHIVE_SHA256" ] \
+    || [ "$(awk -F= '$1 == "archive_sha256" {print $2; exit}' "$PREFIX/.managed-release")" = "$EXPECTED_ARCHIVE_SHA256" ]
+}
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/agent-guard-managed-bootstrap.XXXXXX") \
+  || die "failed to create temporary directory"
+cleanup() { rm -rf "$tmp"; }
+trap cleanup EXIT INT TERM
+
+archive=agent-guard-${VERSION}.tar.gz
+release_base=${AGENT_GUARD_RELEASE_BASE_URL:-https://github.com/${REPO}/releases/download/v${VERSION}}
+jq_base=${AGENT_GUARD_JQ_BASE_URL:-https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}}
+gitleaks_base=${AGENT_GUARD_GITLEAKS_BASE_URL:-https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}}
+metadata_archive_sha256=
+
+if [ "$force" -eq 0 ] && managed_system_ready; then
+  info "pinned managed runtime already matches; skipping downloads"
+else
+  download "$release_base/$archive" "$tmp/$archive"
+  download "$release_base/$archive.sha256" "$tmp/$archive.sha256"
+
+  published_sha256=$(awk -v archive="$archive" '$2 == archive || $2 == "*" archive {print $1; exit}' "$tmp/$archive.sha256")
+  case "$published_sha256" in
+    *[!0-9a-f]*|'') die "published checksum does not contain a valid digest for $archive" ;;
+  esac
+  [ "${#published_sha256}" -eq 64 ] || die "published checksum is not a full SHA-256"
+  if [ -n "$EXPECTED_ARCHIVE_SHA256" ] && [ "$published_sha256" != "$EXPECTED_ARCHIVE_SHA256" ]; then
+    die "published checksum for $archive does not match the independently recorded digest"
+  fi
+  verify_sha256 "$tmp/$archive" "$published_sha256"
+
+  if [ -z "$jq_bin" ]; then
+    download "$jq_base/$jq_asset" "$tmp/jq"
+    verify_sha256 "$tmp/jq" "$jq_sha256"
+    chmod 0755 "$tmp/jq"
+    jq_bin=$tmp/jq
+  fi
+  if [ -z "$gitleaks_bin" ]; then
+    download "$gitleaks_base/$gitleaks_asset" "$tmp/$gitleaks_asset"
+    verify_sha256 "$tmp/$gitleaks_asset" "$gitleaks_sha256"
+    mkdir -p "$tmp/gitleaks"
+    tar -xzf "$tmp/$gitleaks_asset" -C "$tmp/gitleaks"
+    gitleaks_bin=$tmp/gitleaks/gitleaks
+  fi
+
+  [ -x "$jq_bin" ] && "$jq_bin" -n '.' >/dev/null 2>&1 \
+    || die "jq binary is missing or cannot run: $jq_bin"
+  [ -x "$gitleaks_bin" ] && "$gitleaks_bin" version >/dev/null 2>&1 \
+    || die "gitleaks binary is missing or cannot run: $gitleaks_bin"
+
+  mkdir -p "$tmp/release"
+  tar -xzf "$tmp/$archive" -C "$tmp/release"
+  [ -x "$tmp/release/managed-install.sh" ] \
+    || die "managed-install.sh is missing from Agent Guard v$VERSION"
+  "$tmp/release/managed-install.sh" system \
+    --prefix "$PREFIX" \
+    --jq-bin "$jq_bin" \
+    --gitleaks-bin "$gitleaks_bin"
+  metadata_archive_sha256=$published_sha256
+fi
+
+"$PREFIX/managed-install.sh" verify --prefix "$PREFIX"
+
+if [ -n "$metadata_archive_sha256" ]; then
+  metadata_tmp=$PREFIX/.managed-release.tmp.$$
+  umask 022
+  {
+    printf 'version=%s\n' "$VERSION"
+    printf 'archive_sha256=%s\n' "$metadata_archive_sha256"
+    printf 'jq_version=%s\n' "$JQ_VERSION"
+    printf 'gitleaks_version=%s\n' "$GITLEAKS_VERSION"
+  } >"$metadata_tmp"
+  chmod 0644 "$metadata_tmp"
+  mv "$metadata_tmp" "$PREFIX/.managed-release"
+fi
+
+detect_target_user() {
+  [ -n "$TARGET_USER" ] && return 0
+  if [ "$(id -u)" -ne 0 ]; then
+    TARGET_USER=$(id -un)
+    return 0
+  fi
+  case "$os" in
+    Darwin)
+      TARGET_USER=$(stat -f %Su /dev/console 2>/dev/null || true)
+      case "$TARGET_USER" in
+        ''|root|loginwindow|_mbsetupuser) TARGET_USER= ;;
+      esac
+      ;;
+    Linux)
+      TARGET_USER=${SUDO_USER:-}
+      [ "$TARGET_USER" = root ] && TARGET_USER=
+      ;;
+  esac
+}
+
+resolve_target_identity() {
+  [ -n "$TARGET_USER" ] || return 1
+  id "$TARGET_USER" >/dev/null 2>&1 || die "target user does not exist: $TARGET_USER"
+  [ "$TARGET_USER" != root ] || die "refusing to install user integration for root"
+
+  if [ -z "$TARGET_HOME" ]; then
+    case "$os" in
+      Darwin)
+        require dscl
+        TARGET_HOME=$(dscl . -read "/Users/$TARGET_USER" NFSHomeDirectory 2>/dev/null | awk '{print $2}')
+        ;;
+      Linux)
+        require getent
+        TARGET_HOME=$(getent passwd "$TARGET_USER" | awk -F: '{print $6}')
+        ;;
+    esac
+  fi
+  case "$TARGET_HOME" in
+    /*) ;;
+    *) die "could not resolve an absolute home for $TARGET_USER" ;;
+  esac
+
+  if [ -z "$TARGET_SHELL" ]; then
+    case "$os" in
+      Darwin)
+        TARGET_SHELL=$(dscl . -read "/Users/$TARGET_USER" UserShell 2>/dev/null | awk '{print $2}')
+        ;;
+      Linux)
+        TARGET_SHELL=$(getent passwd "$TARGET_USER" | awk -F: '{print $7}')
+        ;;
+    esac
+  fi
+  TARGET_SHELL=$(basename "${TARGET_SHELL:-bash}")
+  case "$TARGET_SHELL" in
+    bash) shell_option=--bash; rc_file=$TARGET_HOME/.bashrc ;;
+    zsh) shell_option=--zsh; rc_file=$TARGET_HOME/.zshrc ;;
+    *) die "unsupported target shell for Agent Guard wrapping: $TARGET_SHELL" ;;
+  esac
+}
+
+run_user_phase() {
+  command=$PREFIX/managed-install.sh
+  if [ "$(id -u)" -ne 0 ]; then
+    HOME="$TARGET_HOME" SHELL="/bin/$TARGET_SHELL" \
+      "$command" user --prefix "$PREFIX" "$shell_option" --rc "$rc_file"
+    return
+  fi
+
+  case "$os" in
+    Darwin)
+      require launchctl
+      require sudo
+      target_uid=$(id -u "$TARGET_USER")
+      launchctl asuser "$target_uid" \
+        sudo -H -u "$TARGET_USER" env \
+          HOME="$TARGET_HOME" SHELL="/bin/$TARGET_SHELL" \
+          "$command" user --prefix "$PREFIX" "$shell_option" --rc "$rc_file"
+      ;;
+    Linux)
+      require runuser
+      runuser -u "$TARGET_USER" -- env \
+        HOME="$TARGET_HOME" SHELL="/bin/$TARGET_SHELL" \
+        "$command" user --prefix "$PREFIX" "$shell_option" --rc "$rc_file"
+      ;;
+  esac
+}
+
+if [ "$skip_user" -eq 0 ]; then
+  detect_target_user
+  if resolve_target_identity; then
+    run_user_phase
+    info "default-on shell wrapping installed for $TARGET_USER; it loads in the next shell/Claude session"
+  else
+    info "no login user is available; system phase is complete and the next MDM login run must retry the user phase"
+  fi
+fi
+
+info "Agent Guard v$VERSION managed bootstrap completed"

--- a/scripts/build-release-tarball.sh
+++ b/scripts/build-release-tarball.sh
@@ -11,6 +11,7 @@ trap 'rm -rf "$stage"' EXIT INT TERM
 cp -R "$ROOT/plugins/agent-guard/." "$stage/"
 cp "$ROOT/install.sh" "$stage/install.sh"
 cp "$ROOT/managed-install.sh" "$stage/managed-install.sh"
+cp "$ROOT/managed-bootstrap.sh" "$stage/managed-bootstrap.sh"
 cp -R "$ROOT/deployment" "$stage/deployment"
 mkdir -p "$stage/docs"
 cp "$ROOT/docs/managed-deployment.md" "$stage/docs/managed-deployment.md"

--- a/scripts/validate-plugin-layout.sh
+++ b/scripts/validate-plugin-layout.sh
@@ -231,6 +231,7 @@ validate_archive() {
   validate_archive_contains "$archive" "skills/setup-agent-guard/SKILL.md"
   validate_archive_contains "$archive" "skills/setup-agent-guard/agents/openai.yaml"
   validate_archive_contains "$archive" "managed-install.sh"
+  validate_archive_contains "$archive" "managed-bootstrap.sh"
   validate_archive_contains "$archive" "deployment/codex-hook"
   validate_archive_contains "$archive" "deployment/codex-requirements.toml.template"
   validate_archive_contains "$archive" "deployment/claude-managed-settings.example.json"

--- a/tests/fixtures/mock-gitleaks
+++ b/tests/fixtures/mock-gitleaks
@@ -15,7 +15,7 @@ case "$mode" in
     done
     input=$(cat)
     case "$input" in
-      *AGENT_GUARD_TEST_SECRET*)
+      *AGENT_GUARD_TEST_SECRET*|*"PRIVATE KEY"*)
         [ -n "$report_path" ] && printf '%s\n' '[{"Secret":"AGENT_GUARD_TEST_SECRET"}]' >"$report_path"
         printf '%s\n' "Finding: REDACTED"
         exit 1
@@ -32,11 +32,11 @@ case "$mode" in
       case "$arg" in
         -*|--*) continue ;;
         *)
-          if [ -f "$arg" ] && grep -q 'AGENT_GUARD_TEST_SECRET' "$arg"; then
+          if [ -f "$arg" ] && grep -Eq 'AGENT_GUARD_TEST_SECRET|PRIVATE KEY' "$arg"; then
             printf '%s\n' "Finding: REDACTED"
             exit 1
           fi
-          if [ -d "$arg" ] && grep -R -q 'AGENT_GUARD_TEST_SECRET' "$arg" 2>/dev/null; then
+          if [ -d "$arg" ] && grep -R -E -q 'AGENT_GUARD_TEST_SECRET|PRIVATE KEY' "$arg" 2>/dev/null; then
             printf '%s\n' "Finding: REDACTED"
             exit 1
           fi

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -231,9 +231,29 @@ AGENT_GUARD_RELEASE_BASE_URL="file://$managed_bootstrap_root/does-not-exist" \
     --skip-user >"$OUT" 2>"$ERR"
 status=$?
 if [ "$status" -eq 0 ] && grep -Fq 'skipping downloads' "$ERR"; then
-  ok "managed bootstrap check-in skips matching downloads and repairs in place"
+  ok "managed bootstrap check-in skips downloads for a matching verified runtime"
 else
-  not_ok "managed bootstrap check-in skips matching downloads and repairs in place (status $status)"
+  not_ok "managed bootstrap check-in skips downloads for a matching verified runtime (status $status)"
+  sed 's/^/  stderr: /' "$ERR"
+fi
+
+mv "$managed_bootstrap_prefix/config/gitleaks.toml" \
+  "$managed_bootstrap_root/gitleaks.toml.missing"
+AGENT_GUARD_RELEASE_BASE_URL="file://$managed_bootstrap_release" \
+  sh "$ROOT/managed-bootstrap.sh" \
+    --version "$managed_bootstrap_version" \
+    --archive-sha256 "$managed_bootstrap_sha" \
+    --prefix "$managed_bootstrap_prefix" \
+    --jq-bin "$managed_bootstrap_jq" \
+    --gitleaks-bin "$MOCK_BIN/gitleaks" \
+    --skip-user >"$OUT" 2>"$ERR"
+status=$?
+if [ "$status" -eq 0 ] \
+   && [ -f "$managed_bootstrap_prefix/config/gitleaks.toml" ] \
+   && ! grep -Fq 'skipping downloads' "$ERR"; then
+  ok "managed bootstrap check-in reinstalls a cached runtime that fails verification"
+else
+  not_ok "managed bootstrap check-in reinstalls a cached runtime that fails verification (status $status)"
   sed 's/^/  stderr: /' "$ERR"
 fi
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -214,7 +214,9 @@ if [ "$status" -eq 0 ] \
    && [ -x "$managed_bootstrap_prefix/bin/jq" ] \
    && [ -x "$managed_bootstrap_prefix/bin/gitleaks" ] \
    && grep -Fq "version=$managed_bootstrap_version" "$managed_bootstrap_prefix/.managed-release" \
-   && grep -Fq "archive_sha256=$managed_bootstrap_sha" "$managed_bootstrap_prefix/.managed-release"; then
+   && grep -Fq "archive_sha256=$managed_bootstrap_sha" "$managed_bootstrap_prefix/.managed-release" \
+   && grep -Eq '^jq_sha256=[0-9a-f]{64}$' "$managed_bootstrap_prefix/.managed-release" \
+   && grep -Eq '^gitleaks_sha256=[0-9a-f]{64}$' "$managed_bootstrap_prefix/.managed-release"; then
   ok "managed bootstrap installs and records a checksum-verified release"
 else
   not_ok "managed bootstrap installs and records a checksum-verified release (status $status)"
@@ -236,7 +238,7 @@ else
 fi
 
 run_expect 2 "managed bootstrap requires an explicit release version" \
-  env AGENT_GUARD_VERSION= sh "$ROOT/managed-bootstrap.sh" \
+  env AGENT_GUARD_VERSION=9.9.9 sh "$ROOT/managed-bootstrap.sh" \
     --prefix "$managed_bootstrap_root/no-version" --skip-user
 
 wrong_managed_sha=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -248,6 +250,22 @@ run_expect 2 "managed bootstrap rejects a published checksum that differs from t
       --prefix "$managed_bootstrap_root/wrong-digest" \
       --jq-bin "$managed_bootstrap_jq" \
       --gitleaks-bin "$MOCK_BIN/gitleaks" \
+      --skip-user
+
+managed_bootstrap_tampered_jq="$managed_bootstrap_root/tampered-jq"
+cat >"$managed_bootstrap_tampered_jq" <<EOF
+#!/usr/bin/env sh
+# Deliberately differs from the recorded installed binary while remaining valid.
+exec "$REAL_JQ" "\$@"
+EOF
+chmod +x "$managed_bootstrap_tampered_jq"
+cp "$managed_bootstrap_tampered_jq" "$managed_bootstrap_prefix/bin/jq"
+run_expect 2 "managed bootstrap does not skip a runnable dependency whose identity changed" \
+  env AGENT_GUARD_RELEASE_BASE_URL="file://$managed_bootstrap_root/does-not-exist" \
+    sh "$ROOT/managed-bootstrap.sh" \
+      --version "$managed_bootstrap_version" \
+      --archive-sha256 "$managed_bootstrap_sha" \
+      --prefix "$managed_bootstrap_prefix" \
       --skip-user
 
 if grep -Fq 'AGENT_GUARD_PII_HOOK_MODE' "$ROOT/deployment/claude-managed-settings.example.json"; then

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -96,6 +96,7 @@ for file in \
   "$ROOT/install.sh" \
   "$ROOT/bootstrap.sh" \
   "$ROOT/managed-install.sh" \
+  "$ROOT/managed-bootstrap.sh" \
   "$ROOT/deployment/codex-hook" \
   "$ROOT/scripts/build-release-tarball.sh" \
   "$ROOT/githooks/pre-commit" \
@@ -174,6 +175,80 @@ else
   not_ok "managed user install enables Claude wrapping with the managed bin directory (status $status)"
   sed 's/^/  stderr: /' "$ERR"
 fi
+
+# The standalone managed bootstrap is the organization-light MDM entrypoint.
+# It downloads a pinned Agent Guard release, verifies the published archive
+# checksum, delegates to managed-install.sh, and can use pre-approved dependency
+# binaries without copying deployment logic into an organization repository.
+managed_bootstrap_root="$TESTTMP/managed-bootstrap"
+managed_bootstrap_release="$managed_bootstrap_root/release"
+managed_bootstrap_prefix="$managed_bootstrap_root/prefix"
+managed_bootstrap_version=$(sed -n 's/^VERSION=//p' "$PLUGIN_ROOT/bin/agent-guard" | head -1)
+managed_bootstrap_archive="agent-guard-${managed_bootstrap_version}.tar.gz"
+managed_bootstrap_jq="$managed_bootstrap_root/mock-jq"
+mkdir -p "$managed_bootstrap_release"
+cat >"$managed_bootstrap_jq" <<EOF
+#!/usr/bin/env sh
+exec "$REAL_JQ" "\$@"
+EOF
+chmod +x "$managed_bootstrap_jq"
+"$ROOT/scripts/build-release-tarball.sh" "$managed_bootstrap_version" \
+  "$managed_bootstrap_release/$managed_bootstrap_archive"
+(
+  cd "$managed_bootstrap_release" || exit 1
+  shasum -a 256 "$managed_bootstrap_archive" >"$managed_bootstrap_archive.sha256"
+)
+managed_bootstrap_sha=$(awk '{print $1; exit}' "$managed_bootstrap_release/$managed_bootstrap_archive.sha256")
+
+AGENT_GUARD_RELEASE_BASE_URL="file://$managed_bootstrap_release" \
+  sh "$ROOT/managed-bootstrap.sh" \
+    --version "$managed_bootstrap_version" \
+    --archive-sha256 "$managed_bootstrap_sha" \
+    --prefix "$managed_bootstrap_prefix" \
+    --jq-bin "$managed_bootstrap_jq" \
+    --gitleaks-bin "$MOCK_BIN/gitleaks" \
+    --skip-user >"$OUT" 2>"$ERR"
+status=$?
+if [ "$status" -eq 0 ] \
+   && [ -x "$managed_bootstrap_prefix/bin/agent-guard" ] \
+   && [ -x "$managed_bootstrap_prefix/bin/jq" ] \
+   && [ -x "$managed_bootstrap_prefix/bin/gitleaks" ] \
+   && grep -Fq "version=$managed_bootstrap_version" "$managed_bootstrap_prefix/.managed-release" \
+   && grep -Fq "archive_sha256=$managed_bootstrap_sha" "$managed_bootstrap_prefix/.managed-release"; then
+  ok "managed bootstrap installs and records a checksum-verified release"
+else
+  not_ok "managed bootstrap installs and records a checksum-verified release (status $status)"
+  sed 's/^/  stderr: /' "$ERR"
+fi
+
+AGENT_GUARD_RELEASE_BASE_URL="file://$managed_bootstrap_root/does-not-exist" \
+  sh "$ROOT/managed-bootstrap.sh" \
+    --version "$managed_bootstrap_version" \
+    --archive-sha256 "$managed_bootstrap_sha" \
+    --prefix "$managed_bootstrap_prefix" \
+    --skip-user >"$OUT" 2>"$ERR"
+status=$?
+if [ "$status" -eq 0 ] && grep -Fq 'skipping downloads' "$ERR"; then
+  ok "managed bootstrap check-in skips matching downloads and repairs in place"
+else
+  not_ok "managed bootstrap check-in skips matching downloads and repairs in place (status $status)"
+  sed 's/^/  stderr: /' "$ERR"
+fi
+
+run_expect 2 "managed bootstrap requires an explicit release version" \
+  env AGENT_GUARD_VERSION= sh "$ROOT/managed-bootstrap.sh" \
+    --prefix "$managed_bootstrap_root/no-version" --skip-user
+
+wrong_managed_sha=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+run_expect 2 "managed bootstrap rejects a published checksum that differs from the organization pin" \
+  env AGENT_GUARD_RELEASE_BASE_URL="file://$managed_bootstrap_release" \
+    sh "$ROOT/managed-bootstrap.sh" \
+      --version "$managed_bootstrap_version" \
+      --archive-sha256 "$wrong_managed_sha" \
+      --prefix "$managed_bootstrap_root/wrong-digest" \
+      --jq-bin "$managed_bootstrap_jq" \
+      --gitleaks-bin "$MOCK_BIN/gitleaks" \
+      --skip-user
 
 if grep -Fq 'AGENT_GUARD_PII_HOOK_MODE' "$ROOT/deployment/claude-managed-settings.example.json"; then
   not_ok "managed Claude settings do not force the opt-in PII hook mode"


### PR DESCRIPTION
## Summary

- add a release-provided managed bootstrap for MDM and fleet check-ins
- keep organization repositories limited to reviewed version/digest pins and product policy
- install and verify pinned Agent Guard, jq, and gitleaks assets across macOS and Linux
- run default-on shell wrapping for the actual login user without writing Claude managed settings or Codex TOML
- publish the bootstrap and its SHA-256 as versioned release assets

## Security boundaries

- requires an explicit `--version X.Y.Z` and never follows `latest` or an environment fallback
- verifies the release archive against the published checksum and an optional independently recorded digest
- verifies pinned dependency and installed-binary identities on every check-in
- records and checks a file-level managed payload manifest, reinstalling the approved release on drift
- writes managed release metadata only after runtime verification succeeds
- leaves organization policy, rollout controls, and secrets outside this repository

## Validation

- `make test` — 452 passed, 0 failed
- `scripts/validate-plugin-layout.sh --all` — passed
- `git diff --check` — passed
- official jq 1.8.1 and gitleaks 8.30.1 release asset digests — matched
- organization-specific context scan — no matches