### PR TITLE
fix(detection): narrow lockfile checksums and output redaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@
   `AGENT_GUARD_INFRA_FAILURE_MODE=open|closed` (default `open`). Hooks, `agx`,
   and transparent Claude command wrapping now warn once per session and follow
   the same selected policy; actual secret detections still always block.
+- fix(detection): allow recognized checksum fields in `go.sum`,
+  `package-lock.json`, `yarn.lock`, `Cargo.lock`, and `uv.lock` only when both
+  the lockfile path and checksum-line shape match. Other lockfile content,
+  including embedded credentials, remains scannable.
+- fix(redaction): mask only the value token of a complete secret-bearing
+  assignment. Metadata keys such as `password_policy`, prose such as
+  `error: password: ...`, and text adjacent to a real value are preserved.
 - fix(hooks): report a scan that could not run distinctly from a detection
   (#137). A scanner precondition failure and a real detection previously looked
   identical — both printed and exited 2 — so an operator could not tell whether

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@
 - fix(redaction): mask only the value token of a complete secret-bearing
   assignment. Metadata keys such as `password_policy`, prose such as
   `error: password: ...`, and text adjacent to a real value are preserved.
+  Suffix-qualified credential keys (`AWS_SECRET_ACCESS_KEY_ID`,
+  `API_KEY_VALUE`, `DB_PASSWORD_HASH`) and whitespace-prefixed colon
+  assignments in log lines still mask.
 - fix(hooks): report a scan that could not run distinctly from a detection
   (#137). A scanner precondition failure and a real detection previously looked
   identical — both printed and exited 2 — so an operator could not tell whether

--- a/README.md
+++ b/README.md
@@ -351,9 +351,15 @@ To enable it, add an Actions secret named `OPENAI_API_KEY` in the GitHub reposit
 
 Patch and diff scans inspect added lines only. Removing an existing leaked value is allowed.
 
+Dependency checksums are exempt only for recognized hash-field shapes in
+`go.sum`, `package-lock.json`, `yarn.lock`, `Cargo.lock`, and `uv.lock`. The
+allowlist requires both the lockfile path and the checksum pattern; arbitrary
+content in those files, including a credential added beside normal hashes, is
+still scanned.
+
 ## What Gets Masked
 
-Beyond blocking, Agent Guard **masks** secret-like values in a matched tool's output before the model sees them. Claude uses the native `updatedToolOutput` rewrite and preserves the result shape. Codex does not expose that Claude field, so Agent Guard blocks the original sensitive result and supplies a sanitized replacement through `additionalContext`. Detection combines gitleaks with a `KEY=value` env-assignment heuristic. It is on by default; disable with `AGENT_GUARD_OUTPUT_REDACT=off`.
+Beyond blocking, Agent Guard **masks** secret-like values in a matched tool's output before the model sees them. Claude uses the native `updatedToolOutput` rewrite and preserves the result shape. Codex does not expose that Claude field, so Agent Guard blocks the original sensitive result and supplies a sanitized replacement through `additionalContext`. Detection combines gitleaks with an assignment-value heuristic. The heuristic masks only the quoted value or next unquoted value token of a complete secret-bearing key; it does not mask metadata keys merely beginning with a secret word, prose after an ambiguous colon, or adjacent status text. It is on by default; disable with `AGENT_GUARD_OUTPUT_REDACT=off`.
 
 With `AGENT_GUARD_PII_HOOK_MODE=mask`, the same `PostToolUse` redactor also masks **PII** in tool output — email, phone (including Korean mobile), IPv4, credit card, US SSN, and Korean resident registration number become `[PII:TYPE]` placeholders in place. Secret redaction and PII masking compose into a single rewrite, so a result containing both is fully sanitized at once.
 

--- a/plugins/agent-guard/README.md
+++ b/plugins/agent-guard/README.md
@@ -68,6 +68,12 @@ The Claude plugin registers:
 - `SessionStart` to report missing dependencies and, on Claude Code,
   shell-integration version drift. It never installs software.
 
+Recognized checksum fields in `go.sum`, `package-lock.json`, `yarn.lock`,
+`Cargo.lock`, and `uv.lock` are allowlisted only when both their path and exact
+hash-line shape match. Other content in those files remains subject to normal
+secret detection. Output masking likewise replaces assignment values, not
+secret-like key names or surrounding prose.
+
 Default processing is local, ephemeral, and has no telemetry. PII hook handling
 is off by default. Selecting the optional `pleno` or `http` PII provider sends
 the text described in [PRIVACY.md](PRIVACY.md) to the user-configured endpoint.

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -2206,15 +2206,21 @@ secretish_env_values() {
   awk '
     BEGIN {
       core = "password|passwd|passphrase|db[_-]?pass(word)?|secret|secret[_-]?key|token|refresh[_-]?token|auth[_-]?token|session[_-]?key|api[_-]?key|access[_-]?key|private[_-]?key|signing[_-]?key|encryption[_-]?key|credential|client[_-]?secret|bearer|webhook"
-      # Match complete assignment keys that END in a secret-bearing term.
-      # Arbitrary suffixes such as password_policy or token_name are metadata,
-      # not values to redact. Bare PATH/PWD remain excluded; compound _pat/_pwd
-      # keys keep their intended coverage.
-      key = "[a-z0-9_.-]*(" core "|[_-](pat|pwd))"
+      # Match assignment keys whose secret-bearing term is terminal or carries
+      # only a bounded qualifier suffix (AWS_ACCESS_KEY_ID, API_KEY_VALUE,
+      # DB_PASSWORD_HASH). An unbounded suffix over-masked metadata keys such
+      # as password_policy or token_name; no suffix at all dropped these very
+      # common real-credential names. Bare PATH/PWD remain excluded; compound
+      # _pat/_pwd keys keep their intended coverage.
+      qualifier = "([_-](id|ids|value|val|hash|b64|base64|hex|enc|encrypted|encoded|raw|str|string|prod|production|dev|development|staging|stage|test|local|old|new|current|primary|secondary|backup|main|default|[0-9]+))*"
+      key = "[a-z0-9_.-]*(" core "|[_-](pat|pwd))" qualifier
       equals_assignment = "(^|[ \t,{;])[\"'\''`]?" key "[\"'\''`]?[ \t]*="
-      # A colon is ambiguous in prose. Accept it only at the start of a YAML
-      # field or after a JSON/map delimiter, never after arbitrary text.
-      colon_assignment = "(^[ \t]*|[,{][ \t]*)[\"'\''`]?" key "[\"'\''`]?[ \t]*:"
+      # A colon is ambiguous in prose. Accept it at the start of a YAML field,
+      # after a JSON/map delimiter, or after plain whitespace (log lines such as
+      # `10:00:00 password: hunter2`); the loop below rejects the whitespace
+      # form when the preceding token itself ends in a colon, which marks a
+      # prose chain like `error: password: authentication is disabled`.
+      colon_assignment = "(^[ \t]*|[,{][ \t]*|[ \t]+)[\"'\''`]?" key "[\"'\''`]?[ \t]*:"
     }
     function emit_value(source, start, raw, quote, end, value) {
       raw = substr(source, start)
@@ -2244,16 +2250,28 @@ secretish_env_values() {
 
         start = eq_start
         matched_length = eq_length
+        chose_colon = 0
         if (colon_start > 0 && (start == 0 || colon_start < start)) {
           start = colon_start
           matched_length = colon_length
+          chose_colon = 1
         }
         if (start == 0) break
+
+        # Whitespace-prefixed colon form: if the previous non-space character
+        # is itself a colon, this is a prose chain (`error: password: ...`),
+        # not an assignment — skip past the key without masking.
+        skip = 0
+        if (chose_colon && start > 1) {
+          first = substr(rest, start, 1)
+          if ((first == " " || first == "\t") && substr(rest, start - 1, 1) == ":")
+            skip = 1
+        }
 
         # Emit exactly the quoted value or the next unquoted token. Continuing
         # after the delimiter finds multiple assignments on one log line while
         # leaving adjacent status text untouched.
-        emit_value(rest, start + matched_length)
+        if (!skip) emit_value(rest, start + matched_length)
         rest = substr(rest, start + matched_length)
       }
     }

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -815,11 +815,88 @@ run_gitleaks_stdin() {
   return 2
 }
 
+# Filter records encoded as one lockfile-kind byte, a tab, then the original
+# line. Keeping the checksum grammar in one place prevents staged diffs, host
+# writes, untracked files, and path scans from drifting apart.
+filter_lockfile_records() {
+  awk '
+    {
+      kind = substr($0, 1, 1)
+      line = substr($0, 3)
+      if (kind == "g" && line ~ /^[^[:space:]]+[[:space:]]+[^[:space:]]+[[:space:]]+h1:[A-Za-z0-9+\/]{43}=$/) next
+      if (kind == "p" && line ~ /^[[:space:]]*"integrity"[[:space:]]*:[[:space:]]*"(sha1-[A-Za-z0-9+\/]{27}=|sha256-[A-Za-z0-9+\/]{43}=|sha384-[A-Za-z0-9+\/]{64}|sha512-[A-Za-z0-9+\/]{86}==)"[,]?[[:space:]]*$/) next
+      if (kind == "y" && (line ~ /^[[:space:]]*integrity[[:space:]]+(sha1-[A-Za-z0-9+\/]{27}=|sha256-[A-Za-z0-9+\/]{43}=|sha384-[A-Za-z0-9+\/]{64}|sha512-[A-Za-z0-9+\/]{86}==)[[:space:]]*$/ || line ~ /^[[:space:]]*checksum:[[:space:]]*[0-9a-f]{64}[[:space:]]*$/)) next
+      if (kind == "c" && line ~ /^[[:space:]]*checksum[[:space:]]*=[[:space:]]*"[0-9a-f]{64}"[[:space:]]*$/) next
+      if (kind == "u" && (line ~ /^[[:space:]]*hash[[:space:]]*=[[:space:]]*"sha256:[0-9a-f]{64}"[,]?[[:space:]]*$/ || line ~ /^[[:space:]]*(sdist[[:space:]]*=[[:space:]]*)?\{[[:space:]]*url[[:space:]]*=[[:space:]]*"[^"]+"[[:space:]]*,[[:space:]]*hash[[:space:]]*=[[:space:]]*"sha256:[0-9a-f]{64}"[[:space:]]*,[[:space:]]*size[[:space:]]*=[[:space:]]*[0-9]+[[:space:]]*\}[,]?[[:space:]]*$/)) next
+      print line
+    }
+  '
+}
+
+# Gitleaks' bundled defaults skip common lockfiles by path. Agent Guard rescans
+# them through stdin after removing only exact checksum-field lines; this both
+# fixes checksum false positives and keeps credentials elsewhere detectable.
+filter_lockfile_hashes() {
+  path=$1
+  source=${2:-$path}
+  case "${path##*/}" in
+    go.sum) kind=g ;;
+    package-lock.json) kind=p ;;
+    yarn.lock) kind=y ;;
+    Cargo.lock) kind=c ;;
+    uv.lock) kind=u ;;
+    *) cat -- "$source"; return ;;
+  esac
+  awk -v kind="$kind" '{ print kind "\t" $0 }' "$source" | filter_lockfile_records
+}
+
+scan_lockfiles_under() {
+  root=$1
+  label=$2
+  blob=$(mktemp_file) || die "failed to create temp file"
+  find "$root" -type f \( \
+      -name go.sum -o -name package-lock.json -o -name yarn.lock -o \
+      -name Cargo.lock -o -name uv.lock \
+    \) -exec "$SELF_BIN" filter-lockfile-hashes '{}' '{}' \; >"$blob"
+  find_status=$?
+  if [ "$find_status" -ne 0 ]; then
+    rm -f "$blob"
+    info "$PROGRAM: failed to prepare lockfiles in $label"
+    return 2
+  fi
+  if [ ! -s "$blob" ]; then
+    rm -f "$blob"
+    return 0
+  fi
+  run_gitleaks_stdin "$label lockfile content" <"$blob"
+  status=$?
+  rm -f "$blob"
+  return "$status"
+}
+
 scan_text_direct() {
   label=$1
   text=$2
   [ -n "$text" ] || return 0
   printf '%s\n' "$text" | run_gitleaks_stdin "$label"
+}
+
+# Remove only recognized lockfile checksum fields before scanning proposed file
+# content. The logical path controls the exception; the temporary filename does
+# not, so the same checksum-shaped text in any other file remains detectable.
+scan_file_text_direct() {
+  label=$1
+  path=$2
+  text=$3
+  [ -n "$text" ] || return 0
+  [ -n "$path" ] || { scan_text_direct "$label" "$text"; return $?; }
+
+  source=$(mktemp_file) || die "failed to create temp file"
+  printf '%s\n' "$text" >"$source"
+  filter_lockfile_hashes "$path" "$source" | run_gitleaks_stdin "$label"
+  status=$?
+  rm -f "$source"
+  return "$status"
 }
 
 # Scan status protocol, shared by every scan_* function and this dispatcher:
