### PR TITLE
fix: make setup-shell request sandbox approval

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,12 @@ Because the plugin (auto-updated by `claude plugin update`) and the binary the i
 
 > **Works without the CLI on `$PATH` — but a plugin can't edit your rc.** Direct CLI bootstrap installs the default-on shell integration automatically. For a plugin-only install, run the plugin-local `agent-guard setup-shell` once — invoke it by absolute path if `agent-guard` isn't on your `$PATH`; it bakes that same absolute path into the line it writes — then restart your shell and any Claude Code session. See [Migrating from 1.x to 2.x](docs/migration-v2.md) for old managed blocks and opt-out behavior.
 
+`/agent-guard:setup-shell` invokes that binary through Claude's Bash tool so a
+sandboxed session can request approval before writing the shell rc. If the host
+cannot grant that approval, run the displayed plugin-local command directly in
+your terminal; `!` command interpolation cannot request the required write
+permission.
+
 **This is best-effort, not a security control.** It covers only those command names and is trivially bypassed by an absolute path (`/bin/cat`), `source` / `.`, `python -c 'open(...)'`, or a redirection (`< file`). Because `agent-guard exec` buffers the whole output before masking it, **streaming / follow commands would hang** — so `tail` is deliberately *not* wrapped, and you should not `agx` a `tail -f`, a pager, or any long-running program (wrap only terminating dump commands). Output is captured via shell substitution, so wrapping is **text-only** — a binary or NUL-containing read loses embedded NULs and its trailing newline, so use `command cat` / `\cat` for faithful binary output. Each wrapped call also pays a gitleaks scan. Treat it as a convenience nudge for the common cases, not a boundary — the only channel-agnostic fix remains an egress redaction proxy or an upstream `!`-command hook.
 
 ## Known Limitations

--- a/plugins/agent-guard/README.md
+++ b/plugins/agent-guard/README.md
@@ -41,6 +41,9 @@ Optional Claude shell command wrapping requires an explicit shell-rc change:
 /agent-guard:setup-shell
 ```
 
+The slash command uses Claude's Bash tool so a sandboxed session can request
+approval before changing the shell rc. If the host cannot grant that approval,
+run the plugin-local `agent-guard setup-shell` command directly in a terminal.
 Restart the shell and Claude Code after setup. Dependency downloads never run
 from a lifecycle hook. Until wrapping is loaded, SessionStart repeats the
 `/agent-guard:setup-shell` instruction. The guided setup path asks before

--- a/plugins/agent-guard/commands/setup-shell.md
+++ b/plugins/agent-guard/commands/setup-shell.md
@@ -6,14 +6,24 @@ description: Install Agent Guard's default-on Claude command wrapping into the c
 # /agent-guard:setup-shell
 
 Install or refresh the managed Agent Guard shell integration for Claude Code.
-Command wrapping is enabled by default in Agent Guard 2.x.
+Command wrapping is enabled by default.
 
 ## Run
 
-!`"${CLAUDE_PLUGIN_ROOT}/bin/agent-guard" setup-shell`
+Use the Bash tool to run:
+
+```sh
+"${CLAUDE_PLUGIN_ROOT}/bin/agent-guard" setup-shell
+```
+
+Do not use `!` command interpolation for this step. `setup-shell` writes the
+user's shell rc, so Claude's sandbox may require approval to run the Bash tool
+outside the sandbox. If the host cannot request that approval, tell the user to
+run the same command directly in their terminal.
 
 ## Report
 
 - On success, tell the user to restart the shell and every Claude Code session.
-- On failure, relay the exact error and leave the shell rc unchanged.
+- On failure, relay the exact error and the direct terminal command; leave the
+  shell rc unchanged.
 - To opt out later, tell the user to set `AGENT_GUARD_COMMAND_WRAPPING=off` for a runtime opt-out or run the plugin-local binary with `setup-shell --no-command-wrapping` for a persistent opt-out.

--- a/plugins/agent-guard/skills/setup-agent-guard/SKILL.md
+++ b/plugins/agent-guard/skills/setup-agent-guard/SKILL.md
@@ -39,7 +39,17 @@ Make Agent Guard operational without silently changing the machine. Diagnose fir
 
    Never substitute an unverified checksum and never bypass TLS verification.
 
-5. Verify the plugin-local installation:
+5. If an approved dependency installation is blocked by the host sandbox:
+   - Relay the exact error. Do not retry the same blocked write, change the
+     install destination, or bypass the sandbox silently.
+   - Show the exact command for the user to run in a separate terminal. For the
+     private gitleaks installer, preserve the plugin-local binary path, version,
+     and published checksum from the approved command above.
+   - Wait for the user to confirm that the command finished, rerun the read-only
+     `"<agent-guard-bin>" setup` diagnosis, and continue only when the dependency
+     reports `ok`.
+
+6. Verify the plugin-local installation:
 
    ```sh
    "<agent-guard-bin>" check
@@ -48,13 +58,13 @@ Make Agent Guard operational without silently changing the machine. Diagnose fir
 
    Treat `check` as dependency/config validation and `smoke-test` as proof of the binary's own behavior. They do not prove that the host is dispatching plugin hooks.
 
-6. Verify Codex hook readiness before claiming that protection is active.
+7. Verify Codex hook readiness before claiming that protection is active.
    - Confirm that the Agent Guard plugin is installed and enabled.
    - In Codex **Settings > Hooks**, inspect Agent Guard's `SessionStart`, `PreToolUse`, `PostToolUse`, and `Stop` hooks. Every hook must be enabled and trusted. Treat `Untrusted` and `Modified` as inactive; an updated hook must be reviewed and trusted again.
    - Do not edit `hooks.state` or copy trust hashes into `config.toml`. Hook trust is a user security decision and must go through the Codex trust UI.
    - If `SessionStart` itself is untrusted, explain that it cannot emit the setup warning or invoke this skill automatically.
 
