### PR TITLE
fix(security): close verified scan bypasses + finish v3.0.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,9 +41,14 @@ jobs:
 
       - name: Compute next version
         id: ver
+        env:
+          # Pass the free-form input through the environment, never interpolated
+          # into the script body — `${{ inputs.version }}` inlined into `run:`
+          # executes as shell before the X.Y.Z check below can reject it.
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          explicit="${{ inputs.version }}"
+          explicit="$INPUT_VERSION"
           if [ -n "$explicit" ]; then
             if ! printf '%s' "$explicit" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
               echo "version input must match X.Y.Z (got: $explicit)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 - feat!: simplify managed deployment to settings merge plus developer setup (#122)
 
+Breaking changes (see the [2.x to 3.x migration guide](docs/migration-v3.md)):
+
+- Removed the `managed-install.sh` entrypoint and the self-contained
+  `managed-bootstrap.sh`, including the `managed-bootstrap.sh` /
+  `managed-bootstrap.sh.sha256` release assets.
+- Removed the Codex managed hook path (`deployment/codex-hook`,
+  `deployment/codex-requirements.toml.template`); Codex users install the
+  plugin through the standard install.
+- Removed `setup-shell --prepend-path`.
+
 ## v2.2.0 - 2026-07-18
 
 - feat: add self-contained managed bootstrap (#119)

--- a/README.md
+++ b/README.md
@@ -199,10 +199,11 @@ Rolling Agent Guard out to an organization takes two steps:
    into the organization's Claude Code managed settings. It registers the
    Agent Guard marketplace pinned to a release tag and force-enables the
    plugin for every developer.
-2. **Each developer, once per machine**: run the setup commands — the
-   `setup-agent-guard` skill (or `agent-guard setup --install ...`) for the
-   `jq`/`gitleaks` dependencies, `/agent-guard:setup-shell` for the shell
-   integration, then `agent-guard smoke-test` to verify.
+2. **Each developer, once per machine**: run the setup commands —
+   `agent-guard setup --install ...` for the `jq`/`gitleaks` dependencies
+   (`/agent-guard:checksum` prints the paste-ready command),
+   `/agent-guard:setup-shell` for the shell integration, then
+   `agent-guard smoke-test` to verify.
 
 Developers who have not finished setup are reminded automatically: the
 plugin's `SessionStart` hook detects missing dependencies or a missing shell
@@ -282,13 +283,13 @@ This sets `core.hooksPath=githooks` only when it will not overwrite an existing 
 Add a workflow step:
 
 ```yaml
-- uses: JeongJaeSoon/agent-guard@v2
+- uses: JeongJaeSoon/agent-guard@v3
   with:
     paths: "."
     gitleaks-checksum: "<sha256 of the gitleaks release archive>"
 ```
 
-Use `@v2` for compatible 2.x updates. The existing `@v1` moving tag remains on the 1.x line; pin `@v1`, a full tag, or a commit SHA when you intentionally stay on 1.x.
+Use `@v3` for compatible 3.x updates. The `@v2` and `@v1` moving tags remain on the 2.x and 1.x lines; pin one of them, a full tag, or a commit SHA when you intentionally stay on an older line.
 
 Get the checksum with:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,13 +3,13 @@
 ## Supported versions
 
 Agent Guard ships fixes on the latest release line. Use the most recent tag:
-`@v2` for the GitHub Action, and the latest release for CLI and plugin installs.
+`@v3` for the GitHub Action, and the latest release for CLI and plugin installs.
 
 | Version | Supported |
 |---|---|
-| Latest release (2.x) | ✅ |
-| 1.x / `@v1` | Security fixes only |
-| Older 1.x tags | Best effort |
+| Latest release (3.x) | ✅ |
+| 2.x / `@v2` | Security fixes only |
+| 1.x / `@v1` | Best effort |
 
 ## Reporting a vulnerability
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -20,6 +20,6 @@ Agent Guard supports macOS and Linux on x64 and arm64. Runtime hooks require
 `sh`, `awk`, `git`, `jq`, and gitleaks. Windows is not currently supported.
 Host support and known coverage boundaries are documented in the main README.
 
-The latest 2.x release is the actively supported line. The 1.x moving tag
+The latest 3.x release is the actively supported line. The 2.x moving tag
 receives security fixes only. General support is best effort; security reports
 are acknowledged on the timeline stated in `SECURITY.md`.

--- a/docs/managed-deployment.md
+++ b/docs/managed-deployment.md
@@ -29,10 +29,11 @@ do not add `sha` beside `ref` and describe the result as commit-pinned.
 Once the managed settings land, Claude Code loads the plugin automatically.
 Each developer then completes setup in a Claude Code session:
 
-1. **Dependencies** (`jq`, `gitleaks`): run the `setup-agent-guard` skill —
-   it diagnoses first and asks approval before installing. Equivalent CLI:
-   `agent-guard setup` to diagnose, then
-   `agent-guard setup --install --gitleaks-checksum <published-sha256>`.
+1. **Dependencies** (`jq`, `gitleaks`): run `agent-guard setup` to diagnose,
+   then `agent-guard setup --install --gitleaks-version <version>
+   --gitleaks-checksum <published-sha256>` — `/agent-guard:checksum` prints
+   the paste-ready version/checksum pair. The plugin does not put
+   `agent-guard` on `PATH`; ask Claude to run the plugin-local binary.
 2. **Shell integration** (covers the unhooked `!cat`/`!head`/`!printenv`
    path): run `/agent-guard:setup-shell`, then restart the shell and Claude
    Code.

--- a/docs/migration-v3.md
+++ b/docs/migration-v3.md
@@ -1,0 +1,50 @@
+# Migrating from Agent Guard 2.x to 3.x
+
+Agent Guard 3.0 replaces the managed install scripts with a simpler model:
+the administrator merges the managed settings example into Claude Code's
+managed settings, and each developer runs the one-time setup commands. The
+plugin hooks, CLI commands, policy environment variables, Git hook layout,
+and release archive layout are unchanged from 2.2.
+
+## Breaking changes
+
+- `managed-install.sh` and the self-contained `managed-bootstrap.sh` are
+  removed, along with the `managed-bootstrap.sh` and
+  `managed-bootstrap.sh.sha256` release assets. Fleet tooling that downloads
+  or verifies either asset must stop doing so.
+- The Codex managed hook path is removed (`deployment/codex-hook` and
+  `deployment/codex-requirements.toml.template`). Codex users install the
+  plugin through the standard install described in the README.
+- `setup-shell --prepend-path` is removed. The gitleaks resolution order
+  (`AGENT_GUARD_GITLEAKS_BIN`, then `PATH`, then
+  `AGENT_GUARD_GITLEAKS_BIN_DIR/gitleaks`) already makes the private
+  `setup --install` destination usable without a `PATH` prepend.
+
+## Managed fleets: what to do instead
+
+1. **Administrator, once**: merge
+   [`deployment/claude-managed-settings.example.json`](../deployment/claude-managed-settings.example.json)
+   from the v3 release or tag into the organization's Claude Code managed
+   settings.
+2. **Each developer, once per machine**: run the setup commands described in
+   [Managed deployment for Claude Code](managed-deployment.md). Developers
+   who skip setup are reminded automatically at session start by the
+   plugin's `SessionStart` hook.
+
+## Direct CLI installs
+
+Nothing changes: `bootstrap.sh`, `install.sh`, and the release archive
+layout are the same as in 2.x.
+
+## GitHub Actions
+
+The Action itself is unchanged between 2.2 and 3.0. Move to the new moving
+tag when convenient:
+
+```diff
+- uses: JeongJaeSoon/agent-guard@v2
++ uses: JeongJaeSoon/agent-guard@v3
+```
+
+`@v2` remains on the 2.x line; pin `@v2`, a full tag, or a commit SHA when
+you intentionally stay on 2.x.

--- a/plugins/agent-guard/SECURITY.md
+++ b/plugins/agent-guard/SECURITY.md
@@ -3,13 +3,13 @@
 ## Supported versions
 
 Agent Guard ships fixes on the latest release line. Use the most recent tag:
-`@v2` for the GitHub Action, and the latest release for CLI and plugin installs.
+`@v3` for the GitHub Action, and the latest release for CLI and plugin installs.
 
 | Version | Supported |
 |---|---|
-| Latest release (2.x) | ✅ |
-| 1.x / `@v1` | Security fixes only |
-| Older 1.x tags | Best effort |
+| Latest release (3.x) | ✅ |
+| 2.x / `@v2` | Security fixes only |
+| 1.x / `@v1` | Best effort |
 
 ## Reporting a vulnerability
 

--- a/plugins/agent-guard/SUPPORT.md
+++ b/plugins/agent-guard/SUPPORT.md
@@ -20,6 +20,6 @@ Agent Guard supports macOS and Linux on x64 and arm64. Runtime hooks require
 `sh`, `awk`, `git`, `jq`, and gitleaks. Windows is not currently supported.
 Host support and known coverage boundaries are documented in the main README.
 
-The latest 2.x release is the actively supported line. The 1.x moving tag
+The latest 3.x release is the actively supported line. The 2.x moving tag
 receives security fixes only. General support is best effort; security reports
 are acknowledged on the timeline stated in `SECURITY.md`.

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -695,9 +695,15 @@ block_on_scan_status() {
 }
 
 extract_added_lines() {
+  # Track hunk state so a file header (`+++ b/path`, before the first `@@`) is
+  # told apart from added CONTENT by position, not by shape. Matching `+++ ` by
+  # shape dropped any added line whose own content began with `++ ` — git
+  # prefixes it with one more `+`, so `++ SECRET` arrived as `+++ SECRET` and
+  # slipped past the scanner. Only `+` lines inside a hunk are additions.
   awk '
-    /^(diff --git|index|---|\+\+\+|@@) / { next }
-    /^\+/ { sub(/^\+/, ""); print }
+    /^diff --git / { in_hunk = 0; next }
+    /^@@/ { in_hunk = 1; next }
+    in_hunk && /^\+/ { sub(/^\+/, ""); print }
   '
 }
 

--- a/plugins/agent-guard/config/gitleaks.toml
+++ b/plugins/agent-guard/config/gitleaks.toml
@@ -31,13 +31,15 @@ keywords = ["ghp_", "gho_", "ghu_", "ghs_", "ghr_", "github_pat_", "a3t", "akia"
 
 [[allowlists]]
 description = "Obvious dummy placeholders"
+# Every entry is anchored to the WHOLE secret. A docs placeholder is exempt
+# only when the entire value is placeholder-shaped, so a real token that merely
+# embeds `example_token` / `dummy_secret` / an x-run keeps its finding (a
+# vendor prefix like `sk-proj-` carries a hyphen the alnum decoration cannot
+# span, so the embedded-substring bypass is closed).
 regexes = [
-  '''(?i)example[_-]?(token|key|secret|password)''',
-  '''(?i)dummy[_-]?(token|key|secret|password)''',
-  '''(?i)not[-_ ]?a[-_ ]?real[-_ ]?(token|key|secret|password)''',
-  # Anchored to the whole secret so a placeholder shaped entirely from
-  # alphanumerics with a long run of x's (or all zeros) is still exempt, but a
-  # real secret that merely embeds such a run is no longer silently suppressed.
+  '''(?i)^[a-z0-9]*example[_-]?(token|key|secret|password)[a-z0-9]*$''',
+  '''(?i)^[a-z0-9]*dummy[_-]?(token|key|secret|password)[a-z0-9]*$''',
+  '''(?i)^not[-_ ]?a[-_ ]?real[-_ ]?(token|key|secret|password)$''',
   '''(?i)^[A-Za-z0-9]*x{12,}[A-Za-z0-9]*$''',
   '''^0{12,}$'''
 ]

--- a/scripts/validate-plugin-layout.sh
+++ b/scripts/validate-plugin-layout.sh
@@ -142,10 +142,10 @@ validate_versions() {
   marketplace_version=$(jq -r '.plugins[] | select(.name == "agent-guard") | .version // ""' "$ROOT/.claude-plugin/marketplace.json")
   managed_claude_ref=$(jq -r '.extraKnownMarketplaces["agent-guard"].source.ref // ""' "$ROOT/deployment/claude-managed-settings.example.json")
 
-  if printf '%s\n' "$cli_version" | grep -Eq '^2\.[0-9]+\.[0-9]+$'; then
-    ok "Agent Guard CLI is on the 2.x release line"
+  if printf '%s\n' "$cli_version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+    ok "Agent Guard CLI version is plain semver"
   else
-    fail "Agent Guard CLI is on the 2.x release line"
+    fail "Agent Guard CLI version is plain semver"
   fi
   if [ -n "$cli_version" ] \
      && [ "$claude_version" = "$cli_version" ] \

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1088,6 +1088,49 @@ else
   not_ok "scan-working-tree detects untracked secret (expected 1, got $status)"
 fi
 
+# A staged line whose own content begins with "++ " reaches git diff as
+# "+++ ..." — the added-line filter must scan it, not mistake it for a
+# "+++ b/path" file header and drop it.
+(
+  cd "$TEST_REPO" || exit 2
+  git reset -q
+  rm -f staged.txt untracked.txt
+  printf '%s\n' "++ AGENT_GUARD_TEST_SECRET" > plusplus.txt
+  git add plusplus.txt
+  "$PLUGIN_ROOT/bin/agent-guard" scan-staged >"$OUT" 2>"$ERR"
+)
+status=$?
+if [ "$status" -eq 1 ]; then
+  ok "scan-staged scans an added line whose content starts with '++ '"
+else
+  not_ok "scan-staged scans an added line whose content starts with '++ ' (expected 1, got $status)"
+  sed 's/^/  stderr: /' "$ERR"
+fi
+
+# Same "++ " line, exercised through the working-tree diff path (a tracked
+# modification, not an untracked file which takes the cat path instead).
+(
+  cd "$TEST_REPO" || exit 2
+  git reset -q
+  printf '%s\n' "benign baseline" > plusplus.txt
+  git add plusplus.txt
+  git commit -q -m plusplus-baseline
+  printf '%s\n' "benign baseline" "++ AGENT_GUARD_TEST_SECRET" > plusplus.txt
+  "$PLUGIN_ROOT/bin/agent-guard" scan-working-tree >"$OUT" 2>"$ERR"
+)
+status=$?
+if [ "$status" -eq 1 ]; then
+  ok "scan-working-tree scans a tracked '++ ' line in a modified file"
+else
+  not_ok "scan-working-tree scans a tracked '++ ' line in a modified file (expected 1, got $status)"
+  sed 's/^/  stderr: /' "$ERR"
+fi
+(
+  cd "$TEST_REPO" || exit 2
+  git rm -q plusplus.txt >/dev/null 2>&1
+  git commit -q -m drop-plusplus >/dev/null 2>&1
+)
+
 (
   cd "$TEST_REPO" || exit 2
   printf '%s' '{"stop_hook_active":true}' | "$PLUGIN_ROOT/bin/agent-guard" hook-stop >"$OUT" 2>"$ERR"
@@ -2313,6 +2356,40 @@ if [ -n "$REAL_GITLEAKS" ]; then
     ok "real gitleaks still flags a PAT containing a 12-x run (anchored allowlist)"
   else
     not_ok "real gitleaks still flags a PAT containing a 12-x run (expected 1, got $status)"
+    sed 's/^/  stderr: /' "$ERR"
+  fi
+
+  # The word-placeholder allowlist is anchored to the whole secret too: a real
+  # vendor token that merely embeds `example_token` / `dummy_secret` keeps its
+  # finding, while a bare placeholder stays exempt. Assembled at runtime so this
+  # file never holds a contiguous vendor-shaped literal.
+  EMBED_HEAD='sk-proj-'
+  EMBED_TOKEN=$(printf '%sAAAAAAA%sBBBBBBBBCCCCCC' "$EMBED_HEAD" 'example_token')
+  EMBED_FIXTURE_DIR="$TMP_ROOT/embed-placeholder-dir"
+  mkdir -p "$EMBED_FIXTURE_DIR"
+  printf 'value = %s\n' "$EMBED_TOKEN" > "$EMBED_FIXTURE_DIR/conf.txt"
+  PATH="$(dirname "$REAL_GITLEAKS"):$ORIGINAL_PATH" "$PLUGIN_ROOT/bin/agent-guard" scan-path "$EMBED_FIXTURE_DIR" >"$OUT" 2>"$ERR"
+  status=$?
+  if [ "$status" -eq 1 ]; then
+    ok "real gitleaks flags a real token that merely embeds an example_token substring"
+  else
+    not_ok "real gitleaks flags a token embedding example_token (expected 1, got $status)"
+    sed 's/^/  stderr: /' "$ERR"
+  fi
+
+  PLACEHOLDER_WORD_DIR="$TMP_ROOT/placeholder-word-dir"
+  mkdir -p "$PLACEHOLDER_WORD_DIR"
+  {
+    printf 'a = %s\n' 'example_token'
+    printf 'b = %s\n' 'dummy_secret'
+    printf 'c = %s\n' 'not-a-real-token'
+  } > "$PLACEHOLDER_WORD_DIR/conf.txt"
+  PATH="$(dirname "$REAL_GITLEAKS"):$ORIGINAL_PATH" "$PLUGIN_ROOT/bin/agent-guard" scan-path "$PLACEHOLDER_WORD_DIR" >"$OUT" 2>"$ERR"
+  status=$?
+  if [ "$status" -eq 0 ]; then
+    ok "bare word placeholders stay exempt (example_token, dummy_secret, not-a-real-token)"
+  else
+    not_ok "bare word placeholders stay exempt (expected 0, got $status)"
     sed 's/^/  stderr: /' "$ERR"
   fi
 


### PR DESCRIPTION
## Summary

A joint review (Claude Explore + a Codex repo audit) of the v3.0.0 tree
after PR #122 ("simplify managed deployment"). The removal work itself was
clean — no stale references to the deleted managed-install / managed-bootstrap
/ Codex-hook entrypoints anywhere. The findings below are the release-finishing
and pre-existing security items the audit surfaced.

Every code change here was **reproduced before fixing** and re-verified after,
using the real `gitleaks` binary and `git diff` directly (the full `tests/run.sh`
harness could not be executed in the review sandbox — it needs `mktemp`/`git init`
writes that were blocked, so the added tests are validated by construction against
adjacent passing tests, not by a local run; **please run `make test` in CI/locally**).

## Fixed here

**Security (verified reproductions):**

1. **Placeholder allowlist substring bypass** (`config/gitleaks.toml`) — the
   `example_token` / `dummy_token` / `not-a-real-token` allowlist regexes were
   unanchored, so a real vendor token that merely *embedded* one of those
   substrings was silently exempted. Reproduced: `sk-proj-…example_token…`
   scanned clean (exit 0) while the control was flagged. Fixed by anchoring all
   three to the whole secret, matching the x-run entry that was already anchored.
   Re-verified: embedded-real-token now flags (exit 1); bare placeholders stay
   exempt (exit 0).
2. **`++ ` content line dropped from diff scan** (`bin/agent-guard`
   `extract_added_lines`) — a staged/working-tree line whose own content began
   with `++ ` reached `git diff` as `+++ …` and was skipped as a `+++ b/path`
   file header, never scanned. Fixed by tracking hunk state (only `+` lines
   inside an `@@` hunk are additions). Reproduced against a real `git diff`.
3. **Release workflow script injection** (`.github/workflows/release.yml`) — the
   free-form `inputs.version` was inlined into the `run:` body via `${{ }}` and
   executed as shell *before* the `X.Y.Z` validation could reject it, in a job
   holding `contents: write` / `pull-requests: write`. Fixed by passing it
   through `env:`.

**CI / release finishing:**

4. **Plugin-layout validator hardcoded the 2.x line** (`scripts/validate-plugin-layout.sh`)
   — with the CLI now at `3.0.0`, `--marketplace` would fail on the next `main`
   push (the release commit's token push didn't trigger Plugin Validation, so it
   was latent). Relaxed to plain-semver; the cross-file version-equality check
   still pins CLI/manifests/marketplace/managed-settings together.
5. **v3 docs**: `docs/migration-v3.md` (new), CHANGELOG breaking-changes list,
   README managed-deployment step now points at the CLI path instead of the
   Codex-framed `setup-agent-guard` skill (and pairs `--gitleaks-version` with
   `--gitleaks-checksum`), Actions examples move to `@v3`, and the
   SECURITY/SUPPORT supported-version tables move 2.x → 3.x (root + plugin copies).

## Reported, NOT changed here (need the test harness runnable and/or are maintainer calls)

The Codex audit flagged more. These touch the core scan flow or are accepted
tradeoffs, so they should be done deliberately with `make test` runnable:

- **[High] fail-open on git plumbing failure** — `scan_staged` / `scan_working_tree`
  pipe `git diff | extract_added_lines`; POSIX `sh` has no `pipefail`, so a failed
  `git diff` returns "clean". Capture to a temp file and check the exit first.
- **[High] scan scoped to caller's subdirectory, not repo root** — `-- .` pathspec
  and cwd `git ls-files`; PostToolUse/Stop also ignore the event `workdir` that
  PreToolUse honors.
- **[High] `--no-verify` guard's command parser** misses `&`, newlines, and
  subshell grouping (`echo ok & git commit --no-verify` is not intercepted).
- **[Med] symlink gate** — template-named symlink to a real secret passes the
  Bash path gate (this one is **already documented as a known limitation** in a
  code comment — listed for completeness, not necessarily a fix).
- **[Med] submission validator** accepts a stale pinned SHA; **[Med] install.sh**
  can print success on a stale matching hook / failed `git config`; **[Med]**
  PRIVACY.md's "temp data deleted on exit" claim vs. no global cleanup trap;
  **[Low]** Action `paths` can't express paths with spaces; **CI** only runs
  `ubuntu-latest` and doesn't require real gitleaks / `smoke-test`.

The same `+++ ` shape check also lives in `extract_patch_added_lines`'s unified-diff
fallback (apply_patch path) — lower-traffic, left for a follow-up.

## Test method

- `sh -n` on `bin/agent-guard` and `tests/run.sh` — clean.
- `gitleaks --config config/gitleaks.toml` parses; end-to-end probes confirm
  finding #1 closed and placeholders preserved.
- `extract_added_lines` awk rewrite validated on hand-built diffs (header skip,
  `++ ` content extraction, multi-file reset, deletion/context ignored).
- **Not run:** full `tests/run.sh` (sandbox blocked filesystem writes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated managed deployment setup instructions with direct CLI commands and checksum guidance.
  - Added migration guidance for upgrading from version 2.x to 3.x.

- **Bug Fixes**
  - Improved secret scanning accuracy for diff lines beginning with `++`.
  - Tightened placeholder-secret exclusions so embedded values are still detected.

- **Documentation**
  - Updated GitHub Actions, supported-version, and release guidance for version 3.x.
  - Documented breaking changes and removed deployment workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->