@@ -847,43 +924,58 @@ block_on_scan_status() {
   esac
 }
 
+# Extract only added diff lines, dropping exact checksum fields only when the
+# diff header identifies one of the supported lockfiles.
 extract_added_lines() {
-  # Track hunk state so a file header (`+++ b/path`, before the first `@@`) is
-  # told apart from added CONTENT by position, not by shape. Matching `+++ ` by
-  # shape dropped any added line whose own content began with `++ ` — git
-  # prefixes it with one more `+`, so `++ SECRET` arrived as `+++ SECRET` and
-  # slipped past the scanner. Only `+` lines inside a hunk are additions.
   awk '
-    /^diff --git / { in_hunk = 0; next }
+    function lockfile_kind(path, parts, count, name) {
+      count = split(path, parts, "/")
+      name = parts[count]
+      if (name == "go.sum") return "g"
+      if (name == "package-lock.json") return "p"
+      if (name == "yarn.lock") return "y"
+      if (name == "Cargo.lock") return "c"
+      if (name == "uv.lock") return "u"
+      return "-"
+    }
+    /^diff --git / { in_hunk = 0; path = ""; next }
+    !in_hunk && /^\+\+\+ b\// { path = substr($0, 7); next }
     /^@@/ { in_hunk = 1; next }
-    in_hunk && /^\+/ { sub(/^\+/, ""); print }
-  '
+    in_hunk && /^\+/ { print lockfile_kind(path) "\t" substr($0, 2) }
+  ' | filter_lockfile_records
 }
