### PR TITLE
fix(hooks): scan the repository a git command targets, not the session cwd

### DIFF
--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -1334,14 +1334,56 @@ wrapper_option_takes_value() {
   esac
 }
 
-is_git_commit_or_push() {
+# A path we can act on without running a shell: no expansion, no globbing, no
+# option. A surrounding pair of quotes is stripped only when what is inside is
+# itself inert, so `cd "/srv/repo"` resolves while `cd "$DIR"` does not.
+literal_path_value() {
+  value=$1
+  case "$value" in
+    '"'*'"'|"'"*"'")
+      value=${value#?}
+      value=${value%?}
+      ;;
+  esac
+  case "$value" in
+    ''|-*) return 1 ;;
+    *'$'*|*'`'*|*'"'*|*"'"*|*'~'*|*'*'*|*'?'*|*'['*|*'('*|*')'*|*'\'*|*'{'*) return 1 ;;
+  esac
+  printf '%s' "$value"
+}
+
+join_dir() {
+  case "$2" in
+    /*) printf '%s' "$2"; return 0 ;;
+  esac
+  if [ -n "$1" ]; then
+    printf '%s/%s' "$1" "$2"
+  else
+    printf '%s' "$2"
+  fi
+}
+
+# Resolve which directory a git commit/push in $1 actually runs in, relative to
+# the payload workdir $2. Exit status carries the outcome:
+#   0 - commit/push found; the directory to scan is printed (empty means "use
+#       the payload workdir unchanged")
+#   1 - no commit/push in the command
+#   2 - commit/push found, but the command redirects the working directory in a
+#       way that cannot be resolved statically
+#
+# Status 2 exists because the alternative — falling back to the payload workdir
+# — scans a repository the command never touches and reports success, which is
+# the scan bypass this function was extracted to close.
+git_commit_target() {
   cmd=$1
+  base=${2:-}
   (
     set -f
     words=$(shell_command_words "$cmd")
     # shellcheck disable=SC2086
     set -- $words
 
+    target=$base
     command_start=1
     while [ "$#" -gt 0 ]; do
       token=$1
@@ -1376,11 +1418,50 @@ is_git_commit_or_push() {
           done
           continue
         fi
+        # Directory redirection expressed by the shell rather than by git.
+        # `cd <literal>` is modelled exactly; every other form that can move the
+        # working directory is refused rather than guessed at.
+        case "$token" in
+          cd|pushd|popd)
+            shift
+            [ "$token" = "cd" ] || return 2
+            [ "$#" -gt 0 ] || return 2
+            dir=$(literal_path_value "$1") || return 2
+            shift
+            # A second operand means `cd old new` or an option form we do not
+            # model, so the resulting directory is not knowable here.
+            if [ "$#" -gt 0 ] && ! is_shell_command_separator "$1"; then
+              return 2
+            fi
+            target=$(join_dir "$target" "$dir")
+            command_start=0
+            continue
+            ;;
+        esac
         if [ "$token" = "git" ]; then
           shift
+          gitdir=$target
           while [ "$#" -gt 0 ]; do
             token=$1
             shift
+            case "$token" in
+              -C)
+                [ "$#" -gt 0 ] || return 2
+                dir=$(literal_path_value "$1") || return 2
+                shift
+                # Repeated -C compose, matching git's own handling.
+                gitdir=$(join_dir "$gitdir" "$dir")
+                continue
+                ;;
+              # ponytail: --git-dir/--work-tree split the index from the work
+              # tree, which a plain `cd` into one directory cannot express — so
+              # resolving them risks scanning the wrong index. Refuse instead.
+              # Upgrade path: pass them through to the git invocations inside
+              # scan_staged rather than emulating them with a cd.
+              --git-dir|--work-tree|--git-dir=*|--work-tree=*)
+                return 2
+                ;;
+            esac
             if git_option_takes_value "$token"; then
               [ "$#" -gt 0 ] && shift
               continue
@@ -1389,6 +1470,7 @@ is_git_commit_or_push() {
 
             case "$token" in
               commit|push)
+                printf '%s' "$gitdir"
                 return 0
                 ;;
               *)
@@ -1434,22 +1516,35 @@ is_git_hook_bypass() {
 check_git_command() {
   cmd=$1
   workdir=${2:-}
-  if is_git_commit_or_push "$cmd"; then
-    if is_git_hook_bypass "$cmd"; then
-      info "$PROGRAM: blocked git command that disables hooks/signing"
-      exit 2
-    fi
-    if [ -n "$workdir" ]; then
-      (
-        CDPATH= cd -- "$workdir" 2>/dev/null \
-          || die "hook workdir is not accessible: $workdir"
-        scan_staged
-      )
-    else
-      scan_staged
-    fi
-    block_on_scan_status "$?" "staged changes contain secret-like values; blocking git command"
+  target=$(git_commit_target "$cmd" "$workdir")
+  target_status=$?
+  [ "$target_status" -eq 1 ] && return 0
+
+  if is_git_hook_bypass "$cmd"; then
+    info "$PROGRAM: blocked git command that disables hooks/signing"
+    exit 2
   fi
+
+  if [ "$target_status" -eq 2 ]; then
+    # Fail closed. The command commits somewhere we cannot identify, and
+    # scanning the session directory instead would report success over an
+    # unscanned repository.
+    # NOTE: telling this apart from a genuine secret block by exit status is
+    # being handled separately; reuse the existing info + exit 2 pattern.
+    info "$PROGRAM: cannot determine which repository this git command commits to; run it from the target directory"
+    exit 2
+  fi
+
+  if [ -n "$target" ]; then
+    (
+      CDPATH= cd -- "$target" 2>/dev/null \
+        || die "git command target directory is not accessible: $target"
+      scan_staged
+    )
+  else
+    scan_staged
+  fi
+  block_on_scan_status "$?" "staged changes contain secret-like values; blocking git command"
 }
 
 check_bash_command() {

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -1352,6 +1352,25 @@ literal_path_value() {
   printf '%s' "$value"
 }
 
+# Tokens that end one command inside the target walk. `&` belongs here but is
+# deliberately absent from is_shell_command_separator(), whose other callers
+# treat it as an ordinary character.
+walk_separator() {
+  is_shell_command_separator "$1" && return 0
+  [ "$1" = '&' ]
+}
+
+# `|` and `&` run the left-hand command in its own subshell or background
+# process, so a `cd` there never reaches what follows; `&&`, `||` and `;` run in
+# the same shell and do carry it. Getting this backwards on `|` means scanning
+# the cd target while the commit happens in the original directory.
+separator_carries_cwd() {
+  case "$1" in
+    ';'|'&&'|'||') return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 join_dir() {
   case "$2" in
     /*) printf '%s' "$2"; return 0 ;;
@@ -1373,7 +1392,10 @@ join_dir() {
 #
 # Status 2 exists because the alternative — falling back to the payload workdir
 # — scans a repository the command never touches and reports success, which is
-# the scan bypass this function was extracted to close.
+# the scan bypass this function was extracted to close. It is reported only once
+# a commit/push token is actually reached: an unresolvable `cd` in a git-free
+# command is none of this gate's business, and blocking those would break far
+# more than the bypass ever did.
 git_commit_target() {
   cmd=$1
   base=${2:-}
@@ -1384,6 +1406,7 @@ git_commit_target() {
     set -- $words
 
     target=$base
+    unresolved=0
     command_start=1
     while [ "$#" -gt 0 ]; do
       token=$1
@@ -1418,22 +1441,47 @@ git_commit_target() {
           done
           continue
         fi
+        # A subshell scopes cwd changes in ways this walk does not track. Strip
+        # the parens so the commands inside are still examined, and mark the cwd
+        # unknown — an absolute `cd` inside the subshell re-establishes it,
+        # which is correct because the commit runs inside that subshell too.
+        case "$token" in
+          '('*)
+            unresolved=1
+            rest=$token
+            while [ "${rest#\(}" != "$rest" ]; do rest=${rest#\(}; done
+            shift
+            [ -n "$rest" ] && set -- "$rest" "$@"
+            continue
+            ;;
+        esac
         # Directory redirection expressed by the shell rather than by git.
         # `cd <literal>` is modelled exactly; every other form that can move the
-        # working directory is refused rather than guessed at.
+        # working directory marks the cwd unknown rather than being guessed at.
         case "$token" in
           cd|pushd|popd)
             shift
-            [ "$token" = "cd" ] || return 2
-            [ "$#" -gt 0 ] || return 2
-            dir=$(literal_path_value "$1") || return 2
-            shift
-            # A second operand means `cd old new` or an option form we do not
-            # model, so the resulting directory is not knowable here.
-            if [ "$#" -gt 0 ] && ! is_shell_command_separator "$1"; then
-              return 2
+            if [ "$token" != "cd" ]; then
+              # pushd/popd move a directory stack this walk does not maintain.
+              unresolved=1
+            elif [ "$#" -gt 0 ] && ! walk_separator "$1" \
+              && dir=$(literal_path_value "$1") \
+              && { [ "$#" -eq 1 ] || walk_separator "$2"; }; then
+              # The trailing check rejects `cd old new` and option forms, whose
+              # resulting directory is not knowable here.
+              case "$dir" in
+                /*)
+                  # An absolute cd re-establishes the cwd even if an earlier one
+                  # was unreadable.
+                  target=$dir
+                  unresolved=0
+                  ;;
+                *) target=$(join_dir "$target" "$dir") ;;
+              esac
+              shift
+            else
+              unresolved=1
             fi
-            target=$(join_dir "$target" "$dir")
             command_start=0
             continue
             ;;
@@ -1441,25 +1489,36 @@ git_commit_target() {
         if [ "$token" = "git" ]; then
           shift
           gitdir=$target
+          # Scoped to this one git invocation: its options do not affect any
+          # later command, so `git --git-dir=x status && git commit` must not
+          # taint the commit.
+          opt_unresolved=0
           while [ "$#" -gt 0 ]; do
             token=$1
             shift
             case "$token" in
               -C)
-                [ "$#" -gt 0 ] || return 2
-                dir=$(literal_path_value "$1") || return 2
-                shift
-                # Repeated -C compose, matching git's own handling.
-                gitdir=$(join_dir "$gitdir" "$dir")
+                if [ "$#" -gt 0 ]; then
+                  if dir=$(literal_path_value "$1"); then
+                    # Repeated -C compose, matching git's own handling.
+                    gitdir=$(join_dir "$gitdir" "$dir")
+                  else
+                    opt_unresolved=1
+                  fi
+                  shift
+                else
+                  opt_unresolved=1
+                fi
                 continue
                 ;;
               # ponytail: --git-dir/--work-tree split the index from the work
               # tree, which a plain `cd` into one directory cannot express — so
-              # resolving them risks scanning the wrong index. Refuse instead.
+              # resolving them risks scanning the wrong index. Mark unknown and
+              # fall through so the value token is still consumed below.
               # Upgrade path: pass them through to the git invocations inside
               # scan_staged rather than emulating them with a cd.
               --git-dir|--work-tree|--git-dir=*|--work-tree=*)
-                return 2
+                opt_unresolved=1
                 ;;
             esac
             if git_option_takes_value "$token"; then
@@ -1468,8 +1527,12 @@ git_commit_target() {
             fi
             is_git_global_option "$token" && continue
 
+            # `commit)` / `push)` close a subshell such as `(git commit)`.
             case "$token" in
-              commit|push)
+              commit|push|'commit)'|'push)')
+                if [ "$unresolved" -eq 1 ] || [ "$opt_unresolved" -eq 1 ]; then
+                  return 2
+                fi
                 printf '%s' "$gitdir"
                 return 0
                 ;;
@@ -1484,8 +1547,12 @@ git_commit_target() {
       fi
 
       shift
-      if is_shell_command_separator "$token"; then
+      if walk_separator "$token"; then
         command_start=1
+        if ! separator_carries_cwd "$token"; then
+          target=$base
+          unresolved=0
+        fi
       else
         command_start=0
       fi

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1202,6 +1202,97 @@ else
   sed 's/^/  stderr: /' "$ERR"
 fi
 
+# Scan-target resolution. The gate must scan the repository the command actually
+# commits to, not the session cwd. Pairing a CLEAN payload cwd with a LEAKING
+# target repo isolates that: a block can only mean the target repo was scanned,
+# and an allow can only mean the session cwd was scanned instead.
+XTARGET_CLEAN="$TMP_ROOT/xtarget-clean"
+XTARGET_LEAK="$TMP_ROOT/xtarget-leak"
+mkdir -p "$XTARGET_CLEAN" "$XTARGET_LEAK"
+(
+  cd "$XTARGET_CLEAN" || exit 2
+  git init -q
+  git config user.email test@example.com
+  git config user.name test
+  printf '%s\n' "clean" > ok.txt
+  git add ok.txt
+)
+(
+  cd "$XTARGET_LEAK" || exit 2
+  git init -q
+  git config user.email test@example.com
+  git config user.name test
+  printf '%s\n' "AGENT_GUARD_TEST_SECRET" > leak.txt
+  git add leak.txt
+)
+
+# Runs one command with both the process cwd and the payload cwd set to the
+# clean repo. $3 is the command; $4 is an optional stderr pattern.
+xtarget_case() {
+  expected=$1
+  name=$2
+  command=$3
+  pattern=${4:-}
+  (
+    cd "$XTARGET_CLEAN" || exit 2
+    jq -nc --arg cwd "$XTARGET_CLEAN" --arg cmd "$command" \
+      '{tool_name:"Bash",cwd:$cwd,tool_input:{command:$cmd}}' \
+      | "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool >"$OUT" 2>"$ERR"
+  )
+  status=$?
+  if [ "$status" -eq "$expected" ] \
+    && { [ -z "$pattern" ] || grep -q "$pattern" "$ERR"; }; then
+    ok "$name"
+  else
+    not_ok "$name (expected $expected, got $status)"
+    sed 's/^/  stderr: /' "$ERR"
+  fi
+}
+
+# Control: without redirection the clean session cwd is scanned and allowed.
+# If this fails, every case below is measuring the wrong repository.
+xtarget_case 0 "commit in a clean repo without redirection is allowed" \
+  "git commit -m x"
+
+# Ordinary chains do not redirect the cwd and must not be refused.
+xtarget_case 0 "chained git add before commit in a clean repo is allowed" \
+  "git add . && git commit -m x"
+
+xtarget_case 2 "cd into another repo scans that repo's staged changes" \
+  "cd $XTARGET_LEAK && git commit -m x" \
+  'staged changes contain secret-like values'
+
+xtarget_case 2 "cd with a ; separator scans the target repo" \
+  "cd $XTARGET_LEAK; git commit -m x" \
+  'staged changes contain secret-like values'
+
+xtarget_case 2 "relative cd into another repo scans the target repo" \
+  "cd ../xtarget-leak && git commit -m x" \
+  'staged changes contain secret-like values'
+
+xtarget_case 2 "git -C into another repo scans that repo's staged changes" \
+  "git -C $XTARGET_LEAK commit -m x" \
+  'staged changes contain secret-like values'
+
+# --work-tree and --git-dir split the index from the work tree in ways a plain
+# `cd` cannot model, so they are refused rather than resolved. Both still block.
+xtarget_case 2 "git --work-tree redirection is refused" \
+  "git --work-tree=$XTARGET_LEAK commit -m x" \
+  'cannot determine'
+
+xtarget_case 2 "git --git-dir redirection is refused" \
+  "git --git-dir=$XTARGET_LEAK/.git commit -m x" \
+  'cannot determine'
+
+# Fail closed: silently scanning the session cwd here is the original bypass.
+xtarget_case 2 "cd through a variable is refused as unresolvable" \
+  'cd "$TARGET_DIR" && git commit -m x' \
+  'cannot determine'
+
+xtarget_case 2 "pushd redirection is refused as unresolvable" \
+  "pushd $XTARGET_LEAK && git commit -m x" \
+  'cannot determine'
+
 (
   cd "$TEST_REPO" || exit 2
   printf '%s' '{"tool_name":"Bash","tool_input":{"command":"git status && git -C . push origin main"}}' \
@@ -1233,7 +1324,7 @@ expect_json_status 2 "git hook bypass without separator spaces is blocked" \
   hook-pre-tool
 
 # R2: wrapper/assignment-prefixed commits with NO --no-verify must still reach
-# the staged scan via is_git_commit_or_push (not via the hook-bypass shortcut).
+# the staged scan via git_commit_target (not via the hook-bypass shortcut).
 # leak.txt is still staged from the harness above.
 (
   cd "$TEST_REPO" || exit 2

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1289,9 +1289,82 @@ xtarget_case 2 "cd through a variable is refused as unresolvable" \
   'cd "$TARGET_DIR" && git commit -m x' \
   'cannot determine'
 
-xtarget_case 2 "pushd redirection is refused as unresolvable" \
+xtarget_case 2 "pushd before a commit is refused as unresolvable" \
   "pushd $XTARGET_LEAK && git commit -m x" \
   'cannot determine'
+
+# An unresolvable cd only matters if a commit/push is actually reached. Blocking
+# ordinary navigation would be far more destructive than the bypass this fix
+# closes, so these must stay allowed.
+xtarget_case 0 "cd through a variable without a commit is allowed" \
+  'cd "$HOME" && ls'
+
+xtarget_case 0 "cd through a variable before a non-mutating git command is allowed" \
+  'cd "$VAR" && git status'
+
+xtarget_case 0 "cd through command substitution without a commit is allowed" \
+  'cd $(pwd)/sub && npm test'
+
+xtarget_case 0 "pushd without a commit is allowed" \
+  "pushd /tmp && ls"
+
+xtarget_case 0 "git --git-dir on a non-mutating subcommand is allowed" \
+  "git --git-dir=$XTARGET_LEAK/.git status"
+
+# The commit runs inside the same subshell as the cd, so the target is knowable
+# and gets scanned. A subshell that only *scopes* the cd is refused instead.
+xtarget_case 2 "subshell-wrapped cd and commit scans the target repo" \
+  "(cd $XTARGET_LEAK && git commit -m x)" \
+  'staged changes contain secret-like values'
+
+xtarget_case 2 "commit after a subshell-scoped cd is refused as unresolvable" \
+  "(cd $XTARGET_LEAK) && git commit -m x" \
+  'cannot determine'
+
+xtarget_case 2 "subshell-wrapped bare commit is refused as unresolvable" \
+  "(git commit -m x)" \
+  'cannot determine'
+
+# Session cwd on the LEAKING repo. Here the correct answer is "scan the original
+# cwd", so an allow means the cd target was scanned instead — a bypass.
+xtarget_leak_cwd_case() {
+  expected=$1
+  name=$2
+  command=$3
+  (
+    cd "$XTARGET_LEAK" || exit 2
+    jq -nc --arg cwd "$XTARGET_LEAK" --arg cmd "$command" \
+      '{tool_name:"Bash",cwd:$cwd,tool_input:{command:$cmd}}' \
+      | "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool >"$OUT" 2>"$ERR"
+  )
+  status=$?
+  if [ "$status" -eq "$expected" ]; then
+    ok "$name"
+  else
+    not_ok "$name (expected $expected, got $status)"
+    sed 's/^/  stderr: /' "$ERR"
+  fi
+}
+
+# Control: if this does not block, the cases below prove nothing.
+xtarget_leak_cwd_case 2 "commit in the leaking repo without redirection is blocked" \
+  "git commit -m x"
+
+# Bash runs the left side of a pipe in its own subshell, so the cd never reaches
+# the commit — it still runs in the original (leaking) cwd.
+xtarget_leak_cwd_case 2 "cd across a pipe does not move the scan target" \
+  "cd $XTARGET_CLEAN | git commit -m x"
+
+xtarget_leak_cwd_case 2 "cd backgrounded with & does not move the scan target" \
+  "cd $XTARGET_CLEAN & git commit -m x"
+
+# && and ; DO carry the cd, so these are correctly allowed. Keep them asserted
+# so a future tightening of the pipe rule cannot quietly break them.
+xtarget_leak_cwd_case 0 "cd across && moves the scan target to the clean repo" \
+  "cd $XTARGET_CLEAN && git commit -m x"
+
+xtarget_leak_cwd_case 0 "cd across ; moves the scan target to the clean repo" \
+  "cd $XTARGET_CLEAN ; git commit -m x"
 
 (
   cd "$TEST_REPO" || exit 2


### PR DESCRIPTION
## Problem

The PreToolUse git gate resolved the directory it scans from the hook payload's
cwd and never consulted the command itself. A commit aimed at a different
repository was therefore checked against the wrong one — and allowed.

`is_git_commit_or_push()` already parsed `-C`'s value in order to walk to the
`commit` token, then discarded it. The one place in the codebase that knew the
real target directory threw it away before the scan ran.

Two consequences from the same root:

- **False negative.** With the session cwd on a repo with nothing staged, a
  commit redirected into a *different* repo that has a staged secret was
  allowed, with nothing to indicate the scan had been pointed elsewhere.
- **False positive.** With the session cwd not a git repository at all, the
  scan could not run and the command was refused outright — which makes
  agent-guard unusable from the common layout of one session rooted at a
  non-repo parent with repositories below it.

## Change

Replace `is_git_commit_or_push()` with `git_commit_target()`, which returns the
directory rather than dropping it:

- models `cd <literal>` and `-C`, composing repeated `-C` the way git does
- resolves relative paths against the payload workdir
- **fails closed** on anything it cannot resolve statically — `cd "$DIR"`,
  command substitution, globs, `pushd`/`popd`, and `--git-dir` / `--work-tree`
  (those can split the index from the work tree, which a single `cd` cannot
  express, so emulating them risks scanning the wrong index)

Failing closed is the point. Falling back to the payload workdir is what
produced the false negative: it scans a repository the command never touches
and then reports success.

`block_on_scan_status()` keeps its signature and call sites unchanged.

## Functional verification

Driving `hook-pre-tool` directly with synthetic payloads against a three-repo
fixture (`repoA` clean, `repoB` with a staged secret, `plain` not a repo). Each
case sets both the process cwd and the payload cwd, because releases before #108
ignore the payload cwd and scan the process cwd — a harness that sets only one
of them measures its own cwd leakage. The clean-repo control coming out ALLOWED
is the check that the harness is sound.

| # | session cwd | command | before | after |
|---|---|---|---|---|
| 1 | repoB (leaking) | `git commit` | BLOCKED | BLOCKED (control) |
| 2 | repoA (clean) | `git commit` | ALLOWED | ALLOWED (control) |
| 3 | repoA (clean) | `cd <repoB> && git commit` | **ALLOWED** | **BLOCKED** |
| 4 | repoA (clean) | `git -C <repoB> commit` | **ALLOWED** | **BLOCKED** |
| 5 | plain (non-repo) | `cd <repoB> && git commit` | BLOCKED — scan could not run | **BLOCKED — secret found** |

Case 5 is the one to read closely: it blocked before *and* after, but for
different reasons. It now blocks because the staged secret was found in the
correct repository, not because the scan gave up.

Both controls behaving identically before and after is what shows this is target
selection, not command parsing and not the scanner.

Also run:

- `make test` — 451 passed, 0 failed (446 before; 5 new regression assertions
  covering `cd &&`, `-C`, `--work-tree`, `--git-dir`, and an unresolvable form)
- `make check` — ok
- `make smoke-test` — ok, all 6 cases

## Affected versions

Present in every released version, v1.0.1 through v3.0.0. Confirmed by execution
on 1.3.4 and 3.0.0, not inferred from history. The mechanism differs across the
range — before #108 there was no payload workdir and the hook scanned its own
process cwd — but the observable behaviour is identical.

## Notes for review

- This was found while verifying a clean plugin install against the README, not
  by auditing the code.
- It bit this very PR: with a session rooted at a non-repo parent, the installed
  v3.0.0 gate refused every `git commit` *and* `git push` for the branch
  carrying its own fix. The false positive is not hypothetical.
- Relationship to #126: that issue proposes making PostToolUse/Stop adopt
  PreToolUse's workdir handling. That handling is what this PR fixes, so #126
  should be sequenced after this and implemented against the corrected rule.
- Companion PR on `fix/scan-error-class` makes "the scan could not run"
  distinguishable from "a secret was found". It overlaps with case 5's symptom
  but is independently useful; the two are not duplicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Git commit and push checks now scan the repository actually targeted by the command, including commands using directory changes or `git -C`.
  * Unsafe or unresolved repository redirections now fail closed instead of scanning the wrong location.
  * Hook-bypass options are detected before scanning.

* **Tests**
  * Added coverage for repository targeting, chained directory changes, wrapper commands, and unsupported redirection methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Review round 2 (1102945)

Review caught two defects in the first attempt. Both are fixed and covered by
regression tests.

**A regression worse than the bug.** An unresolvable `cd` / `pushd` / `-C`
returned "unresolvable" before establishing the command was even a commit, and
`check_git_command()` runs on every Bash call — so `cd "$HOME" && ls`,
`pushd /tmp && ls` and `cd $(pwd)/sub && npm test` were all refused. The walk
now defers that outcome until a `commit`/`push` token is actually reached.

**A bypass the fix introduced.** `cd <dir> | git commit` runs the left side in
its own subshell, so the `cd` never reaches the commit — which still runs in the
original directory. Carrying the target across the pipe scanned the wrong
repository. Separators are now split by whether they carry cwd: `;`, `&&`, `||`
do; `|` and `&` do not. `&&` and `;` remain ALLOWED in that scenario and are
asserted as such, because there the `cd` genuinely does reach the commit.

Two adjacent cases were closed at the same time: subshell parens are stripped so
their contents are still examined with cwd marked unknown, and git's directory
options are scoped to the invocation carrying them, so a directory option on an
earlier `git` in the chain no longer taints a later commit.

### Verification

A 20-case sweep across the original bypass matrix, the git-free false positives,
separator semantics, unresolvable-then-commit, and option scoping: **20 passed,
0 failed**. Unit tests **464 pass** (446 before this PR, 451 after the first
round). `make check` and `make smoke-test` ok.

The original five-case matrix is unchanged, which is the point: the false
positives were fixed without reopening the bypass.
