### PR TITLE
fix(hooks): prefix the Claude setup-skill invocation with a slash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,15 @@
   Suffix-qualified credential keys (`AWS_SECRET_ACCESS_KEY_ID`,
   `API_KEY_VALUE`, `DB_PASSWORD_HASH`) and whitespace-prefixed colon
   assignments in log lines still mask.
+- fix(hooks): prefix the Claude Code setup-skill invocation with a slash
+  (#151). The degraded-session warning told Claude Code users to run
+  `agent-guard:setup-agent-guard`; pasted verbatim that is ordinary prompt
+  text, not a skill invocation. Claude Code exposes a plugin skill on the
+  slash-command surface as `/plugin:skill`, which is how this plugin already
+  writes its sibling skill `/agent-guard:setup-shell`. The degraded message
+  and every Claude-facing doc reference now use `/agent-guard:setup-agent-guard`.
+  The Codex form `$setup-agent-guard` is unchanged.
+
 - fix(hooks): report a scan that could not run distinctly from a detection
   (#137). A scanner precondition failure and a real detection previously looked
   identical — both printed and exited 2 — so an operator could not tell whether

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ make check
 make smoke-test
 ```
 
-The Claude Code and Codex plugin installs do not put `agent-guard` on your shell `PATH`. In Codex, invoke `$setup-agent-guard`: it uses the plugin-local binary even when a different standalone version is on `PATH`, presents the exact host-appropriate install plan, requests approval, runs `check` plus `smoke-test`, verifies hook trust, and runs live host probes. It never installs software merely because a session started. The same skill is available in Claude Code as `agent-guard:setup-agent-guard`; Claude Code users can also run the equivalent manual commands below.
+The Claude Code and Codex plugin installs do not put `agent-guard` on your shell `PATH`. In Codex, invoke `$setup-agent-guard`: it uses the plugin-local binary even when a different standalone version is on `PATH`, presents the exact host-appropriate install plan, requests approval, runs `check` plus `smoke-test`, verifies hook trust, and runs live host probes. It never installs software merely because a session started. The same skill is available in Claude Code as `/agent-guard:setup-agent-guard`; Claude Code users can also run the equivalent manual commands below.
 
 Manual macOS equivalent:
 
@@ -152,7 +152,7 @@ Install and verify in the [Claude Code quick start](#claude-code). Useful slash 
 ```
 
 For guided dependency diagnosis and installation, use the
-`agent-guard:setup-agent-guard` skill — the same skill Codex invokes as
+`/agent-guard:setup-agent-guard` skill — the same skill Codex invokes as
 `$setup-agent-guard`. SessionStart recommends it when it reports degraded
 protection, but never invokes it: it only emits the warning. The skill selects
 the active host's plugin-verification path and runs live probes through that
@@ -482,7 +482,7 @@ agent-guard setup --install \
 ```
 
 The checksum helper prints all supported OS / arch values and paste-ready snippets for CLI setup and GitHub Actions. The guided setup skill —
-`agent-guard:setup-agent-guard` in Claude Code, `$setup-agent-guard` in Codex —
+`/agent-guard:setup-agent-guard` in Claude Code, `$setup-agent-guard` in Codex —
 automates the diagnosis and checksum-selection workflow, but still asks before the download or a package-manager change.
 
 ## Host Integrations

--- a/README.md
+++ b/README.md
@@ -481,7 +481,9 @@ agent-guard setup --install \
   --gitleaks-checksum <sha256-for-this-os-and-arch>
 ```
 
-The checksum helper prints all supported OS / arch values and paste-ready snippets for CLI setup and GitHub Actions. `$setup-agent-guard` automates the diagnosis and checksum-selection workflow, but still asks before the download or a package-manager change.
+The checksum helper prints all supported OS / arch values and paste-ready snippets for CLI setup and GitHub Actions. The guided setup skill —
+`agent-guard:setup-agent-guard` in Claude Code, `$setup-agent-guard` in Codex —
+automates the diagnosis and checksum-selection workflow, but still asks before the download or a package-manager change.
 
 ## Host Integrations
 

--- a/plugins/agent-guard/README.md
+++ b/plugins/agent-guard/README.md
@@ -27,7 +27,7 @@ plugin. Until then, install from the project's marketplace:
 After installation, SessionStart reports `DEGRADED` protection whenever `jq`,
 `git`, gitleaks, or a bundled policy is unavailable. The warning names the
 host-appropriate skill: `$setup-agent-guard` in Codex or
-`agent-guard:setup-agent-guard` in Claude Code. You can also run the
+`/agent-guard:setup-agent-guard` in Claude Code. You can also run the
 plugin-local `agent-guard setup` directly. Dependency installation always
 requires explicit approval. Then verify:
 
@@ -91,11 +91,11 @@ gitleaks 8.30 or newer (recommended).
 
 ## Skills
 
-- `agent-guard:setup-agent-guard` — resolve the plugin-local binary, diagnose
+- `/agent-guard:setup-agent-guard` — resolve the plugin-local binary, diagnose
   `jq`/gitleaks, and guide approved installation. Codex invokes the same skill
   as `$setup-agent-guard`; the skill selects the correct host verification path
   and runs live probes through that host's normal command surface.
-- `agent-guard:setup-shell` — install or refresh the optional shell integration
+- `/agent-guard:setup-shell` — install or refresh the optional shell integration
   through the plugin-local binary with approval before changing the shell rc.
   Codex invokes the same skill as `$setup-shell`.
 

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -235,7 +235,7 @@ handle_hook_infrastructure_failure() {
 degraded_hook_message() {
   case "${AGENT_GUARD_HOOK_HOST:-claude}" in
     codex) setup_ref='$setup-agent-guard' ;;
-    *) setup_ref='agent-guard:setup-agent-guard' ;;
+    *) setup_ref='/agent-guard:setup-agent-guard' ;;
   esac
   printf 'agent-guard: protection is DEGRADED because jq, git, gitleaks, or a policy file is unavailable. Run %s (or agent-guard setup), approve any required installation, verify with agent-guard check and smoke-test, then restart the host;' "$setup_ref"
 }