-
 # Extract lines introduced by Codex apply_patch envelopes or unified diffs.
 extract_patch_added_lines() {
   awk '
-    BEGIN { mode = "none" }
-    /^\*\*\* Begin Patch/ { mode = "none"; next }
-    /^\*\*\* End Patch/ { mode = "none"; next }
-    /^\*\*\* Add File:/ { mode = "add"; next }
-    /^\*\*\* Update File:/ { mode = "update"; next }
-    /^\*\*\* Delete File:/ { mode = "none"; next }
+    function lockfile_kind(path, parts, count, name) {
+      count = split(path, parts, "/")
+      name = parts[count]
+      if (name == "go.sum") return "g"
+      if (name == "package-lock.json") return "p"
+      if (name == "yarn.lock") return "y"
+      if (name == "Cargo.lock") return "c"
+      if (name == "uv.lock") return "u"
+      return "-"
+    }
+    BEGIN { mode = "none"; in_hunk = 0 }
+    /^\*\*\* Begin Patch/ { mode = "none"; in_hunk = 0; next }
+    /^\*\*\* End Patch/ { mode = "none"; in_hunk = 0; next }
+    /^\*\*\* Add File:/ { path = $0; sub(/^\*\*\* Add File:[ \t]*/, "", path); mode = "add"; next }
+    /^\*\*\* Update File:/ { path = $0; sub(/^\*\*\* Update File:[ \t]*/, "", path); mode = "update"; next }
+    /^\*\*\* Delete File:/ { mode = "none"; path = ""; in_hunk = 0; next }
     /^\*\*\* End of File/ { next }
-    /^diff --git / { in_hunk = 0; next }
-    /^@@/ { in_hunk = 1; next }
+    /^diff --git / { if (mode == "none") in_hunk = 0; next }
+    /^@@/ { if (mode == "none") in_hunk = 1; next }
     {
       if (mode == "add") {
         line = $0
         sub(/^\+/, "", line)
-        print line
+        print lockfile_kind(path) "\t" line
         next
       }
       if (mode == "update") {
-        if (substr($0, 1, 1) == "+") {
-          line = substr($0, 2)
-          print line
-        }
+        if (substr($0, 1, 1) == "+")
+          print lockfile_kind(path) "\t" substr($0, 2)
         next
       }
       # Fallback: treat as a unified diff hunk. Tell a `+++ b/path` file header
@@ -891,15 +983,16 @@ extract_patch_added_lines() {
       # shape — matching `+++ ` by shape dropped any added line whose own content
       # began with `++ `, which git prefixes to `+++ SECRET`. Only `+` lines
       # inside a hunk are additions.
+      if (!in_hunk && /^\+\+\+ b\//) { path = substr($0, 7); next }
+      if (!in_hunk && /^\+\+\+ /) next
       if (in_hunk && /^\+/) {
         line = $0
         sub(/^\+/, "", line)
-        print line
+        print lockfile_kind(path) "\t" line
       }
     }
-  '
+  ' | filter_lockfile_records
 }
-
 inside_git_repo() {
   git rev-parse --is-inside-work-tree >/dev/null 2>&1
 }
@@ -961,20 +1054,31 @@ scan_untracked_files() {
     return 0
   fi
 
-  # Stream every untracked file through a single gitleaks stdin call. The
-  # "### file: <path>" header keeps a finding's context pointing at its file
-  # while holding the gitleaks process count at O(1). xargs -0 drives the
-  # NUL-delimited list because POSIX `read` cannot split on NUL.
+  # Stream every untracked file through one gitleaks stdin call. Exact checksum
+  # fields are removed only for supported lockfile basenames; all other content
+  # from those files, including credentials, remains in the stream.
   blob=$(mktemp_file) || { rm -f "$list"; die "failed to create temp file"; }
   xargs -0 -I '{}' sh -c '
     cd "$0" 2>/dev/null || exit 0
     f=$1
+    filter=$2
     [ -f "$f" ] || exit 0
     printf "### file: %s\n" "$f"
-    cat -- "$f"
+    case "${f##*/}" in
+      go.sum|package-lock.json|yarn.lock|Cargo.lock|uv.lock)
+        "$filter" filter-lockfile-hashes "$f" "$f"
+        ;;
+      *) cat -- "$f" ;;
+    esac
     printf "\n"
-  ' "$root" '{}' >>"$blob" <"$list"
+  ' "$root" '{}' "$SELF_BIN" >>"$blob" <"$list"
+  prepare_status=$?
   rm -f "$list"
+  if [ "$prepare_status" -ne 0 ]; then
+    rm -f "$blob"
+    info "$PROGRAM: failed to prepare untracked files for scanning"
+    return 2
+  fi
 
   if [ ! -s "$blob" ]; then
     rm -f "$blob"
@@ -1051,13 +1155,8 @@ scan_path() {
         info "$PROGRAM: gitleaks reported an error while scanning path: $path"
         sed 's/^/  /' "$out" >&2
         result=2
-        rm -f "$out"
-        continue
       fi
-      rm -f "$out"
-      continue
-    fi
-    if [ "$status" -eq 1 ]; then
+    elif [ "$status" -eq 1 ]; then
       info "$PROGRAM: secret-like value detected in path: $path"
       sed 's/^/  /' "$out" >&2
       [ "$result" -eq 0 ] && result=1
@@ -1067,6 +1166,14 @@ scan_path() {
       result=2
     fi
     rm -f "$out"
+
+    scan_lockfiles_under "$path" "path: $path"
+    status=$?
+    case "$status" in
+      0) ;;
+      1) [ "$result" -eq 0 ] && result=1 ;;
+      *) result=2 ;;
+    esac
   done
   return "$result"
 }
