### PR TITLE
chore(ci): re-pin marketplace .source.sha and verify linter download checksums

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,15 @@ jobs:
     env:
       SHELLCHECK_VERSION: "0.10.0"
       ACTIONLINT_VERSION: "1.7.7"
+      # sha256 of shellcheck-v0.10.0.linux.x86_64.tar.xz. The shellcheck release
+      # publishes no checksums file, so this is cross-checked against
+      # pantsbuild's independently published known_versions entry
+      # ("v0.10.0|linux_x86_64|6c881ab…|2404716", digest and byte length both
+      # matching the release asset).
+      SHELLCHECK_CHECKSUM_LINUX_X64: "6c881ab0698e4e6ea235245f22832860544f17ba386442fe7e9d629f8cbedf87"
+      # sha256 of actionlint_1.7.7_linux_amd64.tar.gz, taken from the upstream
+      # actionlint_1.7.7_checksums.txt release asset.
+      ACTIONLINT_CHECKSUM_LINUX_X64: "023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757"
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -124,6 +133,7 @@ jobs:
           url="https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/${archive}"
           tmp="$(mktemp -d)"
           curl -fsSL "$url" -o "${tmp}/${archive}"
+          echo "${SHELLCHECK_CHECKSUM_LINUX_X64}  ${tmp}/${archive}" | sha256sum -c -
           tar -xJf "${tmp}/${archive}" -C "${tmp}"
           mkdir -p "${RUNNER_TEMP}/lint-bin"
           mv "${tmp}/shellcheck-v${SHELLCHECK_VERSION}/shellcheck" "${RUNNER_TEMP}/lint-bin/shellcheck"
@@ -137,6 +147,7 @@ jobs:
           url="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${archive}"
           tmp="$(mktemp -d)"
           curl -fsSL "$url" -o "${tmp}/${archive}"
+          echo "${ACTIONLINT_CHECKSUM_LINUX_X64}  ${tmp}/${archive}" | sha256sum -c -
           tar -xzf "${tmp}/${archive}" -C "${tmp}" actionlint
           mkdir -p "${RUNNER_TEMP}/lint-bin"
           mv "${tmp}/actionlint" "${RUNNER_TEMP}/lint-bin/actionlint"

--- a/.github/workflows/plugin-validation.yml
+++ b/.github/workflows/plugin-validation.yml
@@ -43,11 +43,7 @@ jobs:
         run: scripts/validate-plugin-layout.sh --archive
 
       - name: Validate Marketplace Submission Readiness
-        # Temporary: the readiness check now resolves the pinned .source.sha
-        # (fetch-depth: 0 above) and correctly reports that the pin has drifted
-        # from the current payload — a real finding that was silently skipped
-        # before. Re-pinning is a separate decision (#130 follow-up), so keep the
-        # check running and visible in the logs without blocking this PR. Remove
-        # continue-on-error once .source.sha is re-pinned.
-        continue-on-error: true
+        # Blocking again (#149): .source.sha is re-pinned to the commit whose
+        # plugins/agent-guard tree is currently shipping, so any change to the
+        # payload that forgets to re-pin the submission drafts fails here.
         run: make submission-check