--- a/plugins/agent-guard/skills/setup-agent-guard/SKILL.md
+++ b/plugins/agent-guard/skills/setup-agent-guard/SKILL.md
@@ -62,7 +62,7 @@ Make Agent Guard operational without silently changing the machine. Diagnose fir
    - In Codex, confirm that the Agent Guard plugin is installed and enabled. In **Settings > Hooks**, inspect Agent Guard's `SessionStart`, `PreToolUse`, `PostToolUse`, and `Stop` hooks. Every hook must be enabled and trusted. Treat `Untrusted` and `Modified` as inactive; an updated hook must be reviewed and trusted again.
    - In Codex, do not edit `hooks.state` or copy trust hashes into `config.toml`. Hook trust is a user security decision and must go through the Codex trust UI. If `SessionStart` itself is untrusted, explain that it cannot emit the setup warning or invoke this skill automatically.
    - In Claude Code, confirm that the Agent Guard plugin is installed and enabled, then reload plugins after an install or update. Do not direct Claude Code users to Codex **Settings > Hooks**; Claude Code does not use that trust workflow. `/agent-guard:verify` can check the working tree, but it does not prove live hook dispatch.
-   - If the active host is unclear, infer it from the current product and invocation (`$setup-agent-guard` in Codex or `agent-guard:setup-agent-guard` in Claude Code). Do not apply one host's setup steps to the other.
+   - If the active host is unclear, infer it from the current product and invocation (`$setup-agent-guard` in Codex or `/agent-guard:setup-agent-guard` in Claude Code). Do not apply one host's setup steps to the other.
 
 8. Run live host probes through the normal command tool selected by the active host for the current task. Do not read a real sensitive file.
    - Pre-tool probe:

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -2934,7 +2934,7 @@ else
 fi
 
 codex_setup_ref="\$setup-agent-guard"
