### PR TITLE
fix(hooks): report a scan that could not run distinctly from a detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## Unreleased
+
+- fix(hooks): report a scan that could not run distinctly from a detection
+  (#137). A scanner precondition failure and a real detection previously looked
+  identical — both printed and exited 2 — so an operator could not tell whether
+  agent-guard had found something in their staged changes or had never managed
+  to look. Both still fail closed; they now say which happened, and the message
+  names the directory and the action instead of an internal subcommand.
+
+  CLI behaviour change: `agent-guard scan-staged` and `agent-guard
+  scan-working-tree` invoked outside a git work tree now exit **3** rather than
+  2. Everything in this repo treats non-zero as failure (the native pre-commit
+  hook, the `make` targets, the verify command), so no consumer changes — but
+  scripts that test for exactly 2 should be updated.
+
 ## v3.0.0 - 2026-07-19
 
 - feat!: simplify managed deployment to settings merge plus developer setup (#122)

--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ agent-guard smoke-test
 agent-guard checksum
 ```
 
+Scan commands exit `0` when nothing was found, `1` when a secret was detected, and `3` when the scan could not run at all — for example `scan-staged` outside a git work tree. `3` exists so that "I looked and it was clean" is never confused with "I never got to look"; both non-zero results mean the change is not cleared. Any other non-zero status is a scanner error.
+
 Override install defaults with `AGENT_GUARD_VERSION`, `AGENT_GUARD_HOME`, `AGENT_GUARD_BIN_DIR`, or `AGENT_GUARD_COMMAND_WRAPPING`.
 
 ## Managed deployment

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -684,12 +684,26 @@ scan_text_direct() {
   printf '%s\n' "$text" | run_gitleaks_stdin "$label"
 }
 
+# Scan status protocol, shared by every scan_* function and this dispatcher:
+#   0 clean, 1 a secret was found, 3 the scan could not run, other scanner error.
+# 3 exists because "I found a secret in your staged changes" and "I never got to
+# look" are different facts and an operator has to be able to act on the right
+# one. Both still fail closed; a scan that cannot run is not a pass.
+SCAN_STATUS_UNAVAILABLE=3
+
 block_on_scan_status() {
   status=$1
   message=$2
   case "$status" in
     0) return 0 ;;
     1) info "$PROGRAM: $message"; exit 2 ;;
+    # Exit 2 is the host's only "block" signal, so it cannot carry the
+    # distinction — the message has to. The caller that returned this status
+    # already named the reason and the directory; add what it means.
+    "$SCAN_STATUS_UNAVAILABLE")
+      info "$PROGRAM: nothing was verified, so the command is blocked"
+      exit 2
+      ;;
     *) exit 2 ;;
   esac
 }
@@ -747,10 +761,19 @@ inside_git_repo() {
   git rev-parse --is-inside-work-tree >/dev/null 2>&1
 }
 
+# Name the directory and the action, not the internal subcommand: the operator
+# never typed `scan-staged`, so telling them it "must run inside a git work
+# tree" describes agent-guard's plumbing instead of their problem.
+require_git_repo() {
+  inside_git_repo && return 0
+  info "$PROGRAM could not scan: $(pwd) is not a git repository; run the command from inside the repository"
+  return "$SCAN_STATUS_UNAVAILABLE"
+}
+
 scan_staged() {
   need_cmd git
   need_gitleaks
-  inside_git_repo || die "scan-staged must run inside a git work tree"
+  require_git_repo || return $?
   added=$(git diff --cached --unified=0 --no-ext-diff -- . | extract_added_lines)
   [ -n "$added" ] || return 0
   scan_text_direct "staged added lines" "$added"
@@ -802,7 +825,7 @@ scan_untracked_files() {
 scan_working_tree() {
   need_cmd git
   need_gitleaks
-  inside_git_repo || die "scan-working-tree must run inside a git work tree"
+  require_git_repo || return $?
 
   if git rev-parse --verify HEAD >/dev/null 2>&1; then
     tracked=$(git diff --unified=0 --no-ext-diff HEAD -- . | extract_added_lines)

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -766,7 +766,7 @@ inside_git_repo() {
 # tree" describes agent-guard's plumbing instead of their problem.
 require_git_repo() {
   inside_git_repo && return 0
-  info "$PROGRAM could not scan: $(pwd) is not a git repository; run the command from inside the repository"
+  info "$PROGRAM: could not scan: $(pwd) is not a git repository; run the command from inside the repository"
   return "$SCAN_STATUS_UNAVAILABLE"
 }
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -2081,6 +2081,15 @@ else
   sed 's/^/  stderr: /' "$CANNOT_SCAN_ERR"
 fi
 
+# Operators filter stderr on the `agent-guard: ` prefix, so a message that drops
+# the colon is invisible to them no matter how well worded it is.
+if grep -q '^agent-guard: could not scan' "$CANNOT_SCAN_ERR"; then
+  ok "unscannable commit message keeps the agent-guard: prefix"
+else
+  not_ok "unscannable commit message keeps the agent-guard: prefix"
+  sed 's/^/  stderr: /' "$CANNOT_SCAN_ERR"
+fi
+
 if grep -q 'scan-staged' "$CANNOT_SCAN_ERR"; then
   not_ok "unscannable commit message does not name an internal subcommand"
   sed 's/^/  stderr: /' "$CANNOT_SCAN_ERR"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -2035,19 +2035,94 @@ expect_json_status 2 "MCP input with secret in nested object is blocked" \
   '{"tool_name":"mcp__server__tool","tool_input":{"config":{"auth":{"token":"AGENT_GUARD_TEST_SECRET"}}}}' \
   hook-pre-tool
 
-# --- scan_staged outside a git work tree ----------------------------------
+# --- "could not scan" is distinguishable from "found a secret" -------------
+# Both fail closed, and at the hook boundary both must exit 2 because that is
+# the host's only block signal. So the MESSAGE is what has to tell an operator
+# which of the two happened: a secret in their staged changes, or a scan that
+# never ran. The assertions below pin both directions of that distinction.
 
-NON_REPO_DIR="$TMP_ROOT/not-a-repo"
-mkdir -p "$NON_REPO_DIR"
+mkdir -p "$TMP_ROOT/not-a-repo"
+# Canonicalize: $TMPDIR often ends in a slash, so "$TMP_ROOT/not-a-repo" can
+# carry a `//` that the binary's own `pwd` normalizes away. Compare like for
+# like, otherwise the message assertion below fails on punctuation.
+NON_REPO_DIR=$(CDPATH= cd -- "$TMP_ROOT/not-a-repo" && pwd)
 (
   cd "$NON_REPO_DIR" || exit 2
   "$PLUGIN_ROOT/bin/agent-guard" scan-staged >"$OUT" 2>"$ERR"
 )
 status=$?
-if [ "$status" -eq 2 ]; then
-  ok "scan-staged dies outside a git work tree"
+if [ "$status" -eq 3 ]; then
+  ok "scan-staged exits 3 (cannot scan) outside a git work tree"
 else
-  not_ok "scan-staged dies outside a git work tree (expected 2, got $status)"
+  not_ok "scan-staged exits 3 (cannot scan) outside a git work tree (expected 3, got $status)"
+  sed 's/^/  stderr: /' "$ERR"
+fi
+
+CANNOT_SCAN_ERR="$TESTTMP/cannot-scan-err"
+(
+  cd "$NON_REPO_DIR" || exit 2
+  jq -nc --arg cwd "$NON_REPO_DIR" \
+    '{tool_name:"Bash",tool_input:{command:"git commit -m x"},cwd:$cwd}' \
+    | "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool >"$OUT" 2>"$CANNOT_SCAN_ERR"
+)
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "commit from a non-repo cwd still fails closed"
+else
+  not_ok "commit from a non-repo cwd still fails closed (expected 2, got $status)"
+  sed 's/^/  stderr: /' "$CANNOT_SCAN_ERR"
+fi
+
+if grep -q 'could not scan' "$CANNOT_SCAN_ERR" \
+  && grep -Fq "$NON_REPO_DIR" "$CANNOT_SCAN_ERR"; then
+  ok "unscannable commit names the reason and the directory"
+else
+  not_ok "unscannable commit names the reason and the directory"
+  sed 's/^/  stderr: /' "$CANNOT_SCAN_ERR"
+fi
+
+if grep -q 'scan-staged' "$CANNOT_SCAN_ERR"; then
+  not_ok "unscannable commit message does not name an internal subcommand"
+  sed 's/^/  stderr: /' "$CANNOT_SCAN_ERR"
+else
+  ok "unscannable commit message does not name an internal subcommand"
+fi
+
+if grep -q 'secret-like' "$CANNOT_SCAN_ERR"; then
+  not_ok "unscannable commit is not reported as a secret detection"
+  sed 's/^/  stderr: /' "$CANNOT_SCAN_ERR"
+else
+  ok "unscannable commit is not reported as a secret detection"
+fi
+
+DETECTION_REPO="$TMP_ROOT/detection-repo"
+DETECTION_ERR="$TESTTMP/detection-err"
+mkdir -p "$DETECTION_REPO"
+(
+  cd "$DETECTION_REPO" || exit 2
+  git init -q
+  git config user.email t@e
+  git config user.name t
+  printf '%s\n' "AGENT_GUARD_TEST_SECRET" > leak.txt
+  git add leak.txt
+  jq -nc --arg cwd "$DETECTION_REPO" \
+    '{tool_name:"Bash",tool_input:{command:"git commit -m x"},cwd:$cwd}' \
+    | "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool >"$OUT" 2>"$DETECTION_ERR"
+)
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "commit with a staged secret is still blocked"
+else
+  not_ok "commit with a staged secret is still blocked (expected 2, got $status)"
+  sed 's/^/  stderr: /' "$DETECTION_ERR"
+fi
+
+if grep -q 'secret-like' "$DETECTION_ERR" \
+  && ! grep -q 'could not scan' "$DETECTION_ERR"; then
+  ok "secret detection is reported as a detection, not as a scan failure"
+else
+  not_ok "secret detection is reported as a detection, not as a scan failure"
+  sed 's/^/  stderr: /' "$DETECTION_ERR"
 fi
 
 # --- install.sh git-hooks safety ------------------------------------------


### PR DESCRIPTION
## Problem

A scanner precondition failure and a real detection were reported identically.

`die()` printed and exited 2 directly, and 2 is also what
`block_on_scan_status()` uses for a policy block. So an operator seeing a blocked
command could not tell whether agent-guard had found something in their staged
changes, or had never managed to look at all — not from the exit status, and
largely not from the output shape either.

The message made it worse by naming `scan-staged`, an internal subcommand the
user never typed, and by describing agent-guard's plumbing rather than the
operator's actual problem:

```
agent-guard: scan-staged must run inside a git work tree
```

For a security control, "I checked and it was clean" and "I never checked" are
different facts, and only one of them means the change is safe.

## Change

- Add `SCAN_STATUS_UNAVAILABLE=3` as a distinct scan status, documented as a
  protocol shared by every `scan_*` function and the dispatcher.
- `require_git_repo()` names the directory and the action instead of the
  internal subcommand.
- Both outcomes still **fail closed** — a scan that could not run is not a pass.
  What changes is that they now say which one happened.

`block_on_scan_status()` keeps its signature and both existing call sites
unchanged; the new status is handled inside it. Every internal caller of
`scan_staged` / `scan_working_tree` already routes through it, so the new status
is handled everywhere it can arise.

Before / after, operator-facing:

```
- agent-guard: scan-staged must run inside a git work tree
+ agent-guard could not scan: <dir> is not a git repository; run the command from inside the repository
+ agent-guard: nothing was verified, so the command is blocked
```

## Functional verification

- `make test` — 447 passed, 0 failed (446 before; 5 new assertions, 1 rewritten),
  including assertions that a scanner-precondition failure and a
  secret-detection block are distinguishable
- `make check` — ok
- `make smoke-test` — ok, all 6 cases
- `scan-staged` against this branch's own staged changes — exit 0

## Notes for review

- One behaviour change worth a decision: `agent-guard scan-staged` invoked
  directly outside a repository now exits 3 rather than 2. Every consumer in the
  tree treats non-zero as failure (the native pre-commit hook, the `make`
  targets, the verify skill), so nothing regresses — but if you consider the CLI
  exit codes part of the public contract, this belongs in the changelog.
- Relationship to the `fix/scan-target-resolution` PR: that one fixes *why* a
  non-repo cwd is reached at all — the gate resolving its scan target from the
  payload cwd instead of the directory the command targets. With it in place the
  non-repo case stops arising through that path. This PR is still independently
  useful: any future condition that prevents a scan from running should report
  honestly rather than look like a detection. The two are not duplicates, and
  this one deliberately does not touch target resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Scan failures are now clearly distinguished from genuine secret detections.
  * Scans run outside a Git work tree now return status `3`, indicating that verification was unavailable.
  * Hooks fail closed when a scan cannot run, with clearer error messages including the affected directory.

* **Documentation**
  * Documented scan exit codes: `0` for clean, `1` for detected secrets, and `3` when scanning is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->