--- a/docs/claude-marketplace-readiness.md
+++ b/docs/claude-marketplace-readiness.md
@@ -30,9 +30,9 @@ source repository that already backs a live marketplace entry.
   which includes merged PR
   [#54](https://github.com/JeongJaeSoon/agent-guard/pull/54) and its shared
   Claude Code/Codex Quick Start.
-- Submission-ready plugin payload: `bdf51638652db846e1b19aa28f99cfa2d3f337e3`,
+- Submission-ready plugin payload: `ff50c21e3444dec3e35bc9ff8e764966038e54ad`,
   merged through Agent Guard
-  [PR #115](https://github.com/JeongJaeSoon/agent-guard/pull/115).
+  [PR #145](https://github.com/JeongJaeSoon/agent-guard/pull/145).
 - Official repository: `anthropics/claude-plugins-official` at
   `f9cb226d81172f53a1787cc3ba90dc9ab51aa169`.
 - The official repository has no root `CONTRIBUTING.md` or `SECURITY.md` at that
@@ -45,7 +45,7 @@ source repository that already backs a live marketplace entry.
 |---|---|---|
 | Registration path | The repository README still links a plugin submission form, but current Claude Code docs clarify that the form targets the community marketplace and that official inclusion has no application process. | **Blocker outside the repo.** Prepare artifacts, but seek curator contact or use the community route. |
 | External PRs | Non-member PRs are closed unless they only add marketplace entries from a repository that already has a live entry. | **Blocker.** `JeongJaeSoon/agent-guard` is not already listed. |
-| Source pinning | External sources use `url` or `git-subdir` and a full commit SHA. Automated jobs later bump the SHA and re-scan. | **Ready.** The `git-subdir` template uses `path: plugins/agent-guard` and pins reachable commit `bdf51638652db846e1b19aa28f99cfa2d3f337e3`. |
+| Source pinning | External sources use `url` or `git-subdir` and a full commit SHA. Automated jobs later bump the SHA and re-scan. | **Ready.** The `git-subdir` template uses `path: plugins/agent-guard` and pins reachable commit `ff50c21e3444dec3e35bc9ff8e764966038e54ad`. |
 | Name | Marketplace names are immutable kebab-case slugs. | **Ready.** `agent-guard` is stable and kebab-case. |
 | Manifest | Plugin root contains `.claude-plugin/plugin.json`; components stay at plugin root. New work prefers `skills/`, while `commands/` remains supported as legacy. | **Ready with legacy note.** Manifest is valid; Claude commands remain legacy-compatible and the Codex setup workflow is a skill. |
 | Hook review | External scan enumerates every hook and fails ungated `PreToolUse` or `PostToolUse` hooks. Descriptions must disclose hook scope and data access. | **Blocker.** Agent Guard's broad hooks are core behavior. Descriptions and privacy docs now disclose the scope, but disclosure does not override the scanner's broad-hook failure rule. |

--- a/docs/submission/README.md
+++ b/docs/submission/README.md
@@ -8,10 +8,10 @@
    changed.
 3. Resolve the reachable 40-character GitHub commit SHA that contains the exact
    plugin payload under `plugins/agent-guard`. The prepared submission pins
-   `bdf51638652db846e1b19aa28f99cfa2d3f337e3`, merged through Agent Guard
-   [PR #115](https://github.com/JeongJaeSoon/agent-guard/pull/115).
+   `ff50c21e3444dec3e35bc9ff8e764966038e54ad`, merged through Agent Guard
+   [PR #145](https://github.com/JeongJaeSoon/agent-guard/pull/145).
 4. Re-run `make submission-check` with
-   `AGENT_GUARD_SUBMISSION_SHA=bdf51638652db846e1b19aa28f99cfa2d3f337e3`.
+   `AGENT_GUARD_SUBMISSION_SHA=ff50c21e3444dec3e35bc9ff8e764966038e54ad`.
    If the plugin payload changes, replace the pinned SHA in both submission
    drafts and validate the new reachable commit before submitting.
 5. For the public community route, submit the form draft through the Console

--- a/docs/submission/claude-community/form-draft.md
+++ b/docs/submission/claude-community/form-draft.md
@@ -8,7 +8,7 @@
 
 - Repository: `https://github.com/JeongJaeSoon/agent-guard`
 - Plugin path: `plugins/agent-guard`
-- Commit SHA: `bdf51638652db846e1b19aa28f99cfa2d3f337e3`
+- Commit SHA: `ff50c21e3444dec3e35bc9ff8e764966038e54ad`
 
 ## Short description
 

--- a/docs/submission/claude-plugins-official/marketplace-entry.template.json
+++ b/docs/submission/claude-plugins-official/marketplace-entry.template.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/JeongJaeSoon/agent-guard.git",
     "path": "plugins/agent-guard",
     "ref": "main",
-    "sha": "bdf51638652db846e1b19aa28f99cfa2d3f337e3"
+    "sha": "ff50c21e3444dec3e35bc9ff8e764966038e54ad"
   },
   "homepage": "https://github.com/JeongJaeSoon/agent-guard"
 }


### PR DESCRIPTION
Closes #149 — items 1 and 2. Item 3 was already resolved separately (see below).

## Item 1 — Re-pin `.source.sha` and re-arm the drift check

### Decision: the pin tracks the shipping payload (HEAD), not a frozen snapshot

Re-pinned to `ff50c21e3444dec3e35bc9ff8e764966038e54ad` (current `main` tip, and the last commit that touched `plugins/agent-guard`).

**This is not ambiguous.** Two independent lines of evidence:

**a) `f9cb226d…` was never a candidate value.** The issue framed the choice as "HEAD payload vs. the reviewed snapshot `f9cb226d…`", but `f9cb226d81172f53a1787cc3ba90dc9ab51aa169` is not an agent-guard commit at all — it is the pinned snapshot of **`anthropics/claude-plugins-official`**, the upstream marketplace repo. `docs/claude-marketplace-readiness.md` says so verbatim:

> - Official repository: `anthropics/claude-plugins-official` at `f9cb226d81172f53a1787cc3ba90dc9ab51aa169`.

And it does not resolve in this repository:

```
$ git cat-file -t f9cb226d81172f53a1787cc3ba90dc9ab51aa169
fatal: git cat-file: could not get object info
```

The validator's separate `contains "$REPORT" 'f9cb226d…'` assertion is about that upstream snapshot and is untouched.

**b) The repo's own docs state the invariant explicitly.** `docs/submission/README.md`:

> 3. Resolve the reachable 40-character GitHub commit SHA that **contains the exact plugin payload** under `plugins/agent-guard`.
> 4. … **If the plugin payload changes, replace the pinned SHA in both submission drafts** and validate the new reachable commit before submitting.

`docs/claude-marketplace-readiness.md`, under *Recommended before any review request*:

> - **Keep the pinned commit synchronized with any future plugin-payload change** and re-run submission validation before each submission or curator request.

…and its Source-pinning row notes upstream behavior: *"Automated jobs later bump the SHA and re-scan."* The validator's own comment agrees: *"A 40-hex `.source.sha` is only a safety net if it still resolves to the payload reviewers will actually install."* And `tests/run.sh` encodes it as a test: pin == HEAD passes, stale pin fails.

So the pin is a *freshness* assertion about what a marketplace reviewer would install, not an archival record of a reviewed tree. Tracking HEAD keeps the check meaningful: it now fails whenever someone changes the plugin payload without updating the submission drafts.

### Changes

- `.source.sha` in `marketplace-entry.template.json`: `bdf51638…` → `ff50c21e…`
- Same SHA updated in lock-step in `docs/submission/claude-community/form-draft.md` (the second "submission draft" that step 4 requires), `docs/submission/README.md` (steps 3–4), and `docs/claude-marketplace-readiness.md` (verified-snapshot bullet + source-pinning row). Stale SHAs left in a submission draft are exactly the failure mode this check exists to catch. The now-wrong `PR #115` attribution alongside them is corrected to `PR #145`, the PR that merged `ff50c21`.
- `continue-on-error: true` removed from the "Validate Marketplace Submission Readiness" step in `plugin-validation.yml`, with the temporary comment replaced by one stating the invariant.

`fetch-depth: 0` on that job's checkout is unchanged — the drift check needs it to resolve the pin.

## Item 2 — shellcheck / actionlint checksum pins

Mirrors the existing gitleaks block in the same workflow (`GITLEAKS_CHECKSUM_LINUX_X64` in workflow `env`, then `echo "${SUM}  ${tmp}/${archive}" | sha256sum -c -` immediately before `tar`). No second style introduced.

### Where each sha256 came from

**actionlint `1.7.7` — `023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757`**

From the upstream **`actionlint_1.7.7_checksums.txt`** asset that `rhysd/actionlint` publishes in the v1.7.7 release:

```
$ gh release download v1.7.7 --repo rhysd/actionlint --pattern 'actionlint_1.7.7_checksums.txt' --output -
…
023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757  actionlint_1.7.7_linux_amd64.tar.gz
…
```

**shellcheck `0.10.0` — `6c881ab0698e4e6ea235245f22832860544f17ba386442fe7e9d629f8cbedf87`**

`koalaman/shellcheck` v0.10.0 ships **no** checksums asset and its release notes contain no digests (only 7 platform tarballs + a zip). So this value is cross-checked against an **independently published** source: pantsbuild's `default_known_versions` table in `src/python/pants/backend/shell/lint/shellcheck/subsystem.py`, which publishes digest **and byte length** per platform:

```
"v0.10.0|linux_x86_64|6c881ab0698e4e6ea235245f22832860544f17ba386442fe7e9d629f8cbedf87|2404716"
```

Both fields match the downloaded asset (`2404716` bytes, see verification below). As further corroboration that this table is a faithful mirror of the release rather than a coincidence, pantsbuild's `macos_arm64` entry (`bbd2f148…`) also verifies against `shellcheck-v0.10.0.darwin.aarch64.tar.xz` — checked while installing shellcheck locally to run the lint step.

If a maintainer wants a stronger provenance chain than a third-party mirror, the honest fix is upstream publishing signed checksums; the readiness report already tracks attestation/signing as an open recommendation.

## Functional verification

All commands run in a clean worktree at this branch's HEAD (`91acd24`), rebased on `main` (`ff50c21`).

**`make submission-check` — passes, and the drift assertion actually evaluated (not skipped):**

```
$ make submission-check
…
ok: official marketplace entry template uses the pinned git-subdir form and discloses material behavior
ok: entry template contains a full commit SHA
ok: pinned .source.sha's plugins/agent-guard tree matches the current payload
ok: readiness report records the official submission blocker
ok: readiness report records the broad-hook blocker
ok: readiness report pins the reviewed official snapshot
submission readiness validation passed
EXIT=0
```

**`make check`:**

```
$ make check
agent-guard: dependencies ok
agent-guard: gitleaks 8.30.1 (>= 8.30 recommended)
CHECK_EXIT=0
```

**`make test` — full suite:**

```
$ make test
…
passed: 556
failed: 0
TEST_EXIT=0
```

The negative half of the drift guard is covered by the suite and confirmed to have run rather than self-skipped:

```
$ tests/run.sh 2>&1 | grep -iE "submission validator|stale-pin|history-unavailable|git archive unavailable"
ok - submission validator accepts a pin whose plugins/agent-guard tree matches HEAD
ok - submission validator rejects a stale pin whose plugins/agent-guard tree differs from HEAD
ok - stale-pin rejection names the payload drift and tells the maintainer to re-pin
ok - submission validator fails closed when the pinned commit is not available locally
ok - history-unavailable pin fails with an actionable full-history message
```

**Each pinned sha256 verified against the actual release asset** (downloads via `gh release download`, digests via `shasum -a 256`):

```
$ shasum -a 256 shellcheck-v0.10.0.linux.x86_64.tar.xz actionlint_1.7.7_linux_amd64.tar.gz
6c881ab0698e4e6ea235245f22832860544f17ba386442fe7e9d629f8cbedf87  shellcheck-v0.10.0.linux.x86_64.tar.xz
023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757  actionlint_1.7.7_linux_amd64.tar.gz

$ wc -c shellcheck-v0.10.0.linux.x86_64.tar.xz
 2404716 shellcheck-v0.10.0.linux.x86_64.tar.xz   # matches pantsbuild's published length
```

Both match the values hard-coded in `ci.yml`, so the pins will not break the Lint job.

**`actionlint` + `shellcheck` run over the edited workflows.** Both linters were installed locally through the same download-then-verify flow this PR adds (macOS/arm64 assets, digests from the same two sources — `2693315b…` from the official `checksums.txt`, `bbd2f148…` from pantsbuild):

```
$ echo "2693315b9093aeacb4ebd91a993fea54fc215057bf0da2659056b4bc033873db  actionlint_1.7.7_darwin_arm64.tar.gz" | shasum -a 256 -c -
actionlint_1.7.7_darwin_arm64.tar.gz: OK

$ echo "bbd2f14826328eee7679da7221f2bc3afb011f6a928b848c80c321f6046ddf81  shellcheck-v0.10.0.darwin.aarch64.tar.xz" | shasum -a 256 -c -
shellcheck-v0.10.0.darwin.aarch64.tar.xz: OK

$ shellcheck --severity=error <the 10 scripts from the Lint job>
SHELLCHECK_EXIT=0

$ SHELLCHECK_OPTS=--severity=error actionlint -color
ACTIONLINT_WITH_SHELLCHECK_EXIT=0
```

`actionlint` with `shellcheck` on `PATH` is clean on both edited workflows, including the new `sha256sum -c` lines in the `run:` blocks.

## Not covered

- **No CI run had yet exercised the new checksum lines on a Linux runner** when this body was written. The digests are verified byte-for-byte against the real assets above, and the local runs used the same verify-then-extract flow on the macOS assets, but the `sha256sum -c -` invocation itself (vs. macOS `shasum -a 256 -c -`) executes for the first time in this PR's Lint job. Confirmed from the run log before merge.
- **No test asserts the checksum block fails on a bad digest.** Deliberate: a negative test would have to fake a download, and the block is a copy of the proven gitleaks pattern. A wrong pin fails loudly and immediately in the Lint job.
- **Linux-x64 only.** The Lint job runs on `ubuntu-latest`; other OS/arch archives have different digests and no pins were added for them (same scoping the gitleaks pin already uses).
- **No provenance/signature verification.** These pins protect against a tampered transfer or a mutated release asset, not against a compromised upstream publisher. `docs/claude-marketplace-readiness.md` already tracks attestation/signing as an open recommendation; unchanged here.
- **`.source.sha` re-pinning is still manual.** The check now fails when the pin goes stale, but nothing bumps it automatically — a payload change requires editing the two submission drafts. Making that automatic was not in scope.
- **The pinned commit's reachability on `origin/main` is not asserted.** The validator only checks that the commit resolves locally and that its `plugins/agent-guard` tree equals HEAD's; a pin to a local-only commit with a matching tree would pass. Pre-existing behavior, unchanged.
- **Item 3 of #149 (commit-target-directory resolution) is not in this PR** — and no longer needs to be. #149 listed it as "tracked in #138", but #138 is already `CLOSED`/`COMPLETED` (2026-07-26T12:45:19Z), closed by PR #143 ("fix(runtime): keep Agent Guard stable across plugin upgrades", `9f0848d`, body: `- Fixes #138`). So #149's context note is stale and all of its actual checkboxes are covered here — hence `Closes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