-claude_setup_ref='agent-guard:setup-agent-guard'
+claude_setup_ref='/agent-guard:setup-agent-guard'
 
 printf '%s' '{"tool_name":"Bash","tool_input":{"command":"brew install gitleaks"}}' \
   | AGENT_GUARD_HOOK_HOST=codex AGENT_GUARD_GITLEAKS_BIN=/nonexistent/gitleaks PATH="$NO_GITLEAKS_BIN" \


### PR DESCRIPTION
## Summary

Claude Code exposes a plugin **skill** on the slash-command surface as `/plugin-name:skill-name`. The plugin named its own setup skill as bare `agent-guard:setup-agent-guard`, so a user copying that string submitted ordinary prompt text instead of invoking the skill.

This started as a one-line README fix. Review (Codex, P2, `README.md`) flagged the reviewed line; auditing the rest of the repo showed **the same defect in the runtime**, which is what users actually copy.

### The evidence: the repo already contradicted itself

`plugins/agent-guard/commands/` contains only `checksum.md` and `verify.md`. So `setup-shell` is a **skill**, not a command — and the repo writes it **with** a slash in every invocation context (`README.md:25,151,230,395`, `plugins/agent-guard/README.md:41,49`, `docs/managed-deployment.md:38,52`, `docs/migration-v2.md:58,63`, `CHANGELOG.md:57`, and `bin/agent-guard:2140`).

The two forms sat **in the same emitted sentence**, four lines apart in `bin/agent-guard`:

```
Run agent-guard:setup-agent-guard (or agent-guard setup), ... 
   agent-guard command wrapping is not loaded. Run /agent-guard:setup-shell, ...
```

Sibling skills, same host, same message, two different conventions. `setup-agent-guard` was the outlier: zero slashed occurrences anywhere, against 13 for `setup-shell`.

### What changed

**Runtime (the one users copy out of a degraded session):**

- `plugins/agent-guard/bin/agent-guard` — `degraded_hook_message()`, the single source for every degraded emit path (`hook-session-start`, `hook-pre-tool`, `hook-post-tool`, `stop`). This line came from #144, not from this PR's original scope.

**Docs (5 sites):**

- `README.md` ×3 — the Claude quick-start prose, the slash-command section, and the checksum section (the originally reviewed line).
- `plugins/agent-guard/README.md` ×3 — the DEGRADED paragraph, and both entries of the `## Skills` list. The second `## Skills` entry was `agent-guard:setup-shell`: the same defect on the sibling skill, in the same list. Fixing only its neighbour would have left the list internally inconsistent.
- `plugins/agent-guard/skills/setup-agent-guard/SKILL.md` — the host-inference bullet, which teaches the model to recognise the invocation form.

**Test:**

- `tests/run.sh` — `claude_setup_ref` was the **unslashed** literal. Because the slashed message also contains that substring, the assertion matched either form and could not detect this defect. It now pins `/agent-guard:setup-agent-guard`.

### Deliberately left unslashed

- **All `$setup-agent-guard` / `$setup-shell`** — correct Codex syntax, out of scope, unchanged. `scripts/validate-plugin-layout.sh:131,157` greps for these in `agents/openai.yaml`; untouched.
- `docs/managed-deployment.md:49` — "points at the `setup-agent-guard` skill" is a prose reference to the skill **by name**, with no `agent-guard:` prefix. Not an invocation.
- `docs/migration-v2.md:80` — `$setup-agent-guard` under the **Codex plugin upgrade** heading. Correct as-is.
- **No rename**, per #135: Codex invokes skills by bare name.

## Functional verification

**The test now actually catches this.** Reverting only the runtime line and re-running the suite:

```
$ make test        # with the runtime line reverted to the unslashed form
not ok - Claude hook degraded mode uses Claude setup guidance (status 0)
not ok - Claude SessionStart emits host-appropriate degraded guidance
failed: 2
```

Before this PR that same regression passed clean. (Measured on the pre-rebase base; the
assertion itself is unchanged by the rebase, and all four host cases pass in CI below.)