@@ -1929,23 +2036,27 @@ scan_proposed_write() {
 
   case "$tool" in
     Write)
+      path=$(json_value '.tool_input.file_path // .tool_input.path // empty' "$input")
       content=$(json_value '.tool_input.content // empty' "$input")
-      scan_text_direct "proposed Write content" "$content"
+      scan_file_text_direct "proposed Write content" "$path" "$content"
       block_on_scan_status "$?" "proposed Write contains secret-like values"
       ;;
     Edit)
+      path=$(json_value '.tool_input.file_path // .tool_input.path // empty' "$input")
       content=$(json_value '.tool_input.new_string // empty' "$input")
-      scan_text_direct "proposed Edit content" "$content"
+      scan_file_text_direct "proposed Edit content" "$path" "$content"
       block_on_scan_status "$?" "proposed Edit contains secret-like values"
       ;;
     MultiEdit)
+      path=$(json_value '.tool_input.file_path // .tool_input.path // empty' "$input")
       content=$(printf '%s' "$input" | jq -r '[.tool_input.edits[]?.new_string // empty] | join("\n")')
-      scan_text_direct "proposed MultiEdit content" "$content"
+      scan_file_text_direct "proposed MultiEdit content" "$path" "$content"
       block_on_scan_status "$?" "proposed MultiEdit contains secret-like values"
       ;;
     NotebookEdit)
+      path=$(json_value '.tool_input.notebook_path // .tool_input.file_path // empty' "$input")
       content=$(json_value '.tool_input.new_source // empty' "$input")
-      scan_text_direct "proposed NotebookEdit content" "$content"
+      scan_file_text_direct "proposed NotebookEdit content" "$path" "$content"
       block_on_scan_status "$?" "proposed NotebookEdit contains secret-like values"
       ;;
     apply_patch)