-7. Run live host probes through the normal command tool that Codex selected for the current task. Do not read a real sensitive file.
+8. Run live host probes through the normal command tool that Codex selected for the current task. Do not read a real sensitive file.
    - Pre-tool probe:
 
      ```sh
@@ -71,7 +81,7 @@ Make Agent Guard operational without silently changing the machine. Diagnose fir
      The raw marker must not reach the model; expect `[REDACTED]` in a masked or sanitized replacement. These sentinels prove host dispatch without reading a sensitive file or printing a credential-shaped value; the plugin-local smoke test separately proves the real detection rules.
    - If Codex exposes only a wrapping/orchestration tool such as `functions.exec`, test that exact route. Agent Guard cannot replace or wrap Codex's host executor; it can protect only nested calls that Codex exposes to plugin hooks. If either probe bypasses the hook, report the route as unsupported in the current host instead of claiming successful setup.
 
-8. After dependency, enablement, or trust changes, restart Codex and run both live probes again in a new task. In Codex, plugin hooks provide the supported command boundary; do not configure Claude-specific command wrapping as a Codex setup step.
+9. After dependency, enablement, or trust changes, restart Codex and run both live probes again in a new task. In Codex, plugin hooks provide the supported command boundary; do not configure Claude-specific command wrapping as a Codex setup step.
 
 ## Safety And Host Boundaries
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -88,6 +88,20 @@ cleanup() {
 trap cleanup EXIT INT TERM
 
 mkdir -p "$MOCK_BIN"
+
+setup_shell_command="$PLUGIN_ROOT/commands/setup-shell.md"
+if grep -Eq '^!`' "$setup_shell_command"; then
+  not_ok "setup-shell slash command avoids unapprovable shell interpolation"
+else
+  ok "setup-shell slash command avoids unapprovable shell interpolation"
+fi
+if grep -Fq 'Use the Bash tool' "$setup_shell_command" \
+  && grep -Fq 'outside the sandbox' "$setup_shell_command" \
+  && grep -Fq 'directly in their terminal' "$setup_shell_command"; then
+  ok "setup-shell slash command documents the approval and terminal fallback"
+else
+  not_ok "setup-shell slash command documents the approval and terminal fallback"
+fi
 cp "$ROOT/tests/fixtures/mock-gitleaks" "$MOCK_BIN/gitleaks"
 chmod +x "$MOCK_BIN/gitleaks"
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -236,6 +236,10 @@ if grep -Fq '../../bin/agent-guard' "$setup_skill" \
    && grep -Fq 'AGENT_GUARD_LIVE_POST_TOOL_PROBE' "$setup_skill" \
    && ! grep -Fq 'cat .env' "$setup_skill" \
    && grep -Fq '`functions.exec`' "$setup_skill" \
+   && grep -Fq 'blocked by the host sandbox' "$setup_skill" \
+   && grep -Fq 'Do not retry the same blocked write' "$setup_skill" \
+   && grep -Fq 'run in a separate terminal' "$setup_skill" \
+   && grep -Fq 'rerun the read-only' "$setup_skill" \
    && grep -Fq 'They do not prove that the host is dispatching plugin hooks' "$setup_skill"; then
   ok "Codex setup skill verifies plugin-local, trust, and live-hook layers"
 else


### PR DESCRIPTION
## Summary

- replace `/agent-guard:setup-shell` command interpolation with an approval-capable Bash tool call
- document the direct-terminal fallback for hosts that cannot grant shell-rc write access
- make `$setup-agent-guard` hand approved dependency installs off to a separate terminal when the host sandbox still blocks the destination
- add regression coverage that prevents reintroducing unapprovable `!` interpolation

## Root cause

The slash command used `!` command interpolation to run `agent-guard setup-shell`. Claude evaluates that interpolation inside its sandbox before the command can request permission. `setup-shell` intentionally creates a temporary file beside the target shell rc for an atomic rename, so the sandbox rejects the write in the user's home directory.

Moving only the temporary file would not fix the issue because the final shell-rc update also requires home-directory write access. Using the Bash tool lets Claude surface the required approval; hosts that cannot do so now report the exact direct-terminal fallback.

The guided setup skill can encounter the same host boundary when an approved dependency install writes to `~/.agent-guard/bin`. It now preserves the approved command, requires an explicit terminal handoff instead of retrying or relocating the install, and resumes only after a read-only diagnosis reports the dependency as ready.

## User impact

`/agent-guard:setup-shell` no longer fails immediately with `failed to create temp file` merely because command interpolation cannot request sandbox approval. The underlying atomic shell-rc update and its idempotency remain unchanged.

## Functional verification

- `make test` — 450 passed, 0 failed
- `scripts/validate-plugin-layout.sh --all` — passed
- `git diff --check` — passed
- reproduced the original failure with the v3.0.0 plugin command under a home-write-restricted sandbox
- confirmed direct `setup-shell`, `check`, and `smoke-test` succeed outside that restricted target; the updated Claude approval UI could not be exercised from Codex because the Anthropic API domain was blocked by the local network allowlist

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified shell setup behavior when sandbox approval is required.
  * Added terminal fallback instructions if approval cannot be granted.
  * Expanded setup guidance for blocked dependency installation and safe retry procedures.
  * Clarified workflow sequencing for setup verification and live probes.

* **Tests**
  * Added checks confirming shell setup documentation includes approval and fallback guidance.
  * Expanded setup documentation validation for sandbox-blocked operations and terminal recovery steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->