**Per-host degraded message, end to end:**

```
$ AGENT_GUARD_HOOK_HOST=claude AGENT_GUARD_GITLEAKS_BIN=/nonexistent/gitleaks \
    plugins/agent-guard/bin/agent-guard hook-session-start
{"systemMessage":"agent-guard: protection is DEGRADED ... Run /agent-guard:setup-agent-guard
 (or agent-guard setup), ... Run /agent-guard:setup-shell, then restart the shell and Claude Code. ..."}

$ AGENT_GUARD_HOOK_HOST=codex AGENT_GUARD_GITLEAKS_BIN=/nonexistent/gitleaks \
    plugins/agent-guard/bin/agent-guard hook-session-start
{"systemMessage":"agent-guard: protection is DEGRADED ... Run $setup-agent-guard (or agent-guard
 setup), ...","hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"... Run
 $setup-agent-guard ..."}}
```

Claude now emits both skills in the same slashed convention. Codex is byte-identical to before. Neither host leaks the other's syntax. `hook-pre-tool` (stderr) matches for both hosts.

The surrounding sentence (`restart the host;`, and the `AGENT_GUARD_INFRA_FAILURE_MODE=open` continuation on `hook-pre-tool`) comes from #143/#145, not this PR: `git diff origin/main HEAD -- plugins/agent-guard/bin/agent-guard` is exactly one character, the `/`.

**CI on `821237e`** — all four workflows green, and the four host-specific assertions confirmed present and passing in the Test job logs on both runners:

```
ok - Codex hook degrades open with Codex setup guidance
ok - Claude hook degrades open with Claude setup guidance
ok - Codex SessionStart uses Codex dependency setup guidance
ok - Claude SessionStart uses Claude dependency setup guidance
```

Counts are environment-dependent, all `failed: 0` — ubuntu 552, macos 520 (`real gitleaks not available; skipped real-gitleaks integration tests`), local darwin 556 (gitleaks 8.30.1 present).

**Suites:**

Rebased onto `ff50c21`, which picks up #143 and #145.

```
$ make test
passed: 556
failed: 0

$ make check
agent-guard: dependencies ok
agent-guard: gitleaks 8.30.1 (>= 8.30 recommended)

$ make smoke-test
agent-guard: smoke ok: scan-path allows a clean directory
agent-guard: smoke ok: scan-path blocks a private-key fixture
agent-guard: smoke ok: hook-pre-tool blocks .env reads
agent-guard: smoke ok: pii-filter runs with the regex provider
agent-guard: smoke ok: hook-pre-tool blocks secret-like writes
agent-guard: smoke ok: native pre-commit hook blocks staged fixture
agent-guard: smoke-test ok

$ scripts/validate-plugin-layout.sh
plugin layout validation passed
```

`scripts/validate-submission-readiness.sh` byte-compares only `LICENSE`, `PRIVACY.md`, `SUPPORT.md`, `THIRD_PARTY_NOTICES.md` between root and payload — not the READMEs, which are independent files. No sync needed.

## Not covered

- **No live-host E2E.** Host behaviour was driven with `AGENT_GUARD_HOOK_HOST`, the same mechanism the Codex hook manifest uses — not by running a genuinely degraded Claude Code or Codex session. In particular, **nobody typed `/agent-guard:setup-agent-guard` into a real Claude Code session to confirm the plugin resolves it.** The claim rests on the repo's own established convention for `/agent-guard:setup-shell`, not on an observed invocation.
- **No new test case.** The existing per-host assertions were strengthened rather than duplicated; the revert experiment above is the evidence they now bind. A separate doc-content assertion was not added — the five doc sites are unpinned by tests and could drift again.
- **`docs/managed-deployment.md` and `docs/migration-v2.md` were judged, not swept.** Both were read and deliberately left; if the intent at `managed-deployment.md:49` was an invocation rather than a name, that one is still wrong.
- **No rename, no merge, no issue closed.**

Refs #140, #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)