@@ -2093,27 +2204,57 @@ output_redact_enabled() {
 # of these (custom value formats), so emit the VALUE for literal redaction.
 secretish_env_values() {
   awk '
+    BEGIN {
+      core = "password|passwd|passphrase|db[_-]?pass(word)?|secret|secret[_-]?key|token|refresh[_-]?token|auth[_-]?token|session[_-]?key|api[_-]?key|access[_-]?key|private[_-]?key|signing[_-]?key|encryption[_-]?key|credential|client[_-]?secret|bearer|webhook"
+      # Match complete assignment keys that END in a secret-bearing term.
+      # Arbitrary suffixes such as password_policy or token_name are metadata,
+      # not values to redact. Bare PATH/PWD remain excluded; compound _pat/_pwd
+      # keys keep their intended coverage.
+      key = "[a-z0-9_.-]*(" core "|[_-](pat|pwd))"
+      equals_assignment = "(^|[ \t,{;])[\"'\''`]?" key "[\"'\''`]?[ \t]*="
+      # A colon is ambiguous in prose. Accept it only at the start of a YAML
+      # field or after a JSON/map delimiter, never after arbitrary text.
+      colon_assignment = "(^[ \t]*|[,{][ \t]*)[\"'\''`]?" key "[\"'\''`]?[ \t]*:"
+    }
+    function emit_value(source, start, raw, quote, end, value) {
+      raw = substr(source, start)
+      sub(/^[ \t]+/, "", raw)
+      quote = substr(raw, 1, 1)
+      if (quote == "\"" || quote == "'\''" || quote == "`") {
+        raw = substr(raw, 2)
+        end = index(raw, quote)
+        if (end == 0) return
+        value = substr(raw, 1, end - 1)
+      } else {
+        value = raw
+        sub(/[ \t,;].*$/, "", value)
+      }
+      if (length(value) >= 4) print value
+    }
     {
-      low = tolower($0)
-      # Anchor the value to the delimiter that follows the matched key, not the
-      # first [=:] on the line — a log/timestamp prefix (e.g. "12:00:00") would
-      # otherwise hijack the split and mis-slice the value. tolower preserves
-      # byte offsets for ASCII, so RSTART/RLENGTH from `low` apply to $0.
-      #
-      # Two matchers, OR-ed so RSTART/RLENGTH come from whichever hits:
-      #  1. distinctive secret-bearing key words (safe as bare prefixes).
-      #  2. short ambiguous abbreviations `pat`/`pwd` — matched ONLY as a
-      #     compound-key suffix (preceded by _ or -, e.g. github_pat, db_pwd) AND
-      #     ending right at the delimiter, so the ubiquitous bare shell vars
-      #     PATH= / PWD= (directory paths) and benign compounds like NODE_PATH= /
-      #     FILE_PATTERN= do NOT get masked. No word-boundary metachar exists in
-      #     portable ERE, hence the explicit leading [_-] anchor and the absence
-      #     of a trailing [a-z0-9_]* run before the delimiter.
-      if (match(low, /(password|passwd|passphrase|db[_-]?pass(word)?|secret|token|refresh[_-]?token|auth[_-]?token|session[_-]?key|api[_-]?key|access[_-]?key|private[_-]?key|signing[_-]?key|encryption[_-]?key|credential|client[_-]?secret|bearer|webhook)[a-z0-9_]*[ \t]*[=:]/) || match(low, /[_-](pat|pwd)[ \t]*[=:]/)) {
-        val = substr($0, RSTART + RLENGTH)
-        gsub(/^[ \t"'\''`]+/, "", val)
-        gsub(/[ \t"'\''`,;]+$/, "", val)
-        if (length(val) >= 4) print val
+      rest = $0
+      while (length(rest) > 0) {
+        low = tolower(rest)
+        match(low, equals_assignment)
+        eq_start = RSTART
+        eq_length = RLENGTH
+        match(low, colon_assignment)
+        colon_start = RSTART
+        colon_length = RLENGTH
+
+        start = eq_start
+        matched_length = eq_length
+        if (colon_start > 0 && (start == 0 || colon_start < start)) {
+          start = colon_start
+          matched_length = colon_length
+        }
+        if (start == 0) break
+
+        # Emit exactly the quoted value or the next unquoted token. Continuing
+        # after the delimiter finds multiple assignments on one log line while
+        # leaving adjacent status text untouched.
+        emit_value(rest, start + matched_length)
+        rest = substr(rest, start + matched_length)
       }
     }
   '
@@ -3019,6 +3160,7 @@ case "$cmd" in
   scan-staged) shift; scan_staged "$@" ;;
   scan-working-tree) shift; scan_working_tree "$@" ;;
   scan-path) shift; scan_path "$@" ;;
+  filter-lockfile-hashes) shift; filter_lockfile_hashes "$@" ;;
   check) check_deps ;;
   setup) shift; do_setup "$@" ;;
   setup-shell) shift; do_setup_shell "$@" ;;

--- a/plugins/agent-guard/config/gitleaks.toml
+++ b/plugins/agent-guard/config/gitleaks.toml
@@ -43,3 +43,12 @@ regexes = [
   '''(?i)^[A-Za-z0-9]*x{12,}[A-Za-z0-9]*$''',
   '''^0{12,}$'''
 ]
+
+# Directory scans skip these exact lockfile names, then agent-guard rescans
+# their non-checksum content through stdin. This avoids checksum false positives
+# without allowing credentials elsewhere in a lockfile.
+[[allowlists]]
+description = "Lockfiles rescanned after exact checksum fields are removed"
+paths = [
+  '''(^|/)(go\.sum|package-lock\.json|yarn\.lock|Cargo\.lock|uv\.lock)$'''
+]

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -3988,6 +3988,53 @@ else
   sed 's/^/  out: /' "$OUT"
 fi
 
