### PR TITLE
docs: surface the setup skill as a Claude Code entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,10 +139,12 @@ Install and verify in the [Claude Code quick start](#claude-code). Useful slash 
 /agent-guard:setup-shell
 ```
 
-For guided dependency setup and live hook verification, use the
-`agent-guard:setup-agent-guard` skill. It is the same skill Codex invokes as
-`$setup-agent-guard`, and it is usually triggered for you when SessionStart
-reports degraded protection.
+For guided dependency diagnosis and installation, use the
+`agent-guard:setup-agent-guard` skill — the same skill Codex invokes as
+`$setup-agent-guard`. SessionStart recommends it when it reports degraded
+protection, but never invokes it: it only emits the warning. The skill's
+later hook-trust and live-probe steps are written for Codex; on Claude Code
+use `/agent-guard:verify` and `agent-guard smoke-test` instead.
 
 ## Codex Plugin
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ make check
 make smoke-test
 ```
 
-The Claude Code and Codex plugin installs do not put `agent-guard` on your shell `PATH`. In Codex, invoke `$setup-agent-guard`: it uses the plugin-local binary even when a different standalone version is on `PATH`, presents the exact host-appropriate install plan, requests approval, runs `check` plus `smoke-test`, verifies hook trust, and runs live host probes. It never installs software merely because a session started. Claude Code users can run the equivalent manual commands below.
+The Claude Code and Codex plugin installs do not put `agent-guard` on your shell `PATH`. In Codex, invoke `$setup-agent-guard`: it uses the plugin-local binary even when a different standalone version is on `PATH`, presents the exact host-appropriate install plan, requests approval, runs `check` plus `smoke-test`, verifies hook trust, and runs live host probes. It never installs software merely because a session started. The same skill is available in Claude Code as `agent-guard:setup-agent-guard`; Claude Code users can also run the equivalent manual commands below.
 
 Manual macOS equivalent:
 
@@ -138,6 +138,11 @@ Install and verify in the [Claude Code quick start](#claude-code). Useful slash 
 /agent-guard:checksum [VERSION]
 /agent-guard:setup-shell
 ```
+
+For guided dependency setup and live hook verification, use the
+`agent-guard:setup-agent-guard` skill. It is the same skill Codex invokes as
+`$setup-agent-guard`, and it is usually triggered for you when SessionStart
+reports degraded protection.
 
 ## Codex Plugin
 

--- a/docs/managed-deployment.md
+++ b/docs/managed-deployment.md
@@ -29,11 +29,8 @@ do not add `sha` beside `ref` and describe the result as commit-pinned.
 Once the managed settings land, Claude Code loads the plugin automatically.
 Each developer then completes setup in a Claude Code session:
 
-1. **Dependencies** (`jq`, `gitleaks`): use the
-   `agent-guard:setup-agent-guard` skill, which resolves the plugin-local
-   binary, proposes the install plan, and asks before changing anything.
-   The equivalent manual commands are `agent-guard setup` to diagnose, then
-   `agent-guard setup --install --gitleaks-version <version>
+1. **Dependencies** (`jq`, `gitleaks`): run `agent-guard setup` to diagnose,
+   then `agent-guard setup --install --gitleaks-version <version>
    --gitleaks-checksum <published-sha256>` — `/agent-guard:checksum` prints
    the paste-ready version/checksum pair. The plugin does not put
    `agent-guard` on `PATH`; ask Claude to run the plugin-local binary.

--- a/docs/managed-deployment.md
+++ b/docs/managed-deployment.md
@@ -29,8 +29,11 @@ do not add `sha` beside `ref` and describe the result as commit-pinned.
 Once the managed settings land, Claude Code loads the plugin automatically.
 Each developer then completes setup in a Claude Code session:
 
-1. **Dependencies** (`jq`, `gitleaks`): run `agent-guard setup` to diagnose,
-   then `agent-guard setup --install --gitleaks-version <version>
+1. **Dependencies** (`jq`, `gitleaks`): use the
+   `agent-guard:setup-agent-guard` skill, which resolves the plugin-local
+   binary, proposes the install plan, and asks before changing anything.
+   The equivalent manual commands are `agent-guard setup` to diagnose, then
+   `agent-guard setup --install --gitleaks-version <version>
    --gitleaks-checksum <published-sha256>` — `/agent-guard:checksum` prints
    the paste-ready version/checksum pair. The plugin does not put
    `agent-guard` on `PATH`; ask Claude to run the plugin-local binary.

--- a/plugins/agent-guard/README.md
+++ b/plugins/agent-guard/README.md
@@ -26,7 +26,8 @@ plugin. Until then, install from the project's marketplace:
 
 After installation, SessionStart reports `DEGRADED` protection whenever `jq`,
 `git`, gitleaks, or a bundled policy is unavailable. Follow its prompt to run
-`$setup-agent-guard` (or the plugin-local `agent-guard setup`); dependency
+the `agent-guard:setup-agent-guard` skill (or the plugin-local
+`agent-guard setup`); dependency
 installation always requires explicit approval. Then verify:
 
 ```text
@@ -72,6 +73,12 @@ gitleaks 8.30 or newer (recommended).
 - `/agent-guard:verify` — scan staged, unstaged, and untracked work-tree data.
 - `/agent-guard:checksum [VERSION]` — print published gitleaks checksums.
 - `/agent-guard:setup-shell` — install or refresh Claude command wrapping.
+
+## Skills
+
+- `agent-guard:setup-agent-guard` — diagnose dependencies, guide approved
+  installation, and verify live hook protection. Codex invokes the same skill
+  as `$setup-agent-guard`.
 
 ## Policies and support
 

--- a/plugins/agent-guard/README.md
+++ b/plugins/agent-guard/README.md
@@ -25,10 +25,11 @@ plugin. Until then, install from the project's marketplace:
 ```
 
 After installation, SessionStart reports `DEGRADED` protection whenever `jq`,
-`git`, gitleaks, or a bundled policy is unavailable. Follow its prompt to run
-the `agent-guard:setup-agent-guard` skill (or the plugin-local
-`agent-guard setup`); dependency
-installation always requires explicit approval. Then verify:
+`git`, gitleaks, or a bundled policy is unavailable. The warning names the
+skill in Codex form (`$setup-agent-guard`); in Claude Code, invoke it as
+`agent-guard:setup-agent-guard`, or run the plugin-local `agent-guard setup`
+directly. Dependency installation always requires explicit approval. Then
+verify:
 
 ```text
 /agent-guard:verify
@@ -76,9 +77,9 @@ gitleaks 8.30 or newer (recommended).
 
 ## Skills
 
-- `agent-guard:setup-agent-guard` — diagnose dependencies, guide approved
-  installation, and verify live hook protection. Codex invokes the same skill
-  as `$setup-agent-guard`.
+- `agent-guard:setup-agent-guard` — resolve the plugin-local binary, diagnose
+  `jq`/gitleaks, and guide approved installation. Codex invokes the same skill
+  as `$setup-agent-guard`; its hook-trust and live-probe steps are Codex-specific.
 
 ## Policies and support
 


### PR DESCRIPTION
## Problem

`setup-agent-guard` works in both Claude Code and Codex, but the docs only ever presented it as the Codex path. Claude Code readers were routed to manual install commands instead, and the name never appeared in its Claude form — so `/agent-guard:setup` looks missing when you go looking for it.

Two concrete defects found while tracing this:

- `plugins/agent-guard/README.md:29` — the **Claude** plugin README (it lists `/reload-plugins` and `/agent-guard:*` commands) used Codex's `$setup-agent-guard` syntax. Codex notation leaked into Claude-only docs.
- `docs/managed-deployment.md:32` — the developer setup step runs "in a Claude Code session" but listed only the bare `agent-guard setup`, then admitted the binary is not on `PATH` and told the reader to ask Claude to run it. The skill already resolves the plugin-local binary itself.

## What changed

Docs only. The skill keeps its name.

- `README.md` — name the Claude form alongside the Codex form; add a pointer in the Claude Code Plugin section next to the slash commands.
- `plugins/agent-guard/README.md` — drop the Codex `$` syntax; add a `## Skills` section beside `## Commands`.
- `docs/managed-deployment.md` — lead the dependency step with the skill, keep the manual commands as the documented fallback.

## Why not rename the skill to `setup`

Considered and rejected. Codex invokes skills by bare name with no plugin namespace (`agent-guard/skills/setup-agent-guard/agents/openai.yaml` uses `$setup-agent-guard`), so `setup` would become a collision-prone global noun there. Claude's `agent-guard:` prefix already disambiguates. Renaming would also touch 30 references across 9 files, including hardcoded assertions in `scripts/validate-plugin-layout.sh:121,131` and `tests/run.sh:1939,3222`, and ship a breaking change days after v3.0.0. The verbose name is a deliberate consequence of Codex's flat namespace, not an oversight.

## Functional verification

Docs-only change, so verification is that the repo's own checks still pass and that the documented claims match the code.

```
$ ./scripts/validate-plugin-layout.sh
plugin layout validation passed
```

Specifically green, and the two checks that hardcode the skill name are untouched by this PR:

```
ok: setup-agent-guard skill has valid required frontmatter
ok: setup-agent-guard UI metadata is complete
```

Claims cross-checked against source rather than assumed:

- Skill name in docs matches `skills/setup-agent-guard/SKILL.md:2` (`name: setup-agent-guard`).
- "Resolves the plugin-local binary" matches `SKILL.md:16`, which falls back to `command -v agent-guard` only when the plugin-relative binary is unavailable.
- No stale `agent-guard:setup` references introduced: every `/agent-guard:setup*` hit in the tree is `setup-shell`.

Note: a full local run initially failed on `Agent Guard CLI is on the 2.x release line`. That was a stale local `main`; #124 already replaced the hardcoded major with a plain-semver check. Rebased onto it, no fix needed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for setting up and verifying dependency protection in Claude Code.
  * Documented the `agent-guard:setup-agent-guard` skill and its Codex equivalent.
  * Clarified that Codex recommends setup when protection is degraded but does not run it automatically.
  * Added Claude Code verification instructions using `/agent-guard:verify` and `agent-guard smoke-test`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->