+# Suffix-qualified real credential keys must still mask: requiring the secret
+# term to be terminal dropped AWS_*_KEY_ID / *_VALUE / *_HASH names entirely.
+for display_case in \
+  'AWS_SECRET_ACCESS_KEY_ID=wJalrX-fake-example-key-id' \
+  'API_KEY_VALUE=supersecret-value-9876' \
+  'DB_PASSWORD_HASH=deadbeefdeadbeefcafe'; do
+  display_key=${display_case%%=*}
+  display_val=${display_case#*=}
+  display_input=$(jq -nc --arg stdout "$display_case" \
+    '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
+  post_tool_out "$display_input"
+  post_out=$(cat "$OUT")
+  if printf '%s' "$post_out" | grep -q '\[REDACTED\]' \
+     && ! printf '%s' "$post_out" | grep -Fq "$display_val"; then
+    ok "post-tool masks suffix-qualified credential key $display_key"
+  else
+    not_ok "post-tool masks suffix-qualified credential key $display_key"
+    printf '%s\n' "$post_out" | sed 's/^/  out: /'
+  fi
+done
+
+# A colon assignment after plain whitespace (a timestamped log line) is a real
+# leak, not prose: only the value token is masked, the timestamp survives.
+display_input=$(jq -nc --arg stdout '2026-07-26 10:00:00 password: hunter2-timestamped-value' \
+  '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
+post_tool_out "$display_input"
+post_out=$(cat "$OUT")
+if printf '%s' "$post_out" | grep -q '\[REDACTED\]' \
+   && printf '%s' "$post_out" | grep -q '2026-07-26 10:00:00' \
+   && ! printf '%s' "$post_out" | grep -q 'hunter2-timestamped-value'; then
+  ok "post-tool masks a whitespace-prefixed colon assignment in a log line"
+else
+  not_ok "post-tool masks a whitespace-prefixed colon assignment in a log line"
+  printf '%s\n' "$post_out" | sed 's/^/  out: /'
+fi
+
+# Control: a word merely containing a secret term with a non-qualifier tail
+# (tokenizer) is not an assignment key.
+post_tool_out '{"tool_name":"Bash","tool_input":{"command":"x"},"tool_response":{"stdout":"tokenizer=whitespace-mode\n","stderr":"","interrupted":false,"isImage":false}}'
+post_status=$?
+if [ "$post_status" -eq 0 ] && [ ! -s "$OUT" ]; then
+  ok "post-tool does not mask non-credential words that merely contain a secret term"
+else
+  not_ok "post-tool leaves tokenizer=... untouched"
+  sed 's/^/  out: /' "$OUT"
+fi
+
 post_tool_out '{"tool_name":"Read","tool_input":{"file_path":"memo.txt"},"tool_response":"API_KEY=supersecretvalue123\n"}'
 post_out=$(cat "$OUT")
 if printf '%s' "$post_out" | jq -e '.hookSpecificOutput.updatedToolOutput | type == "string"' >/dev/null 2>&1 \

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1359,6 +1359,8 @@ fi
   git reset -q
   rm -f staged.txt untracked.txt
   printf '%s\n' "++ AGENT_GUARD_TEST_SECRET" > plusplus.txt
+  sed 's|^++ |++ b/|' plusplus.txt > plusplus.tmp
+  mv plusplus.tmp plusplus.txt
   git add plusplus.txt
   "$PLUGIN_ROOT/bin/agent-guard" scan-staged >"$OUT" 2>"$ERR"
 )
@@ -3741,6 +3743,119 @@ if [ -n "$REAL_GITLEAKS" ]; then
     not_ok "shape rule leaves x-run and AWS-docs EXAMPLE placeholders alone (expected 0, got $status)"
     sed 's/^/  stderr: /' "$ERR"
   fi
+
+  # Lockfile checksum allowlists are path + field combinations. A go.sum line
+  # whose module name ends in `api` reproduces the default generic-api-key false
+  # positive, while the identical line outside go.sum and a credential mixed
+  # into go.sum must remain findings.
+  LOCK_SUM=$(printf '%s%s%s' 'h1:QmvMAjj2aEICy' 'tGiWzmxoE0x2KZvE' '0fvmqMOfy2tjT8=')
+  LOCK_B64=${LOCK_SUM#h1:}
+  LOCK_B64_BODY=${LOCK_B64%=}
+  LOCK_SHA512="${LOCK_B64_BODY}${LOCK_B64_BODY}=="
+  LOCK_SECRET=$(printf '%s%s' 'A1b2C3d4E5f6G7h8' 'I9j0K1l2M3n4O5p6')
+  LOCK_HEX=$(printf '%s%s' '0123456789abcdef0123456789abcdef' 'fedcba9876543210fedcba9876543210')
+  LOCKFILE_FIXTURE_DIR="$TMP_ROOT/lockfile-hash-dir"
+  mkdir -p "$LOCKFILE_FIXTURE_DIR"
+  printf 'example.com/clientapi v1.2.3 %s\n' "$LOCK_SUM" >"$LOCKFILE_FIXTURE_DIR/go.sum"
+  printf '  "integrity": "sha512-%s"\n' "$LOCK_SHA512" >"$LOCKFILE_FIXTURE_DIR/package-lock.json"
+  printf '  integrity sha512-%s\n' "$LOCK_SHA512" >"$LOCKFILE_FIXTURE_DIR/yarn.lock"
+  printf 'checksum = "%s"\n' "$LOCK_HEX" >"$LOCKFILE_FIXTURE_DIR/Cargo.lock"
+  printf 'hash = "sha256:%s"\n' "$LOCK_HEX" >"$LOCKFILE_FIXTURE_DIR/uv.lock"
+  PATH="$(dirname "$REAL_GITLEAKS"):$ORIGINAL_PATH" "$PLUGIN_ROOT/bin/agent-guard" \
+    scan-path "$LOCKFILE_FIXTURE_DIR" >"$OUT" 2>"$ERR"
+  status=$?
+  if [ "$status" -eq 0 ]; then
+    ok "lockfile checksum fields are exempt only in recognized lockfile paths"
+  else
+    not_ok "recognized lockfile checksum fields stay clean (expected 0, got $status)"
+    sed 's/^/  stderr: /' "$ERR"
+  fi
+
+  cp "$LOCKFILE_FIXTURE_DIR/go.sum" "$TMP_ROOT/safe-go-sum"
+  printf 'api_token = "%s"\n' "$LOCK_SECRET" >>"$LOCKFILE_FIXTURE_DIR/go.sum"
+  PATH="$(dirname "$REAL_GITLEAKS"):$ORIGINAL_PATH" "$PLUGIN_ROOT/bin/agent-guard" \
+    scan-path "$LOCKFILE_FIXTURE_DIR/go.sum" >"$OUT" 2>"$ERR"
+  status=$?
+  if [ "$status" -eq 1 ]; then
+    ok "scan-path still detects a credential mixed into a recognized lockfile"
+  else
+    not_ok "scan-path keeps non-checksum lockfile content scannable (expected 1, got $status)"
+  fi
+  cp "$TMP_ROOT/safe-go-sum" "$LOCKFILE_FIXTURE_DIR/go.sum"
+
+  cp "$LOCKFILE_FIXTURE_DIR/go.sum" "$LOCKFILE_FIXTURE_DIR/not-a-lockfile.txt"
+  PATH="$(dirname "$REAL_GITLEAKS"):$ORIGINAL_PATH" "$PLUGIN_ROOT/bin/agent-guard" \
+    scan-path "$LOCKFILE_FIXTURE_DIR/not-a-lockfile.txt" >"$OUT" 2>"$ERR"
+  status=$?
+  if [ "$status" -eq 1 ]; then
+    ok "go.sum-shaped checksum outside go.sum remains a generic-api-key finding"
+  else
+    not_ok "lockfile checksum allowlist remains path-scoped (expected 1, got $status)"
+  fi
+
+  LOCK_GIT_DIR="$TMP_ROOT/lockfile-git-dir"
+  mkdir -p "$LOCK_GIT_DIR"
+  (
+    cd "$LOCK_GIT_DIR"
+    git init -q
+    git config user.email test@example.com
+    git config user.name "Agent Guard Tests"
+    cp "$LOCKFILE_FIXTURE_DIR/go.sum" go.sum
+    git add go.sum
+  )
+  (
+    cd "$LOCK_GIT_DIR"
+    PATH="$(dirname "$REAL_GITLEAKS"):$ORIGINAL_PATH" \
+      "$PLUGIN_ROOT/bin/agent-guard" scan-staged
+  ) >"$OUT" 2>"$ERR"
+  status=$?
+  if [ "$status" -eq 0 ]; then
+    ok "scan-staged preserves go.sum path context for checksum allowlisting"
+  else
+    not_ok "scan-staged allows a go.sum checksum (expected 0, got $status)"
+    sed 's/^/  stderr: /' "$ERR"
+  fi
+
+  printf 'api_token = "%s"\n' "$LOCK_SECRET" >>"$LOCK_GIT_DIR/go.sum"
+  (cd "$LOCK_GIT_DIR" && git add go.sum)
+  (
+    cd "$LOCK_GIT_DIR"
+    PATH="$(dirname "$REAL_GITLEAKS"):$ORIGINAL_PATH" \
+      "$PLUGIN_ROOT/bin/agent-guard" scan-staged
+  ) >"$OUT" 2>"$ERR"
+  status=$?
+  if [ "$status" -eq 1 ]; then
+    ok "scan-staged still detects a credential mixed into go.sum"
+  else
+    not_ok "credential in go.sum remains detectable (expected 1, got $status)"
+  fi
+
+  LOCK_SUM_LINE="example.com/clientapi v1.2.3 $LOCK_SUM"
+  lock_write=$(jq -nc --arg content "$LOCK_SUM_LINE" \
+    '{tool_name:"Write",tool_input:{file_path:"go.sum",content:$content}}')
+  printf '%s' "$lock_write" \
+    | AGENT_GUARD_GITLEAKS_BIN="$REAL_GITLEAKS" PATH="$(dirname "$REAL_GITLEAKS"):$ORIGINAL_PATH" \
+        "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool >"$OUT" 2>"$ERR"
+  status=$?
+  if [ "$status" -eq 0 ]; then
+    ok "Write scanning preserves go.sum path context for checksum allowlisting"
+  else
+    not_ok "Write allows a go.sum checksum (expected 0, got $status)"
+  fi
+
+  lock_patch=$(printf '%s\n%s\n%s\n%s\n%s\n' \
+    '*** Begin Patch' '*** Update File: go.sum' '@@' "+$LOCK_SUM_LINE" '*** End Patch')
+  lock_patch_input=$(jq -nc --arg patch "$lock_patch" \
+    '{tool_name:"apply_patch",tool_input:{patch:$patch}}')
+  printf '%s' "$lock_patch_input" \
+    | AGENT_GUARD_GITLEAKS_BIN="$REAL_GITLEAKS" PATH="$(dirname "$REAL_GITLEAKS"):$ORIGINAL_PATH" \
+        "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool >"$OUT" 2>"$ERR"
+  status=$?
+  if [ "$status" -eq 0 ]; then
+    ok "apply_patch scanning preserves go.sum path context for checksum allowlisting"
+  else
+    not_ok "apply_patch allows a go.sum checksum (expected 0, got $status)"
+  fi
 else
   say "real gitleaks not available; skipped real-gitleaks integration tests"
 fi
@@ -3835,6 +3950,42 @@ if printf '%s' "$post_out" | grep -q '\[REDACTED\]' \
 else
   not_ok "post-tool env-assignment heuristic masks KEY=value gitleaks misses"
   printf '%s\n' "$post_out" | sed 's/^/  out: /'
+fi
+
+# Display redaction replaces only the assignment value token. Text after it is
+# preserved, metadata keys with secret-ish prefixes are not values, and a prose
+# colon must not be interpreted as a YAML/JSON secret assignment.
+DISPLAY_SECRET=$(printf '%s%s' 'hunter2-' 'long-value')
+display_input=$(jq -nc --arg stdout "DATABASE_PASSWORD=$DISPLAY_SECRET status=ok" \
+  '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
+post_tool_out "$display_input"
+post_out=$(cat "$OUT")
+display_expected=$(printf 'DATABASE_PASSWORD=[%s] status=ok' 'REDACTED')
+if printf '%s' "$post_out" \
+  | jq -e --arg expected "$display_expected" \
+      '.hookSpecificOutput.updatedToolOutput.stdout == $expected' >/dev/null 2>&1; then
+  ok "post-tool masks only the matched assignment value and preserves adjacent text"
+else
+  not_ok "post-tool value redaction preserves adjacent text"
+  printf '%s\n' "$post_out" | sed 's/^/  out: /'
+fi
+
+post_tool_out '{"tool_name":"Bash","tool_input":{"command":"x"},"tool_response":{"stdout":"password_policy=disabled\n","stderr":"","interrupted":false,"isImage":false}}'
+post_status=$?
+if [ "$post_status" -eq 0 ] && [ ! -s "$OUT" ]; then
+  ok "post-tool does not mask metadata keys that merely begin with a secret keyword"
+else
+  not_ok "post-tool leaves password_policy metadata untouched"
+  sed 's/^/  out: /' "$OUT"
+fi
+
+post_tool_out '{"tool_name":"Bash","tool_input":{"command":"x"},"tool_response":{"stdout":"error: password: authentication is disabled\n","stderr":"","interrupted":false,"isImage":false}}'
+post_status=$?
+if [ "$post_status" -eq 0 ] && [ ! -s "$OUT" ]; then
+  ok "post-tool does not treat a prose colon as a secret assignment"
+else
+  not_ok "post-tool leaves prose after a secret-like key name untouched"
+  sed 's/^/  out: /' "$OUT"
 fi
 
 post_tool_out '{"tool_name":"Read","tool_input":{"file_path":"memo.txt"},"tool_response":"API_KEY=supersecretvalue123\n"}'


### PR DESCRIPTION
## Summary

- exempt only exact checksum-field shapes in `go.sum`, `package-lock.json`, `yarn.lock`, `Cargo.lock`, and `uv.lock`
- rescan every other lockfile line so credentials embedded beside dependency hashes still block
- preserve lockfile path context for staged diffs, untracked files, host writes, and `apply_patch`
- narrow output masking to the quoted value or next unquoted token of a complete secret-bearing assignment
- keep metadata keys, prose after ambiguous colons, and adjacent status text unchanged

## Stack

- Depends on #143 (`codex/p0-stable-runtime`)
- This PR contains only the P1 lockfile false-positive and P2 display-redaction fixes.
- Merge #143 first, then retarget this PR to `main`.

## Root cause and reproduction

### P1: lockfile checksums detected as generic API keys

1. Add a valid `h1:` checksum line to `go.sum` whose module path ends in an API-like term.
2. Stage the file and run `agent-guard scan-staged`.
3. Before this change, the checksum can be reported as `generic-api-key` because staged changes are scanned through stdin without path context.
4. After this change, that exact path + checksum-field combination is clean.
5. Add a separate high-entropy credential assignment beside the checksum; it is still detected and blocks the scan.

Directory scans require an additional safeguard because the upstream default rules skip several lockfiles by path. Agent Guard now skips the five exact lockfile basenames in the directory pass and immediately rescans their content through stdin after removing only recognized checksum lines.

### P2: key-oriented masking rewrites surrounding text

1. Feed PostToolUse output such as `error: password: authentication is disabled`.
2. Before this change, the key-word matcher can treat prose following the second colon as a value and emit a rewrite.
3. Feed an assignment followed by status text, such as `DATABASE_PASSWORD=<test-fixture> status=ok`.
4. Before this change, the heuristic can consume the surrounding text; after this change, only `<test-fixture>` is masked and `status=ok` is preserved.
5. Metadata keys such as `password_policy` no longer trigger assignment masking.

## Functional verification

- `make test` — 478 passed, 0 failed
- `make smoke-test`
- `scripts/validate-plugin-layout.sh`
- `make submission-check`
- `sh -n plugins/agent-guard/bin/agent-guard`
- `sh -n tests/run.sh`
- `git diff --check HEAD^`
- `plugins/agent-guard/bin/agent-guard scan-staged`

## User impact

Normal dependency lockfile updates no longer block commits because of checksum-only false positives. Real credentials in those same files remain detectable, and output redaction no longer replaces benign prose or text adjacent to the matched value.
