### PR TITLE
fix(detection): scan credentials beside lockfile checksums

### DIFF
--- a/docs/claude-marketplace-readiness.md
+++ b/docs/claude-marketplace-readiness.md
@@ -30,7 +30,7 @@ source repository that already backs a live marketplace entry.
   which includes merged PR
   [#54](https://github.com/JeongJaeSoon/agent-guard/pull/54) and its shared
   Claude Code/Codex Quick Start.
-- Submission-ready plugin payload: `e99a505f3a6ea779ddeb08ae02cb2cec17143b44`,
+- Submission-ready plugin payload: `18dcbe01da1a6413c4d79838e10c70730c805cfd`,
   reviewed in Agent Guard
   [PR #159](https://github.com/JeongJaeSoon/agent-guard/pull/159).
 - Official repository: `anthropics/claude-plugins-official` at
@@ -45,7 +45,7 @@ source repository that already backs a live marketplace entry.
 |---|---|---|
 | Registration path | The repository README still links a plugin submission form, but current Claude Code docs clarify that the form targets the community marketplace and that official inclusion has no application process. | **Blocker outside the repo.** Prepare artifacts, but seek curator contact or use the community route. |
 | External PRs | Non-member PRs are closed unless they only add marketplace entries from a repository that already has a live entry. | **Blocker.** `JeongJaeSoon/agent-guard` is not already listed. |
-| Source pinning | External sources use `url` or `git-subdir` and a full commit SHA. Automated jobs later bump the SHA and re-scan. | **Ready.** The `git-subdir` template uses `path: plugins/agent-guard` and pins reachable commit `e99a505f3a6ea779ddeb08ae02cb2cec17143b44`. |
+| Source pinning | External sources use `url` or `git-subdir` and a full commit SHA. Automated jobs later bump the SHA and re-scan. | **Ready.** The `git-subdir` template uses `path: plugins/agent-guard` and pins reachable commit `18dcbe01da1a6413c4d79838e10c70730c805cfd`. |
 | Name | Marketplace names are immutable kebab-case slugs. | **Ready.** `agent-guard` is stable and kebab-case. |
 | Manifest | Plugin root contains `.claude-plugin/plugin.json`; components stay at plugin root. New work prefers `skills/`, while `commands/` remains supported as legacy. | **Ready with legacy note.** Manifest is valid; Claude commands remain legacy-compatible and the Codex setup workflow is a skill. |
 | Hook review | External scan enumerates every hook and fails ungated `PreToolUse` or `PostToolUse` hooks. Descriptions must disclose hook scope and data access. | **Blocker.** Agent Guard's broad hooks are core behavior. Descriptions and privacy docs now disclose the scope, but disclosure does not override the scanner's broad-hook failure rule. |

--- a/docs/claude-marketplace-readiness.md
+++ b/docs/claude-marketplace-readiness.md
@@ -30,7 +30,7 @@ source repository that already backs a live marketplace entry.
   which includes merged PR
   [#54](https://github.com/JeongJaeSoon/agent-guard/pull/54) and its shared
   Claude Code/Codex Quick Start.
-- Submission-ready plugin payload: `4fe569c01c18c2225ef75b02b8cb5a411ca2300b`,
+- Submission-ready plugin payload: `e99a505f3a6ea779ddeb08ae02cb2cec17143b44`,
   reviewed in Agent Guard
   [PR #159](https://github.com/JeongJaeSoon/agent-guard/pull/159).
 - Official repository: `anthropics/claude-plugins-official` at
@@ -45,7 +45,7 @@ source repository that already backs a live marketplace entry.
 |---|---|---|
 | Registration path | The repository README still links a plugin submission form, but current Claude Code docs clarify that the form targets the community marketplace and that official inclusion has no application process. | **Blocker outside the repo.** Prepare artifacts, but seek curator contact or use the community route. |
 | External PRs | Non-member PRs are closed unless they only add marketplace entries from a repository that already has a live entry. | **Blocker.** `JeongJaeSoon/agent-guard` is not already listed. |
-| Source pinning | External sources use `url` or `git-subdir` and a full commit SHA. Automated jobs later bump the SHA and re-scan. | **Ready.** The `git-subdir` template uses `path: plugins/agent-guard` and pins reachable commit `4fe569c01c18c2225ef75b02b8cb5a411ca2300b`. |
+| Source pinning | External sources use `url` or `git-subdir` and a full commit SHA. Automated jobs later bump the SHA and re-scan. | **Ready.** The `git-subdir` template uses `path: plugins/agent-guard` and pins reachable commit `e99a505f3a6ea779ddeb08ae02cb2cec17143b44`. |
 | Name | Marketplace names are immutable kebab-case slugs. | **Ready.** `agent-guard` is stable and kebab-case. |
 | Manifest | Plugin root contains `.claude-plugin/plugin.json`; components stay at plugin root. New work prefers `skills/`, while `commands/` remains supported as legacy. | **Ready with legacy note.** Manifest is valid; Claude commands remain legacy-compatible and the Codex setup workflow is a skill. |
 | Hook review | External scan enumerates every hook and fails ungated `PreToolUse` or `PostToolUse` hooks. Descriptions must disclose hook scope and data access. | **Blocker.** Agent Guard's broad hooks are core behavior. Descriptions and privacy docs now disclose the scope, but disclosure does not override the scanner's broad-hook failure rule. |

--- a/docs/claude-marketplace-readiness.md
+++ b/docs/claude-marketplace-readiness.md
@@ -30,7 +30,7 @@ source repository that already backs a live marketplace entry.
   which includes merged PR
   [#54](https://github.com/JeongJaeSoon/agent-guard/pull/54) and its shared
   Claude Code/Codex Quick Start.
-- Submission-ready plugin payload: `18dcbe01da1a6413c4d79838e10c70730c805cfd`,
+- Submission-ready plugin payload: `f49d6e41d42ebaa3c09dc99a0c2f428237058e44`,
   reviewed in Agent Guard
   [PR #159](https://github.com/JeongJaeSoon/agent-guard/pull/159).
 - Official repository: `anthropics/claude-plugins-official` at
@@ -45,7 +45,7 @@ source repository that already backs a live marketplace entry.
 |---|---|---|
 | Registration path | The repository README still links a plugin submission form, but current Claude Code docs clarify that the form targets the community marketplace and that official inclusion has no application process. | **Blocker outside the repo.** Prepare artifacts, but seek curator contact or use the community route. |
 | External PRs | Non-member PRs are closed unless they only add marketplace entries from a repository that already has a live entry. | **Blocker.** `JeongJaeSoon/agent-guard` is not already listed. |
-| Source pinning | External sources use `url` or `git-subdir` and a full commit SHA. Automated jobs later bump the SHA and re-scan. | **Ready.** The `git-subdir` template uses `path: plugins/agent-guard` and pins reachable commit `18dcbe01da1a6413c4d79838e10c70730c805cfd`. |
+| Source pinning | External sources use `url` or `git-subdir` and a full commit SHA. Automated jobs later bump the SHA and re-scan. | **Ready.** The `git-subdir` template uses `path: plugins/agent-guard` and pins reachable commit `f49d6e41d42ebaa3c09dc99a0c2f428237058e44`. |
 | Name | Marketplace names are immutable kebab-case slugs. | **Ready.** `agent-guard` is stable and kebab-case. |
 | Manifest | Plugin root contains `.claude-plugin/plugin.json`; components stay at plugin root. New work prefers `skills/`, while `commands/` remains supported as legacy. | **Ready with legacy note.** Manifest is valid; Claude commands remain legacy-compatible and the Codex setup workflow is a skill. |
 | Hook review | External scan enumerates every hook and fails ungated `PreToolUse` or `PostToolUse` hooks. Descriptions must disclose hook scope and data access. | **Blocker.** Agent Guard's broad hooks are core behavior. Descriptions and privacy docs now disclose the scope, but disclosure does not override the scanner's broad-hook failure rule. |

--- a/docs/claude-marketplace-readiness.md
+++ b/docs/claude-marketplace-readiness.md
@@ -30,9 +30,9 @@ source repository that already backs a live marketplace entry.
   which includes merged PR
   [#54](https://github.com/JeongJaeSoon/agent-guard/pull/54) and its shared
   Claude Code/Codex Quick Start.
-- Submission-ready plugin payload: `ff50c21e3444dec3e35bc9ff8e764966038e54ad`,
-  merged through Agent Guard
-  [PR #145](https://github.com/JeongJaeSoon/agent-guard/pull/145).
+- Submission-ready plugin payload: `4fe569c01c18c2225ef75b02b8cb5a411ca2300b`,
+  reviewed in Agent Guard
+  [PR #159](https://github.com/JeongJaeSoon/agent-guard/pull/159).
 - Official repository: `anthropics/claude-plugins-official` at
   `f9cb226d81172f53a1787cc3ba90dc9ab51aa169`.
 - The official repository has no root `CONTRIBUTING.md` or `SECURITY.md` at that
@@ -45,7 +45,7 @@ source repository that already backs a live marketplace entry.
 |---|---|---|
 | Registration path | The repository README still links a plugin submission form, but current Claude Code docs clarify that the form targets the community marketplace and that official inclusion has no application process. | **Blocker outside the repo.** Prepare artifacts, but seek curator contact or use the community route. |
 | External PRs | Non-member PRs are closed unless they only add marketplace entries from a repository that already has a live entry. | **Blocker.** `JeongJaeSoon/agent-guard` is not already listed. |
-| Source pinning | External sources use `url` or `git-subdir` and a full commit SHA. Automated jobs later bump the SHA and re-scan. | **Ready.** The `git-subdir` template uses `path: plugins/agent-guard` and pins reachable commit `ff50c21e3444dec3e35bc9ff8e764966038e54ad`. |
+| Source pinning | External sources use `url` or `git-subdir` and a full commit SHA. Automated jobs later bump the SHA and re-scan. | **Ready.** The `git-subdir` template uses `path: plugins/agent-guard` and pins reachable commit `4fe569c01c18c2225ef75b02b8cb5a411ca2300b`. |
 | Name | Marketplace names are immutable kebab-case slugs. | **Ready.** `agent-guard` is stable and kebab-case. |
 | Manifest | Plugin root contains `.claude-plugin/plugin.json`; components stay at plugin root. New work prefers `skills/`, while `commands/` remains supported as legacy. | **Ready with legacy note.** Manifest is valid; Claude commands remain legacy-compatible and the Codex setup workflow is a skill. |
 | Hook review | External scan enumerates every hook and fails ungated `PreToolUse` or `PostToolUse` hooks. Descriptions must disclose hook scope and data access. | **Blocker.** Agent Guard's broad hooks are core behavior. Descriptions and privacy docs now disclose the scope, but disclosure does not override the scanner's broad-hook failure rule. |

--- a/docs/submission/README.md
+++ b/docs/submission/README.md
@@ -8,10 +8,10 @@
    changed.
 3. Resolve the reachable 40-character GitHub commit SHA that contains the exact
    plugin payload under `plugins/agent-guard`. The prepared submission pins
-   `e99a505f3a6ea779ddeb08ae02cb2cec17143b44`, reviewed in Agent Guard
+   `18dcbe01da1a6413c4d79838e10c70730c805cfd`, reviewed in Agent Guard
    [PR #159](https://github.com/JeongJaeSoon/agent-guard/pull/159).
 4. Re-run `make submission-check` with
-   `AGENT_GUARD_SUBMISSION_SHA=e99a505f3a6ea779ddeb08ae02cb2cec17143b44`.
+   `AGENT_GUARD_SUBMISSION_SHA=18dcbe01da1a6413c4d79838e10c70730c805cfd`.
    If the plugin payload changes, replace the pinned SHA in both submission
    drafts and validate the new reachable commit before submitting.
 5. For the public community route, submit the form draft through the Console

--- a/docs/submission/README.md
+++ b/docs/submission/README.md
@@ -8,10 +8,10 @@
    changed.
 3. Resolve the reachable 40-character GitHub commit SHA that contains the exact
    plugin payload under `plugins/agent-guard`. The prepared submission pins
-   `18dcbe01da1a6413c4d79838e10c70730c805cfd`, reviewed in Agent Guard
+   `f49d6e41d42ebaa3c09dc99a0c2f428237058e44`, reviewed in Agent Guard
    [PR #159](https://github.com/JeongJaeSoon/agent-guard/pull/159).
 4. Re-run `make submission-check` with
-   `AGENT_GUARD_SUBMISSION_SHA=18dcbe01da1a6413c4d79838e10c70730c805cfd`.
+   `AGENT_GUARD_SUBMISSION_SHA=f49d6e41d42ebaa3c09dc99a0c2f428237058e44`.
    If the plugin payload changes, replace the pinned SHA in both submission
    drafts and validate the new reachable commit before submitting.
 5. For the public community route, submit the form draft through the Console

--- a/docs/submission/README.md
+++ b/docs/submission/README.md
@@ -8,10 +8,10 @@
    changed.
 3. Resolve the reachable 40-character GitHub commit SHA that contains the exact
    plugin payload under `plugins/agent-guard`. The prepared submission pins
-   `ff50c21e3444dec3e35bc9ff8e764966038e54ad`, merged through Agent Guard
-   [PR #145](https://github.com/JeongJaeSoon/agent-guard/pull/145).
+   `4fe569c01c18c2225ef75b02b8cb5a411ca2300b`, reviewed in Agent Guard
+   [PR #159](https://github.com/JeongJaeSoon/agent-guard/pull/159).
 4. Re-run `make submission-check` with
-   `AGENT_GUARD_SUBMISSION_SHA=ff50c21e3444dec3e35bc9ff8e764966038e54ad`.
+   `AGENT_GUARD_SUBMISSION_SHA=4fe569c01c18c2225ef75b02b8cb5a411ca2300b`.
    If the plugin payload changes, replace the pinned SHA in both submission
    drafts and validate the new reachable commit before submitting.
 5. For the public community route, submit the form draft through the Console

--- a/docs/submission/README.md
+++ b/docs/submission/README.md
@@ -8,10 +8,10 @@
    changed.
 3. Resolve the reachable 40-character GitHub commit SHA that contains the exact
    plugin payload under `plugins/agent-guard`. The prepared submission pins
-   `4fe569c01c18c2225ef75b02b8cb5a411ca2300b`, reviewed in Agent Guard
+   `e99a505f3a6ea779ddeb08ae02cb2cec17143b44`, reviewed in Agent Guard
    [PR #159](https://github.com/JeongJaeSoon/agent-guard/pull/159).
 4. Re-run `make submission-check` with
-   `AGENT_GUARD_SUBMISSION_SHA=4fe569c01c18c2225ef75b02b8cb5a411ca2300b`.
+   `AGENT_GUARD_SUBMISSION_SHA=e99a505f3a6ea779ddeb08ae02cb2cec17143b44`.
    If the plugin payload changes, replace the pinned SHA in both submission
    drafts and validate the new reachable commit before submitting.
 5. For the public community route, submit the form draft through the Console

--- a/docs/submission/claude-community/form-draft.md
+++ b/docs/submission/claude-community/form-draft.md
@@ -8,7 +8,7 @@
 
 - Repository: `https://github.com/JeongJaeSoon/agent-guard`
 - Plugin path: `plugins/agent-guard`
-- Commit SHA: `18dcbe01da1a6413c4d79838e10c70730c805cfd`
+- Commit SHA: `f49d6e41d42ebaa3c09dc99a0c2f428237058e44`
 
 ## Short description
 

--- a/docs/submission/claude-community/form-draft.md
+++ b/docs/submission/claude-community/form-draft.md
@@ -8,7 +8,7 @@
 
 - Repository: `https://github.com/JeongJaeSoon/agent-guard`
 - Plugin path: `plugins/agent-guard`
-- Commit SHA: `ff50c21e3444dec3e35bc9ff8e764966038e54ad`
+- Commit SHA: `4fe569c01c18c2225ef75b02b8cb5a411ca2300b`
 
 ## Short description
 

--- a/docs/submission/claude-community/form-draft.md
+++ b/docs/submission/claude-community/form-draft.md
@@ -8,7 +8,7 @@
 
 - Repository: `https://github.com/JeongJaeSoon/agent-guard`
 - Plugin path: `plugins/agent-guard`
-- Commit SHA: `4fe569c01c18c2225ef75b02b8cb5a411ca2300b`
+- Commit SHA: `e99a505f3a6ea779ddeb08ae02cb2cec17143b44`
 
 ## Short description
 

--- a/docs/submission/claude-community/form-draft.md
+++ b/docs/submission/claude-community/form-draft.md
@@ -8,7 +8,7 @@
 
 - Repository: `https://github.com/JeongJaeSoon/agent-guard`
 - Plugin path: `plugins/agent-guard`
-- Commit SHA: `e99a505f3a6ea779ddeb08ae02cb2cec17143b44`
+- Commit SHA: `18dcbe01da1a6413c4d79838e10c70730c805cfd`
 
 ## Short description
 

--- a/docs/submission/claude-plugins-official/marketplace-entry.template.json
+++ b/docs/submission/claude-plugins-official/marketplace-entry.template.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/JeongJaeSoon/agent-guard.git",
     "path": "plugins/agent-guard",
     "ref": "main",
-    "sha": "ff50c21e3444dec3e35bc9ff8e764966038e54ad"
+    "sha": "4fe569c01c18c2225ef75b02b8cb5a411ca2300b"
   },
   "homepage": "https://github.com/JeongJaeSoon/agent-guard"
 }

--- a/docs/submission/claude-plugins-official/marketplace-entry.template.json
+++ b/docs/submission/claude-plugins-official/marketplace-entry.template.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/JeongJaeSoon/agent-guard.git",
     "path": "plugins/agent-guard",
     "ref": "main",
-    "sha": "4fe569c01c18c2225ef75b02b8cb5a411ca2300b"
+    "sha": "e99a505f3a6ea779ddeb08ae02cb2cec17143b44"
   },
   "homepage": "https://github.com/JeongJaeSoon/agent-guard"
 }

--- a/docs/submission/claude-plugins-official/marketplace-entry.template.json
+++ b/docs/submission/claude-plugins-official/marketplace-entry.template.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/JeongJaeSoon/agent-guard.git",
     "path": "plugins/agent-guard",
     "ref": "main",
-    "sha": "18dcbe01da1a6413c4d79838e10c70730c805cfd"
+    "sha": "f49d6e41d42ebaa3c09dc99a0c2f428237058e44"
   },
   "homepage": "https://github.com/JeongJaeSoon/agent-guard"
 }

--- a/docs/submission/claude-plugins-official/marketplace-entry.template.json
+++ b/docs/submission/claude-plugins-official/marketplace-entry.template.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/JeongJaeSoon/agent-guard.git",
     "path": "plugins/agent-guard",
     "ref": "main",
-    "sha": "e99a505f3a6ea779ddeb08ae02cb2cec17143b44"
+    "sha": "18dcbe01da1a6413c4d79838e10c70730c805cfd"
   },
   "homepage": "https://github.com/JeongJaeSoon/agent-guard"
 }

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -826,6 +826,10 @@ filter_lockfile_records() {
     function replace_match(line, replacement) {
       return substr(line, 1, RSTART - 1) replacement substr(line, RSTART + RLENGTH)
     }
+    function toml_incomplete(kind) {
+      return (kind == "c" || kind == "u") \
+          && (toml_multiline != "" || toml_array_depth != 0 || toml_invalid)
+    }
     function structured_delimiter(line, at, kind, n, ch) {
       n = length(line)
       # Yarn integrity and Cargo checksum are whole scalar fields. Accept only
@@ -887,7 +891,10 @@ filter_lockfile_records() {
         # Oversized/invalid records stay fully scannable. Their parser state is
         # intentionally not guessed; after one such TOML/JSON record,
         # conservatively skip neutralization for the rest of that file.
-        if (kind == "c" || kind == "u") toml_skip_rest = 1
+        if (kind == "c" || kind == "u") {
+          toml_skip_rest = 1
+          toml_invalid = 1
+        }
         if (kind == "p") json_skip_rest = 1
         print line
         return
@@ -1047,6 +1054,16 @@ filter_lockfile_records() {
           continue
         }
 
+        if (kind == "c" || kind == "u") {
+          if (ch == "[")
+            toml_array_depth++
+          else if (ch == "]") {
+            if (toml_array_depth > 0)
+              toml_array_depth--
+            else
+              toml_invalid = 1
+          }
+        }
         if (ch == "{") {
           if (kind == "p") {
             if (json_depth >= max_json_depth) {
@@ -1066,6 +1083,8 @@ filter_lockfile_records() {
           uv_url_seen[brace_depth] = 0
           if (kind != "c") field_allowed = 1
         } else if (ch == "}") {
+          if ((kind == "c" || kind == "u") && brace_depth == 0)
+            toml_invalid = 1
           if (kind == "p") {
             delete json_role[json_depth]
             if (json_depth > 0) json_depth--
@@ -1082,6 +1101,12 @@ filter_lockfile_records() {
           field_allowed = 0
         i++
       }
+
+      # Ordinary TOML strings and inline tables cannot cross a physical
+      # record. Preserve the whole raw snapshot if either remains open.
+      if ((kind == "c" || kind == "u") \
+          && (quote != "" || brace_depth != 0))
+        toml_invalid = 1
 
       # Emit in bounded chunks. Repeatedly appending an unbounded record is
       # quadratic in some POSIX awks, even when parsing itself is single-pass.
@@ -1112,6 +1137,8 @@ filter_lockfile_records() {
       max_json_depth = 256
       previous_kind = ""
       toml_multiline = ""
+      toml_array_depth = 0
+      toml_invalid = 0
       toml_skip_rest = 0
     }
     {
@@ -1134,10 +1161,11 @@ filter_lockfile_records() {
         # A structured TOML stream must not silently discard incomplete parser
         # state when the record kind changes. Returning nonzero makes the
         # caller scan the immutable raw snapshot instead.
-        if ((previous_kind == "c" || previous_kind == "u") \
-            && toml_multiline != "")
+        if (toml_incomplete(previous_kind))
           exit 2
         toml_multiline = ""
+        toml_array_depth = 0
+        toml_invalid = 0
         toml_skip_rest = 0
         json_skip_rest = 0
         json_depth = 0
@@ -1165,8 +1193,7 @@ filter_lockfile_records() {
     END {
       # Never emit checksum-neutralized output for incomplete TOML. The caller
       # treats this parser failure as a signal to scan the full raw snapshot.
-      if ((previous_kind == "c" || previous_kind == "u") \
-          && toml_multiline != "")
+      if (toml_incomplete(previous_kind))
         exit 2
     }
   ' "$record_source"

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -824,44 +824,201 @@ filter_lockfile_records() {
     function replace_match(line, replacement) {
       return substr(line, 1, RSTART - 1) replacement substr(line, RSTART + RLENGTH)
     }
-    function replace_fields(line, field, suffix, key, replacement,
-                            result, pattern, matched, key_at, field_tail,
-                            field_length, suffix_text, full_start, full_length,
-                            first) {
-      result = ""
-      first = 1
-      while (1) {
-        pattern = (first ? field_prefix : structural_prefix) field suffix
-        if (!match(line, pattern)) break
-        full_start = RSTART
-        full_length = RLENGTH
-        matched = substr(line, RSTART, RLENGTH)
-        key_at = index(matched, key)
-        if (key_at == 0) return result line
-        field_tail = substr(matched, key_at)
-        if (!match(field_tail, "^" field)) return result line
-        field_length = RLENGTH
-        suffix_text = substr(field_tail, field_length + 1)
-        result = result substr(line, 1, full_start - 1) \
-          substr(matched, 1, key_at - 1) replacement
-        # Keep the delimiter in the remaining input. Later matches must begin
-        # at a structural comma/brace, never at arbitrary whitespace that
-        # follows an attacker-controlled key phrase.
-        line = suffix_text substr(line, full_start + full_length)
-        first = 0
+    function structured_delimiter(line, at, kind, n, ch) {
+      n = length(line)
+      if (kind == "y")
+        return at > n || substr(line, at, 1) ~ /[[:space:]]/
+      while (at <= n && substr(line, at, 1) ~ /[[:space:]]/) at++
+      return at > n || substr(line, at, 1) == "," || substr(line, at, 1) == "}"
+    }
+    function field_replacement(line, at, kind, probe) {
+      # All supported checksum fields are shorter than this bounded lookahead.
+      # Excessive inter-token whitespace is left untouched and scanned
+      # conservatively instead of making candidate search depend on line size.
+      probe = substr(line, at, 256)
+      replacement_length = 0
+      replacement_text = ""
+      if (kind == "p") {
+        if (match(probe, "^\"integrity\"[[:space:]]*:[[:space:]]*\"" sri "\"")) {
+          replacement_length = RLENGTH
+          replacement_text = "\"integrity\": \"CHECKSUM\""
+        }
+      } else if (kind == "y") {
+        if (match(probe, "^integrity[[:space:]]+" sri)) {
+          replacement_length = RLENGTH
+          replacement_text = "integrity CHECKSUM"
+        } else if (match(probe, "^checksum:[[:space:]]*[0-9a-f]{64}")) {
+          replacement_length = RLENGTH
+          replacement_text = "checksum: CHECKSUM"
+        }
+      } else if (kind == "c") {
+        if (match(probe, "^checksum[[:space:]]*=[[:space:]]*\"[0-9a-f]{64}\"")) {
+          replacement_length = RLENGTH
+          replacement_text = "checksum = \"CHECKSUM\""
+        }
+      } else if (kind == "u") {
+        if (match(probe, "^hash[[:space:]]*=[[:space:]]*\"sha256:[0-9a-f]{64}\"")) {
+          replacement_length = RLENGTH
+          replacement_text = "hash = \"sha256:CHECKSUM\""
+        }
       }
-      return result line
+      if (replacement_length \
+          && !structured_delimiter(line, at + replacement_length, kind)) {
+        replacement_length = 0
+        replacement_text = ""
+      }
+      return replacement_length
+    }
+    function emit_structural_fields(line, kind,
+                                    encoded, char_count, i, ch, quote, escaped,
+                                    field_allowed, ml_escaped, triple, chunk,
+                                    chars, replacements, skips) {
+      char_count = length(line)
+      if (toml_skip_rest || char_count > max_structured_line_chars \
+          || index(line, char_separator)) {
+        # Oversized/invalid records stay fully scannable. Their quote state is
+        # intentionally not guessed; after one such TOML record, conservatively
+        # skip neutralization for the rest of that file.
+        if (kind == "c" || kind == "u") toml_skip_rest = 1
+        print line
+        return
+      }
+      encoded = line
+      gsub(/./, "&" char_separator, encoded)
+      split(encoded, chars, char_separator)
+      quote = ""
+      escaped = 0
+      field_allowed = 1
+      ml_escaped = 0
+      i = 1
+      while (i <= char_count) {
+        ch = chars[i]
+
+        # TOML multiline basic/literal strings span physical records. Preserve
+        # their content verbatim until an unescaped matching triple delimiter.
+        if ((kind == "c" || kind == "u") && toml_multiline != "") {
+          field_allowed = 0
+          triple = chars[i] chars[i + 1] chars[i + 2]
+          if (toml_multiline == "\"") {
+            if (ch == "\\") {
+              ml_escaped = !ml_escaped
+              i++
+              continue
+            }
+            if (triple == triple_double && !ml_escaped) {
+              i += 3
+              toml_multiline = ""
+              ml_escaped = 0
+              continue
+            }
+            ml_escaped = 0
+          } else if (triple == triple_single) {
+            i += 3
+            toml_multiline = ""
+            continue
+          }
+          i++
+          continue
+        }
+
+        if (quote != "") {
+          if (quote == "\"" && ch == "\\") {
+            escaped = !escaped
+            i++
+            continue
+          }
+          if (ch == quote && !escaped) quote = ""
+          escaped = 0
+          i++
+          continue
+        }
+
+        # JSON has no comments or single-quoted strings. TOML/Yarn comments
+        # consume the remainder of a record and must stay fully scannable.
+        if (kind != "p" && ch == "#") {
+          break
+        }
+
+        if (field_allowed \
+            && ((kind == "p" && ch == "\"") \
+                || (kind == "y" && (ch == "i" || ch == "c")) \
+                || (kind == "c" && ch == "c") \
+                || (kind == "u" && ch == "h")) \
+            && field_replacement(line, i, kind)) {
+          replacements[i] = replacement_text
+          skips[i] = replacement_length
+          i += replacement_length
+          field_allowed = 0
+          continue
+        }
+
+        if ((kind == "c" || kind == "u") \
+            && chars[i] chars[i + 1] chars[i + 2] == triple_double) {
+          i += 3
+          toml_multiline = "\""
+          field_allowed = 0
+          continue
+        }
+        if ((kind == "c" || kind == "u") \
+            && chars[i] chars[i + 1] chars[i + 2] == triple_single) {
+          i += 3
+          toml_multiline = single_quote
+          field_allowed = 0
+          continue
+        }
+        if (ch == "\"" || (kind != "p" && ch == single_quote)) {
+          quote = ch
+          escaped = 0
+          field_allowed = 0
+          i++
+          continue
+        }
+
+        if (ch == "{" || ch == ",")
+          field_allowed = 1
+        else if (ch !~ /[[:space:]]/)
+          field_allowed = 0
+        i++
+      }
+
+      # Emit in bounded chunks. Repeatedly appending an unbounded record is
+      # quadratic in some POSIX awks, even when parsing itself is single-pass.
+      chunk = ""
+      i = 1
+      while (i <= char_count) {
+        if (i in replacements) {
+          chunk = chunk replacements[i]
+          i += skips[i]
+        } else {
+          chunk = chunk chars[i]
+          i++
+        }
+        if (length(chunk) >= 4096) {
+          printf "%s", chunk
+          chunk = ""
+        }
+      }
+      print chunk
     }
     BEGIN {
-      field_prefix = "(^[[:space:]]*|[,{][[:space:]]*)"
-      structural_prefix = "[,{][[:space:]]*"
-      structured_suffix = "[[:space:]]*([,}]|$)"
-      scalar_suffix = "([[:space:]]|$)"
       sri = "(sha1-[A-Za-z0-9+\\/]{27}=|sha256-[A-Za-z0-9+\\/]{43}=|sha384-[A-Za-z0-9+\\/]{64}|sha512-[A-Za-z0-9+\\/]{86}==)"
+      single_quote = "'\''"
+      triple_single = single_quote single_quote single_quote
+      triple_double = "\"\"\""
+      char_separator = sprintf("%c", 28)
+      max_structured_line_chars = 131072
+      previous_kind = ""
+      toml_multiline = ""
+      toml_skip_rest = 0
     }
     {
       kind = substr($0, 1, 1)
       line = substr($0, 3)
+      if (kind != previous_kind) {
+        toml_multiline = ""
+        toml_skip_rest = 0
+        previous_kind = kind
+      }
       if (kind == "g") {
         # Only the third go.sum field is a checksum. A module path may itself
         # contain an h1-shaped secret and must remain visible to gitleaks.
@@ -872,15 +1029,10 @@ filter_lockfile_records() {
               && match(go_tail, /^h1:[A-Za-z0-9+\/]{43}=/))
             line = go_prefix replace_match(go_tail, "h1:CHECKSUM")
         }
-      } else if (kind == "p")
-        line = replace_fields(line, "\"integrity\"[[:space:]]*:[[:space:]]*\"" sri "\"", structured_suffix, "\"integrity\"", "\"integrity\": \"CHECKSUM\"")
-      else if (kind == "y") {
-        line = replace_fields(line, "integrity[[:space:]]+" sri, scalar_suffix, "integrity", "integrity CHECKSUM")
-        line = replace_fields(line, "checksum:[[:space:]]*[0-9a-f]{64}", scalar_suffix, "checksum", "checksum: CHECKSUM")
-      } else if (kind == "c")
-        line = replace_fields(line, "checksum[[:space:]]*=[[:space:]]*\"[0-9a-f]{64}\"", structured_suffix, "checksum", "checksum = \"CHECKSUM\"")
-      else if (kind == "u")
-        line = replace_fields(line, "hash[[:space:]]*=[[:space:]]*\"sha256:[0-9a-f]{64}\"", structured_suffix, "hash", "hash = \"sha256:CHECKSUM\"")
+      } else {
+        emit_structural_fields(line, kind)
+        next
+      }
       print line
     }
   '

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -820,7 +820,9 @@ run_gitleaks_stdin() {
 # writes, untracked files, and path scans from drifting apart. Replace only the
 # checksum field so any other same-line content is still scanned.
 filter_lockfile_records() {
-  awk '
+  forced_kind=${1:-}
+  record_source=${2:--}
+  LC_ALL=C awk -v forced_kind="$forced_kind" '
     function replace_match(line, replacement) {
       return substr(line, 1, RSTART - 1) replacement substr(line, RSTART + RLENGTH)
     }
@@ -1110,8 +1112,13 @@ filter_lockfile_records() {
       toml_skip_rest = 0
     }
     {
-      kind = substr($0, 1, 1)
-      line = substr($0, 3)
+      if (forced_kind != "") {
+        kind = forced_kind
+        line = $0
+      } else {
+        kind = substr($0, 1, 1)
+        line = substr($0, 3)
+      }
       # Uppercase structured kinds are context-free physical-record fragments.
       # Their surrounding parser state is unavailable, so leave them fully
       # scannable instead of guessing that a checksum-looking field is
@@ -1146,7 +1153,7 @@ filter_lockfile_records() {
       }
       print line
     }
-  '
+  ' "$record_source"
 }
 
 # Gitleaks' bundled defaults skip common lockfiles by path. Agent Guard rescans
@@ -1154,7 +1161,7 @@ filter_lockfile_records() {
 # checksum false positives and keeps credentials elsewhere detectable.
 filter_lockfile_hashes() {
   path=$1
-  source=${2:-$path}
+  original_source=${2:-$path}
   snapshot=
   case "${path##*/}" in
     go.sum) kind=g ;;
@@ -1162,22 +1169,34 @@ filter_lockfile_hashes() {
     yarn.lock) kind=y ;;
     Cargo.lock) kind=c ;;
     uv.lock) kind=u ;;
-    *) cat -- "$source"; return ;;
+    *) cat -- "$original_source"; return ;;
   esac
-  if [ "$kind" = p ]; then
-    # Validate and filter the same immutable bytes. Reopening the caller-owned
-    # path after validation would let an atomic replacement swap malformed
-    # content in before the streaming field parser runs.
-    snapshot=$(mktemp_file) || { cat -- "$source"; return; }
-    if ! cat -- "$source" >"$snapshot"; then
-      rm -f "$snapshot"
-      # A full temp filesystem must not turn the filter pipeline into empty
-      # clean input. Fall back to the original bytes without neutralization.
-      cat -- "$source"
-      return
-    fi
-    source=$snapshot
 
+  # Filter one immutable snapshot for every supported lockfile. Besides closing
+  # path-swap races, this lets us reject NUL-bearing input before POSIX awk sees
+  # it: BSD awk truncates a record at NUL and could otherwise discard a
+  # credential suffix. NUL-bearing files stay byte-for-byte scannable.
+  snapshot=$(mktemp_file) || { cat -- "$original_source"; return; }
+  if ! cat -- "$original_source" >"$snapshot"; then
+    rm -f "$snapshot"
+    case "$original_source" in
+      -|/dev/stdin) return 2 ;;
+      *) cat -- "$original_source"; return ;;
+    esac
+  fi
+  source=$snapshot
+  nul_probe=$(mktemp_file) || nul_probe=
+  if [ -z "$nul_probe" ] \
+      || ! LC_ALL=C tr -d '\000' <"$source" >"$nul_probe" \
+      || ! cmp -s "$source" "$nul_probe"; then
+    cat -- "$source"
+    status=$?
+    rm -f "$snapshot" "$nul_probe"
+    return "$status"
+  fi
+  rm -f "$nul_probe"
+
+  if [ "$kind" = p ]; then
     # The streaming field parser cannot know that later input is truncated.
     # Validate the complete document first, keeping only a count/type summary
     # so large lockfiles do not need to be slurped into memory. If jq is absent,
@@ -1222,9 +1241,23 @@ filter_lockfile_hashes() {
       return "$status"
     fi
   fi
-  awk -v kind="$kind" '{ print kind "\t" $0 }' "$source" | filter_lockfile_records
-  status=$?
-  [ -z "$snapshot" ] || rm -f "$snapshot"
+  filtered=$(mktemp_file) || {
+    cat -- "$source"
+    status=$?
+    rm -f "$snapshot"
+    return "$status"
+  }
+  if filter_lockfile_records "$kind" "$source" >"$filtered"; then
+    cat -- "$filtered"
+    status=$?
+  else
+    # Parser failure must never turn a lockfile into empty clean input. The
+    # immutable snapshot is the authoritative byte stream for raw fallback.
+    cat -- "$source"
+    status=$?
+  fi
+  rm -f "$filtered"
+  rm -f "$snapshot"
   return "$status"
 }
 
@@ -1232,12 +1265,26 @@ scan_lockfiles_under() {
   root=$1
   label=$2
   blob=$(mktemp_file) || die "failed to create temp file"
+  list=$(mktemp_file) || { rm -f "$blob"; die "failed to create temp file"; }
   find "$root" -type f \( \
       -name go.sum -o -name package-lock.json -o -name yarn.lock -o \
       -name Cargo.lock -o -name uv.lock \
-    \) -exec "$SELF_BIN" filter-lockfile-hashes '{}' '{}' \; >"$blob"
+    \) -print0 >"$list"
   find_status=$?
   if [ "$find_status" -ne 0 ]; then
+    rm -f "$blob" "$list"
+    info "$PROGRAM: failed to prepare lockfiles in $label"
+    return 2
+  fi
+  if [ ! -s "$list" ]; then
+    rm -f "$blob" "$list"
+    return 0
+  fi
+  xargs -0 -I '{}' "$SELF_BIN" filter-lockfile-hashes '{}' '{}' \
+    >>"$blob" <"$list"
+  prepare_status=$?
+  rm -f "$list"
+  if [ "$prepare_status" -ne 0 ]; then
     rm -f "$blob"
     info "$PROGRAM: failed to prepare lockfiles in $label"
     return 2
@@ -1314,7 +1361,7 @@ block_on_scan_status() {
 # Extract only added diff lines, dropping exact checksum fields only when the
 # diff header identifies one of the supported lockfiles.
 extract_added_lines() {
-  awk '
+  LC_ALL=C awk '
     function lockfile_kind(path, parts, count, name) {
       count = split(path, parts, "/")
       name = parts[count]
@@ -1333,7 +1380,7 @@ extract_added_lines() {
 }
 # Extract lines introduced by Codex apply_patch envelopes or unified diffs.
 extract_patch_added_lines() {
-  awk '
+  LC_ALL=C awk '
     function lockfile_kind(path, parts, count, name) {
       count = split(path, parts, "/")
       name = parts[count]
@@ -1453,11 +1500,11 @@ scan_untracked_files() {
     printf "### file: %s\n" "$f"
     case "${f##*/}" in
       go.sum|package-lock.json|yarn.lock|Cargo.lock|uv.lock)
-        "$filter" filter-lockfile-hashes "$f" "$f"
+        "$filter" filter-lockfile-hashes "$f" "$f" || exit 1
         ;;
-      *) cat -- "$f" ;;
+      *) cat -- "$f" || exit 1 ;;
     esac
-    printf "\n"
+    printf "\n" || exit 1
   ' "$root" '{}' "$SELF_BIN" >>"$blob" <"$list"
   prepare_status=$?
   rm -f "$list"

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -1128,6 +1128,12 @@ filter_lockfile_records() {
         next
       }
       if (kind != previous_kind) {
+        # A structured TOML stream must not silently discard incomplete parser
+        # state when the record kind changes. Returning nonzero makes the
+        # caller scan the immutable raw snapshot instead.
+        if ((previous_kind == "c" || previous_kind == "u") \
+            && toml_multiline != "")
+          exit 2
         toml_multiline = ""
         toml_skip_rest = 0
         json_skip_rest = 0
@@ -1152,6 +1158,13 @@ filter_lockfile_records() {
         next
       }
       print line
+    }
+    END {
+      # Never emit checksum-neutralized output for incomplete TOML. The caller
+      # treats this parser failure as a signal to scan the full raw snapshot.
+      if ((previous_kind == "c" || previous_kind == "u") \
+          && toml_multiline != "")
+        exit 2
     }
   ' "$record_source"
 }

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -828,8 +828,11 @@ filter_lockfile_records() {
     }
     function structured_delimiter(line, at, kind, n, ch) {
       n = length(line)
-      if (kind == "y")
-        return at > n || substr(line, at, 1) ~ /[[:space:]]/
+      # Yarn integrity and Cargo checksum are whole scalar fields. Accept only
+      # end-of-record whitespace or a comment; malformed trailing data must
+      # remain raw and scannable. package-lock and uv use inline containers.
+      if (kind == "y" || kind == "c")
+        return substr(line, at) ~ /^[[:space:]]*(#.*)?$/
       while (at <= n && substr(line, at, 1) ~ /[[:space:]]/) at++
       return at > n || substr(line, at, 1) == "," || substr(line, at, 1) == "}"
     }
@@ -1149,7 +1152,7 @@ filter_lockfile_records() {
         if (match(line, /^[^[:space:]]+[[:space:]]+[^[:space:]]+[[:space:]]+/)) {
           go_prefix = substr(line, 1, RLENGTH)
           go_tail = substr(line, RLENGTH + 1)
-          if (go_tail ~ /^h1:[A-Za-z0-9+\/]{43}=([[:space:]]|$)/ \
+          if (go_tail ~ /^h1:[A-Za-z0-9+\/]{43}=[[:space:]]*$/ \
               && match(go_tail, /^h1:[A-Za-z0-9+\/]{43}=/))
             line = go_prefix replace_match(go_tail, "h1:CHECKSUM")
         }

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -817,17 +817,70 @@ run_gitleaks_stdin() {
 
 # Filter records encoded as one lockfile-kind byte, a tab, then the original
 # line. Keeping the checksum grammar in one place prevents staged diffs, host
-# writes, untracked files, and path scans from drifting apart.
+# writes, untracked files, and path scans from drifting apart. Replace only the
+# checksum field so any other same-line content is still scanned.
 filter_lockfile_records() {
   awk '
+    function replace_match(line, replacement) {
+      return substr(line, 1, RSTART - 1) replacement substr(line, RSTART + RLENGTH)
+    }
+    function replace_fields(line, field, suffix, key, replacement,
+                            result, pattern, matched, key_at, field_tail,
+                            field_length, suffix_text, full_start, full_length,
+                            first) {
+      result = ""
+      first = 1
+      while (1) {
+        pattern = (first ? field_prefix : structural_prefix) field suffix
+        if (!match(line, pattern)) break
+        full_start = RSTART
+        full_length = RLENGTH
+        matched = substr(line, RSTART, RLENGTH)
+        key_at = index(matched, key)
+        if (key_at == 0) return result line
+        field_tail = substr(matched, key_at)
+        if (!match(field_tail, "^" field)) return result line
+        field_length = RLENGTH
+        suffix_text = substr(field_tail, field_length + 1)
+        result = result substr(line, 1, full_start - 1) \
+          substr(matched, 1, key_at - 1) replacement
+        # Keep the delimiter in the remaining input. Later matches must begin
+        # at a structural comma/brace, never at arbitrary whitespace that
+        # follows an attacker-controlled key phrase.
+        line = suffix_text substr(line, full_start + full_length)
+        first = 0
+      }
+      return result line
+    }
+    BEGIN {
+      field_prefix = "(^[[:space:]]*|[,{][[:space:]]*)"
+      structural_prefix = "[,{][[:space:]]*"
+      structured_suffix = "[[:space:]]*([,}]|$)"
+      scalar_suffix = "([[:space:]]|$)"
+      sri = "(sha1-[A-Za-z0-9+\\/]{27}=|sha256-[A-Za-z0-9+\\/]{43}=|sha384-[A-Za-z0-9+\\/]{64}|sha512-[A-Za-z0-9+\\/]{86}==)"
+    }
     {
       kind = substr($0, 1, 1)
       line = substr($0, 3)
-      if (kind == "g" && line ~ /^[^[:space:]]+[[:space:]]+[^[:space:]]+[[:space:]]+h1:[A-Za-z0-9+\/]{43}=$/) next
-      if (kind == "p" && line ~ /^[[:space:]]*"integrity"[[:space:]]*:[[:space:]]*"(sha1-[A-Za-z0-9+\/]{27}=|sha256-[A-Za-z0-9+\/]{43}=|sha384-[A-Za-z0-9+\/]{64}|sha512-[A-Za-z0-9+\/]{86}==)"[,]?[[:space:]]*$/) next
-      if (kind == "y" && (line ~ /^[[:space:]]*integrity[[:space:]]+(sha1-[A-Za-z0-9+\/]{27}=|sha256-[A-Za-z0-9+\/]{43}=|sha384-[A-Za-z0-9+\/]{64}|sha512-[A-Za-z0-9+\/]{86}==)[[:space:]]*$/ || line ~ /^[[:space:]]*checksum:[[:space:]]*[0-9a-f]{64}[[:space:]]*$/)) next
-      if (kind == "c" && line ~ /^[[:space:]]*checksum[[:space:]]*=[[:space:]]*"[0-9a-f]{64}"[[:space:]]*$/) next
-      if (kind == "u" && (line ~ /^[[:space:]]*hash[[:space:]]*=[[:space:]]*"sha256:[0-9a-f]{64}"[,]?[[:space:]]*$/ || line ~ /^[[:space:]]*(sdist[[:space:]]*=[[:space:]]*)?\{[[:space:]]*url[[:space:]]*=[[:space:]]*"[^"]+"[[:space:]]*,[[:space:]]*hash[[:space:]]*=[[:space:]]*"sha256:[0-9a-f]{64}"[[:space:]]*,[[:space:]]*size[[:space:]]*=[[:space:]]*[0-9]+[[:space:]]*\}[,]?[[:space:]]*$/)) next
+      if (kind == "g") {
+        # Only the third go.sum field is a checksum. A module path may itself
+        # contain an h1-shaped secret and must remain visible to gitleaks.
+        if (match(line, /^[^[:space:]]+[[:space:]]+[^[:space:]]+[[:space:]]+/)) {
+          go_prefix = substr(line, 1, RLENGTH)
+          go_tail = substr(line, RLENGTH + 1)
+          if (go_tail ~ /^h1:[A-Za-z0-9+\/]{43}=([[:space:]]|$)/ \
+              && match(go_tail, /^h1:[A-Za-z0-9+\/]{43}=/))
+            line = go_prefix replace_match(go_tail, "h1:CHECKSUM")
+        }
+      } else if (kind == "p")
+        line = replace_fields(line, "\"integrity\"[[:space:]]*:[[:space:]]*\"" sri "\"", structured_suffix, "\"integrity\"", "\"integrity\": \"CHECKSUM\"")
+      else if (kind == "y") {
+        line = replace_fields(line, "integrity[[:space:]]+" sri, scalar_suffix, "integrity", "integrity CHECKSUM")
+        line = replace_fields(line, "checksum:[[:space:]]*[0-9a-f]{64}", scalar_suffix, "checksum", "checksum: CHECKSUM")
+      } else if (kind == "c")
+        line = replace_fields(line, "checksum[[:space:]]*=[[:space:]]*\"[0-9a-f]{64}\"", structured_suffix, "checksum", "checksum = \"CHECKSUM\"")
+      else if (kind == "u")
+        line = replace_fields(line, "hash[[:space:]]*=[[:space:]]*\"sha256:[0-9a-f]{64}\"", structured_suffix, "hash", "hash = \"sha256:CHECKSUM\"")
       print line
     }
   '

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -872,17 +872,72 @@ filter_lockfile_records() {
     function emit_structural_fields(line, kind,
                                     encoded, char_count, i, ch, quote, escaped,
                                     field_allowed, ml_escaped, triple, chunk,
-                                    chars, replacements, skips) {
+                                    header, brace_depth, uv_artifact_line, probe,
+                                    json_open_role,
+                                    chars, replacements, skips, uv_url_seen) {
       char_count = length(line)
-      if (toml_skip_rest || char_count > max_structured_line_chars \
+      if (toml_skip_rest || json_skip_rest \
+          || char_count > max_structured_line_chars \
           || index(line, char_separator)) {
-        # Oversized/invalid records stay fully scannable. Their quote state is
-        # intentionally not guessed; after one such TOML record, conservatively
-        # skip neutralization for the rest of that file.
+        # Oversized/invalid records stay fully scannable. Their parser state is
+        # intentionally not guessed; after one such TOML/JSON record,
+        # conservatively skip neutralization for the rest of that file.
         if (kind == "c" || kind == "u") toml_skip_rest = 1
+        if (kind == "p") json_skip_rest = 1
         print line
         return
       }
+      if (kind == "c" && toml_multiline == "") {
+        header = line
+        sub(/^[[:space:]]*/, "", header)
+        if (substr(header, 1, 1) == "[") {
+          if (header ~ /^\[\[[[:space:]]*package[[:space:]]*\]\][[:space:]]*(#.*)?$/ \
+              || header ~ /^\[[[:space:]]*root[[:space:]]*\][[:space:]]*(#.*)?$/ \
+              || header ~ /^\[\[[[:space:]]*patch[[:space:]]*\.[[:space:]]*unused[[:space:]]*\]\][[:space:]]*(#.*)?$/)
+            cargo_checksum_scope = 1
+          else
+            cargo_checksum_scope = 0
+        }
+      }
+      if (kind == "u" && toml_multiline == "") {
+        header = line
+        sub(/^[[:space:]]*/, "", header)
+        if (substr(header, 1, 1) == "[") {
+          uv_wheels_scope = 0
+          if (header ~ /^\[\[[[:space:]]*(package|distribution)[[:space:]]*\]\][[:space:]]*(#.*)?$/)
+            uv_package_scope = 1
+          else
+            uv_package_scope = 0
+        }
+        if (uv_package_scope \
+            && header ~ /^wheels[[:space:]]*=[[:space:]]*\[[[:space:]]*(#.*)?$/)
+          uv_wheels_scope = 1
+        else if (header ~ /^\][[:space:]]*(#.*)?$/)
+          uv_wheels_scope = 0
+      }
+      json_open_role = ""
+      if (kind == "p") {
+        if (json_depth == 1 \
+            && line ~ /^[[:space:]]*"packages"[[:space:]]*:[[:space:]]*\{[[:space:]]*$/)
+          json_open_role = "package_map"
+        else if (json_depth == 1 \
+            && line ~ /^[[:space:]]*"dependencies"[[:space:]]*:[[:space:]]*\{[[:space:]]*$/)
+          json_open_role = "dependency_map"
+        else if ((json_role[json_depth] == "package_map" \
+                  || json_role[json_depth] == "dependency_map") \
+                 && line ~ /^[[:space:]]*"[^"]*"[[:space:]]*:[[:space:]]*\{[[:space:]]*$/)
+          json_open_role = "entry"
+        else if (json_role[json_depth] == "entry" \
+                 && line ~ /^[[:space:]]*"dependencies"[[:space:]]*:[[:space:]]*\{[[:space:]]*$/)
+          json_open_role = "dependency_map"
+      }
+      uv_artifact_line = 0
+      if (kind == "u" && toml_multiline == "" && uv_package_scope \
+          && (line ~ /^[[:space:]]*sdist[[:space:]]*=[[:space:]]*\{/ \
+              || line ~ /^[[:space:]]*wheels[[:space:]]*=[[:space:]]*\[[[:space:]]*\{/ \
+              || (uv_wheels_scope \
+                  && line ~ /^[[:space:]]*\{/)))
+        uv_artifact_line = 1
       encoded = line
       gsub(/./, "&" char_separator, encoded)
       split(encoded, chars, char_separator)
@@ -890,6 +945,7 @@ filter_lockfile_records() {
       escaped = 0
       field_allowed = 1
       ml_escaped = 0
+      brace_depth = 0
       i = 1
       while (i <= char_count) {
         ch = chars[i]
@@ -939,11 +995,23 @@ filter_lockfile_records() {
           break
         }
 
+        if (kind == "u" && uv_artifact_line && brace_depth == 1 \
+            && field_allowed && ch == "u") {
+          probe = substr(line, i, 256)
+          if (probe ~ /^url[[:space:]]*=[[:space:]]*"/)
+            uv_url_seen[brace_depth] = 1
+        }
+
         if (field_allowed \
             && ((kind == "p" && ch == "\"") \
                 || (kind == "y" && (ch == "i" || ch == "c")) \
                 || (kind == "c" && ch == "c") \
                 || (kind == "u" && ch == "h")) \
+            && (kind != "p" || json_role[json_depth] == "entry") \
+            && (kind != "c" || cargo_checksum_scope) \
+            && (kind != "u" \
+                || (uv_artifact_line && brace_depth == 1 \
+                    && uv_url_seen[brace_depth])) \
             && field_replacement(line, i, kind)) {
           replacements[i] = replacement_text
           skips[i] = replacement_length
@@ -974,7 +1042,36 @@ filter_lockfile_records() {
           continue
         }
 
-        if (ch == "{" || ch == ",")
+        if (ch == "{") {
+          if (kind == "p") {
+            if (json_depth >= max_json_depth) {
+              json_skip_rest = 1
+              print line
+              return
+            }
+            json_depth++
+            if (json_open_role != "") {
+              json_role[json_depth] = json_open_role
+              json_open_role = ""
+            } else {
+              json_role[json_depth] = "other"
+            }
+          }
+          brace_depth++
+          uv_url_seen[brace_depth] = 0
+          if (kind != "c") field_allowed = 1
+        } else if (ch == "}") {
+          if (kind == "p") {
+            delete json_role[json_depth]
+            if (json_depth > 0) json_depth--
+          }
+          delete uv_url_seen[brace_depth]
+          if (brace_depth > 0) brace_depth--
+          field_allowed = 0
+        # Cargo.lock checksums are line-leading fields in dependency tables,
+        # never arbitrary inline-table keys. Other supported formats do use
+        # checksum fields after record delimiters.
+        } else if (kind != "c" && ch == ",")
           field_allowed = 1
         else if (ch !~ /[[:space:]]/)
           field_allowed = 0
@@ -1007,6 +1104,7 @@ filter_lockfile_records() {
       triple_double = "\"\"\""
       char_separator = sprintf("%c", 28)
       max_structured_line_chars = 131072
+      max_json_depth = 256
       previous_kind = ""
       toml_multiline = ""
       toml_skip_rest = 0
@@ -1014,17 +1112,22 @@ filter_lockfile_records() {
     {
       kind = substr($0, 1, 1)
       line = substr($0, 3)
-      # Uppercase TOML kinds are context-free physical-record fragments. Their
-      # surrounding multiline-string state is unavailable, so leave them fully
+      # Uppercase structured kinds are context-free physical-record fragments.
+      # Their surrounding parser state is unavailable, so leave them fully
       # scannable instead of guessing that a checksum-looking field is
       # structural. Full-file records use the lowercase kinds below.
-      if (kind ~ /^[CU]$/) {
+      if (kind ~ /^[CUP]$/) {
         print line
         next
       }
       if (kind != previous_kind) {
         toml_multiline = ""
         toml_skip_rest = 0
+        json_skip_rest = 0
+        json_depth = 0
+        cargo_checksum_scope = 0
+        uv_package_scope = 0
+        uv_wheels_scope = 0
         previous_kind = kind
       }
       if (kind == "g") {
@@ -1047,8 +1150,8 @@ filter_lockfile_records() {
 }
 
 # Gitleaks' bundled defaults skip common lockfiles by path. Agent Guard rescans
-# them through stdin after removing only exact checksum-field lines; this both
-# fixes checksum false positives and keeps credentials elsewhere detectable.
+# them through stdin after replacing only exact checksum fields; this both fixes
+# checksum false positives and keeps credentials elsewhere detectable.
 filter_lockfile_hashes() {
   path=$1
   source=${2:-$path}
@@ -1154,7 +1257,7 @@ extract_added_lines() {
       count = split(path, parts, "/")
       name = parts[count]
       if (name == "go.sum") return "g"
-      if (name == "package-lock.json") return "p"
+      if (name == "package-lock.json") return "P"
       if (name == "yarn.lock") return "y"
       if (name == "Cargo.lock") return "C"
       if (name == "uv.lock") return "U"
@@ -1173,7 +1276,7 @@ extract_patch_added_lines() {
       count = split(path, parts, "/")
       name = parts[count]
       if (name == "go.sum") return "g"
-      if (name == "package-lock.json") return "p"
+      if (name == "package-lock.json") return "P"
       if (name == "yarn.lock") return "y"
       if (name == "Cargo.lock") return "C"
       if (name == "uv.lock") return "U"

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -1014,6 +1014,14 @@ filter_lockfile_records() {
     {
       kind = substr($0, 1, 1)
       line = substr($0, 3)
+      # Uppercase TOML kinds are context-free physical-record fragments. Their
+      # surrounding multiline-string state is unavailable, so leave them fully
+      # scannable instead of guessing that a checksum-looking field is
+      # structural. Full-file records use the lowercase kinds below.
+      if (kind ~ /^[CU]$/) {
+        print line
+        next
+      }
       if (kind != previous_kind) {
         toml_multiline = ""
         toml_skip_rest = 0
@@ -1104,6 +1112,15 @@ scan_file_text_direct() {
   return "$status"
 }
 
+# Edit/MultiEdit payloads contain only replacement fragments, not complete file
+# context. Structural checksum filtering is unsafe there because an unchanged
+# surrounding quote, multiline string, or earlier go.sum field is absent.
+scan_file_fragment_direct() {
+  label=$1
+  text=$3
+  scan_text_direct "$label" "$text"
+}
+
 # Scan status protocol, shared by every scan_* function and this dispatcher:
 #   0 clean, 1 a secret was found, 3 the scan could not run, other scanner error.
 # 3 exists because "I found a secret in your staged changes" and "I never got to
@@ -1139,8 +1156,8 @@ extract_added_lines() {
       if (name == "go.sum") return "g"
       if (name == "package-lock.json") return "p"
       if (name == "yarn.lock") return "y"
-      if (name == "Cargo.lock") return "c"
-      if (name == "uv.lock") return "u"
+      if (name == "Cargo.lock") return "C"
+      if (name == "uv.lock") return "U"
       return "-"
     }
     /^diff --git / { in_hunk = 0; path = ""; next }
@@ -1158,8 +1175,8 @@ extract_patch_added_lines() {
       if (name == "go.sum") return "g"
       if (name == "package-lock.json") return "p"
       if (name == "yarn.lock") return "y"
-      if (name == "Cargo.lock") return "c"
-      if (name == "uv.lock") return "u"
+      if (name == "Cargo.lock") return "C"
+      if (name == "uv.lock") return "U"
       return "-"
     }
     BEGIN { mode = "none"; in_hunk = 0 }
@@ -2249,19 +2266,19 @@ scan_proposed_write() {
     Edit)
       path=$(json_value '.tool_input.file_path // .tool_input.path // empty' "$input")
       content=$(json_value '.tool_input.new_string // empty' "$input")
-      scan_file_text_direct "proposed Edit content" "$path" "$content"
+      scan_file_fragment_direct "proposed Edit content" "$path" "$content"
       block_on_scan_status "$?" "proposed Edit contains secret-like values"
       ;;
     MultiEdit)
       path=$(json_value '.tool_input.file_path // .tool_input.path // empty' "$input")
       content=$(printf '%s' "$input" | jq -r '[.tool_input.edits[]?.new_string // empty] | join("\n")')
-      scan_file_text_direct "proposed MultiEdit content" "$path" "$content"
+      scan_file_fragment_direct "proposed MultiEdit content" "$path" "$content"
       block_on_scan_status "$?" "proposed MultiEdit contains secret-like values"
       ;;
     NotebookEdit)
       path=$(json_value '.tool_input.notebook_path // .tool_input.file_path // empty' "$input")
       content=$(json_value '.tool_input.new_source // empty' "$input")
-      scan_file_text_direct "proposed NotebookEdit content" "$path" "$content"
+      scan_file_fragment_direct "proposed NotebookEdit content" "$path" "$content"
       block_on_scan_status "$?" "proposed NotebookEdit contains secret-like values"
       ;;
     apply_patch)

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -1155,6 +1155,7 @@ filter_lockfile_records() {
 filter_lockfile_hashes() {
   path=$1
   source=${2:-$path}
+  snapshot=
   case "${path##*/}" in
     go.sum) kind=g ;;
     package-lock.json) kind=p ;;
@@ -1163,7 +1164,68 @@ filter_lockfile_hashes() {
     uv.lock) kind=u ;;
     *) cat -- "$source"; return ;;
   esac
+  if [ "$kind" = p ]; then
+    # Validate and filter the same immutable bytes. Reopening the caller-owned
+    # path after validation would let an atomic replacement swap malformed
+    # content in before the streaming field parser runs.
+    snapshot=$(mktemp_file) || { cat -- "$source"; return; }
+    if ! cat -- "$source" >"$snapshot"; then
+      rm -f "$snapshot"
+      # A full temp filesystem must not turn the filter pipeline into empty
+      # clean input. Fall back to the original bytes without neutralization.
+      cat -- "$source"
+      return
+    fi
+    source=$snapshot
+
+    # The streaming field parser cannot know that later input is truncated.
+    # Validate the complete document first, keeping only a count/type summary
+    # so large lockfiles do not need to be slurped into memory. If jq is absent,
+    # the JSON is malformed, or multiple documents are present, preserve every
+    # byte for gitleaks instead of risking an early integrity replacement.
+    if ! command -v jq >/dev/null 2>&1 \
+        || ! jq -e -n --stream '
+          reduce inputs as $event (
+            {documents: 0, in_object: false, valid: true};
+            ($event[0] // []) as $path
+            | if (.valid | not) then
+                .
+              elif .in_object then
+                if (($event | length) == 1 and ($path | length) == 1) then
+                  .in_object = false
+                else
+                  .
+                end
+              elif ($path | length) == 0 then
+                if (($event | length) == 2 and $event[1] == {}) then
+                  .documents += 1
+                else
+                  .valid = false
+                end
+              elif (($path[0] | type) == "string") then
+                .documents += 1
+                | .in_object = true
+                | if (($event | length) == 1 and ($path | length) == 1) then
+                    .in_object = false
+                  else
+                    .
+                  end
+              else
+                .valid = false
+              end
+          )
+          | .valid and (.documents == 1) and (.in_object | not)
+        ' "$source" >/dev/null 2>&1; then
+      cat -- "$source"
+      status=$?
+      rm -f "$snapshot"
+      return "$status"
+    fi
+  fi
   awk -v kind="$kind" '{ print kind "\t" $0 }' "$source" | filter_lockfile_records
+  status=$?
+  [ -z "$snapshot" ] || rm -f "$snapshot"
+  return "$status"
 }
 
 scan_lockfiles_under() {

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -3819,6 +3819,79 @@ if [ -n "$REAL_GITLEAKS" ]; then
     not_ok "lockfile filter preserves prefixed checksum-like fields byte-for-byte"
   fi
 
+  # Checksum-shaped text inside a quoted note or comment is not a structural
+  # lockfile field. It can itself be the value of a credential assignment, so
+  # neutralizing it would erase a real finding before gitleaks sees the record.
+  printf "note = 'api_token = { checksum = \"%s\" }'\n" \
+    "$LOCK_HEX" >"$LOCKFILE_FIXTURE_DIR/Cargo.lock"
+  printf "note = 'api_token = { hash = \"sha256:%s\" }'\n" \
+    "$LOCK_HEX" >"$LOCKFILE_FIXTURE_DIR/uv.lock"
+  printf 'note "api_token = { integrity sha512-%s }"\n' \
+    "$LOCK_SHA512" >"$LOCKFILE_FIXTURE_DIR/yarn.lock"
+  quoted_cargo_expected=$(cat "$LOCKFILE_FIXTURE_DIR/Cargo.lock")
+  quoted_uv_expected=$(cat "$LOCKFILE_FIXTURE_DIR/uv.lock")
+  quoted_yarn_expected=$(cat "$LOCKFILE_FIXTURE_DIR/yarn.lock")
+  quoted_cargo=$("$PLUGIN_ROOT/bin/agent-guard" filter-lockfile-hashes \
+    "$LOCKFILE_FIXTURE_DIR/Cargo.lock" "$LOCKFILE_FIXTURE_DIR/Cargo.lock")
+  quoted_uv=$("$PLUGIN_ROOT/bin/agent-guard" filter-lockfile-hashes \
+    "$LOCKFILE_FIXTURE_DIR/uv.lock" "$LOCKFILE_FIXTURE_DIR/uv.lock")
+  quoted_yarn=$("$PLUGIN_ROOT/bin/agent-guard" filter-lockfile-hashes \
+    "$LOCKFILE_FIXTURE_DIR/yarn.lock" "$LOCKFILE_FIXTURE_DIR/yarn.lock")
+  if [ "$quoted_cargo" = "$quoted_cargo_expected" ] \
+     && [ "$quoted_uv" = "$quoted_uv_expected" ] \
+     && [ "$quoted_yarn" = "$quoted_yarn_expected" ]; then
+    ok "lockfile filter preserves checksum-shaped text inside quoted values"
+  else
+    not_ok "lockfile filter does not treat quoted checksum text as structural fields"
+  fi
+
+  LOCK_CONTEXT_DIR="$TMP_ROOT/lockfile-context-dir"
+  mkdir -p "$LOCK_CONTEXT_DIR"
+  {
+    printf "note = 'api_token = { checksum = \"%s\" }', checksum = \"%s\"\n" \
+      "$LOCK_HEX" "$LOCK_HEX"
+    printf 'note = "quoted%s", checksum = "%s"\n' "\\\\" "$LOCK_HEX"
+    printf 'note = "quoted%s", checksum = "%s"\n' "\\" "$LOCK_HEX"
+  } >"$LOCK_CONTEXT_DIR/Cargo.lock"
+  context_filtered=$("$PLUGIN_ROOT/bin/agent-guard" filter-lockfile-hashes \
+    "$LOCK_CONTEXT_DIR/Cargo.lock" "$LOCK_CONTEXT_DIR/Cargo.lock")
+  context_expected=$(printf "note = 'api_token = { checksum = \"%s\" }', checksum = \"CHECKSUM\"\nnote = \"quoted%s\", checksum = \"CHECKSUM\"\nnote = \"quoted%s\", checksum = \"%s\"" \
+    "$LOCK_HEX" "\\\\" "\\" "$LOCK_HEX")
+  if [ "$context_filtered" = "$context_expected" ]; then
+    ok "lockfile filter continues after quoted text and honors backslash parity"
+  else
+    not_ok "lockfile quote context preserves odd escapes and finds later real fields"
+  fi
+
+  LOCK_MULTILINE_DIR="$TMP_ROOT/lockfile-multiline-dir"
+  mkdir -p "$LOCK_MULTILINE_DIR"
+  {
+    printf '%s\n' 'note = """'
+    printf 'api_token = { checksum = "%s" }\n' "$LOCK_HEX"
+    printf '%s\n' '"""'
+    printf 'checksum = "%s"\n' "$LOCK_HEX"
+  } >"$LOCK_MULTILINE_DIR/Cargo.lock"
+  {
+    printf "%s\n" "note = '''"
+    printf 'api_token = { hash = "sha256:%s" }\n' "$LOCK_HEX"
+    printf "%s\n" "'''"
+    printf 'hash = "sha256:%s"\n' "$LOCK_HEX"
+  } >"$LOCK_MULTILINE_DIR/uv.lock"
+  multiline_cargo=$("$PLUGIN_ROOT/bin/agent-guard" filter-lockfile-hashes \
+    "$LOCK_MULTILINE_DIR/Cargo.lock" "$LOCK_MULTILINE_DIR/Cargo.lock")
+  multiline_uv=$("$PLUGIN_ROOT/bin/agent-guard" filter-lockfile-hashes \
+    "$LOCK_MULTILINE_DIR/uv.lock" "$LOCK_MULTILINE_DIR/uv.lock")
+  multiline_cargo_expected=$(printf 'note = """\napi_token = { checksum = "%s" }\n"""\nchecksum = "CHECKSUM"' \
+    "$LOCK_HEX")
+  multiline_uv_expected=$(printf "note = '''\napi_token = { hash = \"sha256:%s\" }\n'''\nhash = \"sha256:CHECKSUM\"" \
+    "$LOCK_HEX")
+  if [ "$multiline_cargo" = "$multiline_cargo_expected" ] \
+     && [ "$multiline_uv" = "$multiline_uv_expected" ]; then
+    ok "lockfile filter preserves TOML multiline strings across physical records"
+  else
+    not_ok "lockfile filter keeps multiline basic and literal string content scannable"
+  fi
+
   # Use shapes that gitleaks actually recognizes to prove the exact-boundary
   # guard does not create a bypass in an allowlisted path.
   for lock_negative in yarn-checksum yarn-spaced-checksum cargo-checksum; do

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -16,6 +16,7 @@ MOCK_BIN="$TMP_ROOT/bin"
 ORIGINAL_PATH=$PATH
 REAL_GITLEAKS=$(command -v gitleaks 2>/dev/null || true)
 REAL_GIT=$(command -v git)
+REAL_CAT=$(command -v cat)
 REAL_CURL=$(command -v curl 2>/dev/null || true)
 REAL_JQ=$(command -v jq)
 REAL_SH=$(command -v sh)
@@ -3658,6 +3659,16 @@ lock_full_package=$(printf '%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s' '{' \
   '      }' \
   '    }' \
   '  }' '}')
+lock_structural_package=$(printf '%s\n%s\n%s\n%s\n%s\n%s\n%s' '{' \
+  '  "packages": {' \
+  '    "node_modules/example": {' \
+  "      \"integrity\": \"sha512-$LOCK_FRAGMENT_SHA512\"" \
+  '    }' \
+  '  }' '}')
+lock_truncated_package=$(printf '%s\n%s\n%s\n%s' '{' \
+  '  "packages": {' \
+  '    "node_modules/example": {' \
+  "      \"integrity\": \"sha512-$LOCK_FRAGMENT_SHA512\"")
 lock_package_fragment=$(printf '%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s' '{' \
   '  "api_token": {' \
   '    "packages": {' \
@@ -3823,6 +3834,58 @@ else
   not_ok "scan-path keeps non-schema package-lock integrity fields scannable (expected 1, got $status)"
 fi
 
+lock_truncated_write_input=$(jq -nc --arg content "$lock_truncated_package" \
+  '{tool_name:"Write",tool_input:{file_path:"package-lock.json",content:$content}}')
+printf '%s' "$lock_truncated_write_input" \
+  | AGENT_GUARD_GITLEAKS_BIN="$LOCK_FRAGMENT_BIN/gitleaks" \
+      "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool >"$OUT" 2>"$ERR"
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "Write scans malformed package-lock content without early neutralization"
+else
+  not_ok "Write keeps malformed package-lock integrity scannable (expected 2, got $status)"
+fi
+
+LOCK_SNAPSHOT_FAIL_BIN="$TMP_ROOT/package-lock-snapshot-fail-bin"
+LOCK_SNAPSHOT_FAIL_MARKER="$TMP_ROOT/package-lock-snapshot-fail-marker"
+mkdir -p "$LOCK_SNAPSHOT_FAIL_BIN"
+cat >"$LOCK_SNAPSHOT_FAIL_BIN/cat" <<'STUB'
+#!/bin/sh
+if [ "${1:-}" = "--" ] && [ ! -e "$AG_TEST_CAT_FAIL_MARKER" ]; then
+  : >"$AG_TEST_CAT_FAIL_MARKER"
+  exit 1
+fi
+exec "$AG_TEST_REAL_CAT" "$@"
+STUB
+chmod +x "$LOCK_SNAPSHOT_FAIL_BIN/cat"
+lock_snapshot_fail_write_input=$(jq -nc --arg content "$lock_structural_package" \
+  '{tool_name:"Write",tool_input:{file_path:"package-lock.json",content:$content}}')
+printf '%s' "$lock_snapshot_fail_write_input" \
+  | AGENT_GUARD_INFRA_FAILURE_MODE=closed \
+      AGENT_GUARD_GITLEAKS_BIN="$LOCK_FRAGMENT_BIN/gitleaks" \
+      AG_TEST_CAT_FAIL_MARKER="$LOCK_SNAPSHOT_FAIL_MARKER" \
+      AG_TEST_REAL_CAT="$REAL_CAT" \
+      PATH="$LOCK_SNAPSHOT_FAIL_BIN:$PATH" \
+      "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool >"$OUT" 2>"$ERR"
+status=$?
+if [ "$status" -eq 2 ] && [ -e "$LOCK_SNAPSHOT_FAIL_MARKER" ]; then
+  ok "Write scans raw package-lock content when snapshot copying fails"
+else
+  not_ok "Write does not treat package-lock snapshot failure as clean (expected 2, got $status)"
+fi
+
+printf '%s\n' "$lock_truncated_package" \
+  >"$LOCK_FULL_CONTEXT_DIR/package-lock.json"
+AGENT_GUARD_GITLEAKS_BIN="$LOCK_FRAGMENT_BIN/gitleaks" \
+  "$PLUGIN_ROOT/bin/agent-guard" scan-path \
+    "$LOCK_FULL_CONTEXT_DIR/package-lock.json" >"$OUT" 2>"$ERR"
+status=$?
+if [ "$status" -eq 1 ]; then
+  ok "scan-path preserves malformed package-lock integrity values"
+else
+  not_ok "scan-path keeps malformed package-lock integrity scannable (expected 1, got $status)"
+fi
+
 LOCK_PACKAGE_FRAGMENT_REPO="$TMP_ROOT/package-lock-fragment-git-dir"
 mkdir -p "$LOCK_PACKAGE_FRAGMENT_REPO"
 (
@@ -3864,6 +3927,27 @@ if [ "$status" -eq 1 ]; then
   ok "untracked scanning preserves Cargo checksum values outside dependency tables"
 else
   not_ok "untracked Cargo content keeps non-schema checksum fields scannable (expected 1, got $status)"
+fi
+
+LOCK_INVALID_PACKAGE_REPO="$TMP_ROOT/package-lock-invalid-git-dir"
+mkdir -p "$LOCK_INVALID_PACKAGE_REPO"
+(
+  cd "$LOCK_INVALID_PACKAGE_REPO"
+  git init -q
+  git config user.email test@example.com
+  git config user.name "Agent Guard Tests"
+  printf '%s\n' clean >README.md
+  git add README.md
+  git commit -q -m init
+  printf '%s\n' "$lock_truncated_package" >package-lock.json
+  AGENT_GUARD_GITLEAKS_BIN="$LOCK_FRAGMENT_BIN/gitleaks" \
+    "$PLUGIN_ROOT/bin/agent-guard" scan-working-tree
+) >"$OUT" 2>"$ERR"
+status=$?
+if [ "$status" -eq 1 ]; then
+  ok "untracked scanning preserves malformed package-lock integrity values"
+else
+  not_ok "untracked malformed package-lock integrity remains scannable (expected 1, got $status)"
 fi
 
 LOCK_SCHEMA_DIR="$TMP_ROOT/lockfile-schema-dir"
@@ -3950,6 +4034,52 @@ if [ "$package_schema_filtered" = "$package_schema_expected" ]; then
   ok "package-lock filtering is limited to package dependency maps"
 else
   not_ok "package-lock filtering preserves integrity fields outside its generated schema"
+fi
+
+LOCK_JSON_TRUNCATED="$LOCK_SCHEMA_DIR/package-lock-truncated.json"
+{
+  printf '%s\n' '{'
+  printf '%s\n' '  "packages": {'
+  printf '%s\n' '    "node_modules/example": {'
+  printf '      "integrity": "sha512-%s"\n' "$LOCK_FRAGMENT_SHA512"
+} >"$LOCK_JSON_TRUNCATED"
+truncated_json_filtered=$("$PLUGIN_ROOT/bin/agent-guard" filter-lockfile-hashes \
+  package-lock.json "$LOCK_JSON_TRUNCATED")
+truncated_json_expected=$(cat "$LOCK_JSON_TRUNCATED")
+if [ "$truncated_json_filtered" = "$truncated_json_expected" ]; then
+  ok "package-lock filtering preserves malformed JSON for conservative scanning"
+else
+  not_ok "package-lock filtering does not neutralize integrity before full JSON validation"
+fi
+
+LOCK_JSON_SWAP_BIN="$LOCK_SCHEMA_DIR/package-lock-swap-bin"
+LOCK_JSON_SWAP_SOURCE="$LOCK_SCHEMA_DIR/package-lock-swap.json"
+LOCK_JSON_SWAP_REPLACEMENT="$LOCK_SCHEMA_DIR/package-lock-swap-replacement.json"
+mkdir -p "$LOCK_JSON_SWAP_BIN"
+cat >"$LOCK_JSON_SWAP_BIN/jq" <<'STUB'
+#!/bin/sh
+"$AG_TEST_REAL_JQ" "$@"
+status=$?
+if [ "$status" -eq 0 ]; then
+  mv "$AG_TEST_SWAP_REPLACEMENT" "$AG_TEST_SWAP_SOURCE"
+fi
+exit "$status"
+STUB
+chmod +x "$LOCK_JSON_SWAP_BIN/jq"
+cp "$LOCK_SCHEMA_DIR/package-lock.json" "$LOCK_JSON_SWAP_SOURCE"
+cp "$LOCK_JSON_TRUNCATED" "$LOCK_JSON_SWAP_REPLACEMENT"
+swap_json_filtered=$(AG_TEST_REAL_JQ="$REAL_JQ" \
+  AG_TEST_SWAP_SOURCE="$LOCK_JSON_SWAP_SOURCE" \
+  AG_TEST_SWAP_REPLACEMENT="$LOCK_JSON_SWAP_REPLACEMENT" \
+  PATH="$LOCK_JSON_SWAP_BIN:$PATH" \
+  "$PLUGIN_ROOT/bin/agent-guard" filter-lockfile-hashes \
+    package-lock.json "$LOCK_JSON_SWAP_SOURCE")
+swap_json_source=$(cat "$LOCK_JSON_SWAP_SOURCE")
+if [ "$swap_json_filtered" = "$package_schema_expected" ] \
+    && [ "$swap_json_source" = "$truncated_json_expected" ]; then
+  ok "package-lock validation and filtering use one immutable snapshot"
+else
+  not_ok "package-lock path replacement cannot swap bytes after validation"
 fi
 
 LOCK_JSON_DEEP="$LOCK_SCHEMA_DIR/package-lock-deep.json"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -3562,6 +3562,127 @@ else
   sed 's/^/  stderr: /' "$ERR"
 fi
 
+# Context-free mutation/diff fragments cannot safely inherit structural
+# lockfile checksum filtering. This scanner stub models a supported custom rule
+# that treats nested 64-hex and h1-shaped values after api_token as findings;
+# the bundled default rules do not independently flag these exact samples.
+LOCK_FRAGMENT_HEX=$(printf '%s%s' \
+  'b112c9dc389ca44de72cc0d3a732746a' \
+  '423354b9fffedbc467449a8601ea3269')
+LOCK_FRAGMENT_H1_BODY=$(awk 'BEGIN { for (i = 0; i < 43; i++) printf "A" }')
+LOCK_FRAGMENT_H1="h1:$LOCK_FRAGMENT_H1_BODY="
+LOCK_FRAGMENT_BIN="$TMP_ROOT/lockfile-fragment-bin"
+mkdir -p "$LOCK_FRAGMENT_BIN"
+cat >"$LOCK_FRAGMENT_BIN/gitleaks" <<'STUB'
+#!/bin/sh
+case "${1:-}" in
+  stdin)
+    input=$(cat)
+    if printf '%s\n' "$input" \
+      | grep -Eq 'api_token.*(checksum[[:space:]]*=[[:space:]]*"[0-9a-f]{64}"|hash[[:space:]]*=[[:space:]]*"sha256:[0-9a-f]{64}"|h1:[A-Za-z0-9+/]{43}=)'; then
+      printf '%s\n' 'Finding: REDACTED'
+      exit 1
+    fi
+    exit 0
+    ;;
+  version) printf '%s\n' '0.0.0-lock-fragment-test' ;;
+  *) exit 0 ;;
+esac
+STUB
+chmod +x "$LOCK_FRAGMENT_BIN/gitleaks"
+
+LOCK_FRAGMENT_REPO="$TMP_ROOT/lockfile-fragment-git-dir"
+mkdir -p "$LOCK_FRAGMENT_REPO"
+(
+  cd "$LOCK_FRAGMENT_REPO"
+  git init -q
+  git config user.email test@example.com
+  git config user.name "Agent Guard Tests"
+  printf '%s\n%s\n%s\n' 'note = """' baseline '"""' >Cargo.lock
+  git add Cargo.lock
+  git commit -q -m init
+  printf '%s\n%s\n%s\n%s\n' 'note = """' baseline \
+    "api_token = { checksum = \"$LOCK_FRAGMENT_HEX\" }" '"""' >Cargo.lock
+  git add Cargo.lock
+)
+(
+  cd "$LOCK_FRAGMENT_REPO"
+  AGENT_GUARD_GITLEAKS_BIN="$LOCK_FRAGMENT_BIN/gitleaks" \
+    "$PLUGIN_ROOT/bin/agent-guard" scan-staged
+) >"$OUT" 2>"$ERR"
+status=$?
+if [ "$status" -eq 1 ]; then
+  ok "scan-staged scans TOML fragments without guessing multiline-string context"
+else
+  not_ok "scan-staged blocks a checksum-shaped credential in an unchanged multiline string (expected 1, got $status)"
+fi
+
+lock_fragment="api_token = { checksum = \"$LOCK_FRAGMENT_HEX\" }"
+lock_edit_input=$(jq -nc --arg content "$lock_fragment" \
+  '{tool_name:"Edit",tool_input:{file_path:"Cargo.lock",new_string:$content}}')
+printf '%s' "$lock_edit_input" \
+  | AGENT_GUARD_GITLEAKS_BIN="$LOCK_FRAGMENT_BIN/gitleaks" \
+      "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool >"$OUT" 2>"$ERR"
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "Edit scans a structural TOML-looking fragment conservatively"
+else
+  not_ok "Edit blocks a checksum-shaped credential without surrounding TOML context (expected 2, got $status)"
+fi
+
+lock_uv_fragment="api_token = { hash = \"sha256:$LOCK_FRAGMENT_HEX\" }"
+lock_uv_edit_input=$(jq -nc --arg content "$lock_uv_fragment" \
+  '{tool_name:"Edit",tool_input:{file_path:"uv.lock",new_string:$content}}')
+printf '%s' "$lock_uv_edit_input" \
+  | AGENT_GUARD_GITLEAKS_BIN="$LOCK_FRAGMENT_BIN/gitleaks" \
+      "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool >"$OUT" 2>"$ERR"
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "Edit scans a structural uv.lock fragment conservatively"
+else
+  not_ok "Edit blocks a hash-shaped credential without surrounding uv.lock context (expected 2, got $status)"
+fi
+
+lock_go_fragment="api_token v1.2.3 $LOCK_FRAGMENT_H1"
+lock_go_edit_input=$(jq -nc --arg content "$lock_go_fragment" \
+  '{tool_name:"Edit",tool_input:{file_path:"go.sum",new_string:$content}}')
+printf '%s' "$lock_go_edit_input" \
+  | AGENT_GUARD_GITLEAKS_BIN="$LOCK_FRAGMENT_BIN/gitleaks" \
+      "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool >"$OUT" 2>"$ERR"
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "Edit does not infer a complete go.sum record from a replacement fragment"
+else
+  not_ok "Edit preserves a checksum-shaped custom finding without earlier go.sum context (expected 2, got $status)"
+fi
+
+lock_multi_edit_input=$(jq -nc --arg content "$lock_fragment" \
+  '{tool_name:"MultiEdit",tool_input:{file_path:"Cargo.lock",edits:[{new_string:$content}]}}')
+printf '%s' "$lock_multi_edit_input" \
+  | AGENT_GUARD_GITLEAKS_BIN="$LOCK_FRAGMENT_BIN/gitleaks" \
+      "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool >"$OUT" 2>"$ERR"
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "MultiEdit scans structural TOML-looking fragments conservatively"
+else
+  not_ok "MultiEdit blocks a checksum-shaped credential without surrounding TOML context (expected 2, got $status)"
+fi
+
+lock_fragment_patch=$(printf '%s\n%s\n%s\n%s\n%s\n' \
+  '*** Begin Patch' '*** Update File: Cargo.lock' '@@' \
+  "+$lock_fragment" '*** End Patch')
+lock_fragment_patch_input=$(jq -nc --arg patch "$lock_fragment_patch" \
+  '{tool_name:"apply_patch",tool_input:{patch:$patch}}')
+printf '%s' "$lock_fragment_patch_input" \
+  | AGENT_GUARD_GITLEAKS_BIN="$LOCK_FRAGMENT_BIN/gitleaks" \
+      "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool >"$OUT" 2>"$ERR"
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "apply_patch scans structural TOML-looking fragments conservatively"
+else
+  not_ok "apply_patch blocks a checksum-shaped credential without surrounding TOML context (expected 2, got $status)"
+fi
+
 if [ -n "$REAL_GITLEAKS" ]; then
   # Synthetic PEM fixtures: gitleaks default rules match on the BEGIN/END
   # headers, so the body content is irrelevant for detection. We split the
@@ -4082,6 +4203,7 @@ if [ -n "$REAL_GITLEAKS" ]; then
   else
     not_ok "apply_patch allows a go.sum checksum (expected 0, got $status)"
   fi
+
 else
   say "real gitleaks not available; skipped real-gitleaks integration tests"
 fi

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -3985,7 +3985,7 @@ cat >"$LOCK_INCOMPLETE_TOML_BIN/gitleaks" <<'STUB'
 #!/bin/sh
 case "${1:-}" in
   stdin)
-    if grep -Eq '[0-9a-f]{64}'; then
+    if grep -Eq '[0-9a-f]{64}|h1:[A-Za-z0-9+/]{43}=|sha512-[A-Za-z0-9+/]{86}=='; then
       printf '%s\n' 'Finding: REDACTED'
       exit 1
     fi
@@ -4005,6 +4005,39 @@ for incomplete_toml_name in Cargo.lock uv.lock; do
     ok "scan-path keeps incomplete $incomplete_toml_name checksum bytes scannable"
   else
     not_ok "scan-path must detect checksum bytes in incomplete $incomplete_toml_name (expected 1, got $status)"
+  fi
+done
+
+LOCK_MALFORMED_TAIL_DIR="$TMP_ROOT/lockfile-malformed-tail-dir"
+mkdir -p "$LOCK_MALFORMED_TAIL_DIR"
+printf 'example.com/module v1.0.0 %s trailing-junk\n' \
+  "$LOCK_FRAGMENT_H1" >"$LOCK_MALFORMED_TAIL_DIR/go.sum"
+printf '  integrity sha512-%s trailing-junk\n' \
+  "$LOCK_FRAGMENT_SHA512" >"$LOCK_MALFORMED_TAIL_DIR/yarn.lock"
+{
+  printf '%s\n' '[[package]]'
+  printf 'checksum = "%s", trailing-junk\n' "$LOCK_FRAGMENT_HEX"
+} >"$LOCK_MALFORMED_TAIL_DIR/Cargo.lock"
+for malformed_tail_name in go.sum yarn.lock Cargo.lock; do
+  malformed_tail_path="$LOCK_MALFORMED_TAIL_DIR/$malformed_tail_name"
+  malformed_tail_filtered="$LOCK_MALFORMED_TAIL_DIR/$malformed_tail_name.filtered"
+  "$PLUGIN_ROOT/bin/agent-guard" filter-lockfile-hashes \
+    "$malformed_tail_path" "$malformed_tail_path" >"$malformed_tail_filtered"
+  status=$?
+  if [ "$status" -eq 0 ] \
+      && cmp -s "$malformed_tail_path" "$malformed_tail_filtered"; then
+    ok "$malformed_tail_name filtering preserves malformed trailing data"
+  else
+    not_ok "$malformed_tail_name filtering must not neutralize before trailing data"
+  fi
+  AGENT_GUARD_GITLEAKS_BIN="$LOCK_INCOMPLETE_TOML_BIN/gitleaks" \
+    "$PLUGIN_ROOT/bin/agent-guard" scan-path "$malformed_tail_path" \
+      >"$OUT" 2>"$ERR"
+  status=$?
+  if [ "$status" -eq 1 ]; then
+    ok "scan-path keeps malformed $malformed_tail_name checksum bytes scannable"
+  else
+    not_ok "scan-path must detect checksum bytes before trailing data in $malformed_tail_name (expected 1, got $status)"
   fi
 done
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -3753,6 +3753,7 @@ if [ -n "$REAL_GITLEAKS" ]; then
   LOCK_B64_BODY=${LOCK_B64%=}
   LOCK_SHA512="${LOCK_B64_BODY}${LOCK_B64_BODY}=="
   LOCK_SECRET=$(printf '%s%s' 'A1b2C3d4E5f6G7h8' 'I9j0K1l2M3n4O5p6')
+  LOCK_PATH_SECRET="${LOWPAT_HEAD}${LOWPAT_BODY}"
   LOCK_HEX=$(printf '%s%s' '0123456789abcdef0123456789abcdef' 'fedcba9876543210fedcba9876543210')
   LOCKFILE_FIXTURE_DIR="$TMP_ROOT/lockfile-hash-dir"
   mkdir -p "$LOCKFILE_FIXTURE_DIR"
@@ -3770,6 +3771,129 @@ if [ -n "$REAL_GITLEAKS" ]; then
     not_ok "recognized lockfile checksum fields stay clean (expected 0, got $status)"
     sed 's/^/  stderr: /' "$ERR"
   fi
+
+  # go.sum checksums are the third field. An h1-shaped secret in the module
+  # token must not be mistaken for that checksum and erased.
+  LOCK_HARMLESS_BODY=$(awk 'BEGIN { for (i = 0; i < 43; i++) printf "A" }')
+  printf 'clientapi-h1:%s= v1.2.3 h1:%s=\n' \
+    "$LOCK_B64_BODY" "$LOCK_HARMLESS_BODY" >"$LOCKFILE_FIXTURE_DIR/go.sum"
+  go_field_filtered=$("$PLUGIN_ROOT/bin/agent-guard" filter-lockfile-hashes \
+    "$LOCKFILE_FIXTURE_DIR/go.sum" "$LOCKFILE_FIXTURE_DIR/go.sum")
+  if printf '%s' "$go_field_filtered" | grep -Fq "clientapi-h1:$LOCK_B64_BODY=" \
+     && printf '%s' "$go_field_filtered" | grep -Fq 'v1.2.3 h1:CHECKSUM'; then
+    ok "go.sum filter neutralizes only the third checksum field"
+  else
+    not_ok "go.sum filter preserves h1-shaped module text"
+  fi
+  PATH="$(dirname "$REAL_GITLEAKS"):$ORIGINAL_PATH" "$PLUGIN_ROOT/bin/agent-guard" \
+    scan-path "$LOCKFILE_FIXTURE_DIR/go.sum" >"$OUT" 2>"$ERR"
+  status=$?
+  if [ "$status" -eq 1 ]; then
+    ok "scan-path detects an h1-shaped credential in the go.sum module field"
+  else
+    not_ok "go.sum checksum filtering keeps earlier fields scannable (expected 1, got $status)"
+  fi
+  printf 'example.com/clientapi v1.2.3 %s\n' "$LOCK_SUM" >"$LOCKFILE_FIXTURE_DIR/go.sum"
+
+  # Field names must be exact. Preserve prefixed user fields byte-for-byte even
+  # when their suffix resembles an allowlisted checksum field.
+  {
+    printf 'api_integrity sha512-%s\n' "$LOCK_SHA512"
+    printf 'api checksum: %s\n' "$LOCK_HEX"
+  } >"$LOCKFILE_FIXTURE_DIR/yarn.lock"
+  printf 'api_checksum = "%s"\n' "$LOCK_HEX" >"$LOCKFILE_FIXTURE_DIR/Cargo.lock"
+  printf 'api_hash = "sha256:%s"\n' "$LOCK_HEX" >"$LOCKFILE_FIXTURE_DIR/uv.lock"
+  prefixed_yarn=$("$PLUGIN_ROOT/bin/agent-guard" filter-lockfile-hashes \
+    "$LOCKFILE_FIXTURE_DIR/yarn.lock" "$LOCKFILE_FIXTURE_DIR/yarn.lock")
+  prefixed_cargo=$("$PLUGIN_ROOT/bin/agent-guard" filter-lockfile-hashes \
+    "$LOCKFILE_FIXTURE_DIR/Cargo.lock" "$LOCKFILE_FIXTURE_DIR/Cargo.lock")
+  prefixed_uv=$("$PLUGIN_ROOT/bin/agent-guard" filter-lockfile-hashes \
+    "$LOCKFILE_FIXTURE_DIR/uv.lock" "$LOCKFILE_FIXTURE_DIR/uv.lock")
+  prefixed_yarn_expected=$(printf 'api_integrity sha512-%s\napi checksum: %s' \
+    "$LOCK_SHA512" "$LOCK_HEX")
+  if [ "$prefixed_yarn" = "$prefixed_yarn_expected" ] \
+     && [ "$prefixed_cargo" = "api_checksum = \"$LOCK_HEX\"" ] \
+     && [ "$prefixed_uv" = "api_hash = \"sha256:$LOCK_HEX\"" ]; then
+    ok "lockfile filter does not neutralize prefixed checksum-like fields"
+  else
+    not_ok "lockfile filter preserves prefixed checksum-like fields byte-for-byte"
+  fi
+
+  # Use shapes that gitleaks actually recognizes to prove the exact-boundary
+  # guard does not create a bypass in an allowlisted path.
+  for lock_negative in yarn-checksum yarn-spaced-checksum cargo-checksum; do
+    case "$lock_negative" in
+      yarn-checksum)
+        lock_negative_path="$LOCKFILE_FIXTURE_DIR/yarn.lock"
+        printf 'api_checksum: %s\n' "$LOCK_HEX" >"$lock_negative_path"
+        ;;
+      yarn-spaced-checksum)
+        lock_negative_path="$LOCKFILE_FIXTURE_DIR/yarn.lock"
+        printf 'api checksum: %s\n' "$LOCK_HEX" >"$lock_negative_path"
+        ;;
+      cargo-checksum)
+        lock_negative_path="$LOCKFILE_FIXTURE_DIR/Cargo.lock"
+        printf 'api_checksum = "%s"\n' "$LOCK_HEX" >"$lock_negative_path"
+        ;;
+    esac
+    PATH="$(dirname "$REAL_GITLEAKS"):$ORIGINAL_PATH" "$PLUGIN_ROOT/bin/agent-guard" \
+      scan-path "$lock_negative_path" >"$OUT" 2>"$ERR"
+    status=$?
+    if [ "$status" -eq 1 ]; then
+      ok "lockfile filter keeps prefixed field $lock_negative scannable"
+    else
+      not_ok "lockfile filter does not allowlist prefixed field $lock_negative (expected 1, got $status)"
+    fi
+  done
+
+  # A valid-length checksum prefix followed by another value byte is not a
+  # complete checksum field and must remain unchanged.
+  {
+    printf 'checksum: %sa\n' "$LOCK_HEX"
+    printf 'integrity sha512-%sA\n' "$LOCK_SHA512"
+  } >"$LOCKFILE_FIXTURE_DIR/yarn.lock"
+  trailing_yarn=$("$PLUGIN_ROOT/bin/agent-guard" filter-lockfile-hashes \
+    "$LOCKFILE_FIXTURE_DIR/yarn.lock" "$LOCKFILE_FIXTURE_DIR/yarn.lock")
+  trailing_yarn_expected=$(printf 'checksum: %sa\nintegrity sha512-%sA' \
+    "$LOCK_HEX" "$LOCK_SHA512")
+  if [ "$trailing_yarn" = "$trailing_yarn_expected" ]; then
+    ok "lockfile filter requires a delimiter after a checksum value"
+  else
+    not_ok "lockfile filter does not neutralize a checksum-length prefix"
+  fi
+  printf '  integrity sha512-%s\n' "$LOCK_SHA512" >"$LOCKFILE_FIXTURE_DIR/yarn.lock"
+  printf 'checksum = "%s"\n' "$LOCK_HEX" >"$LOCKFILE_FIXTURE_DIR/Cargo.lock"
+  printf 'hash = "sha256:%s"\n' "$LOCK_HEX" >"$LOCKFILE_FIXTURE_DIR/uv.lock"
+
+  # Compact lockfile records can contain more than one recognized hash field.
+  # Neutralize every field, not only the first, while preserving both URLs.
+  printf 'wheels = [{ url = "https://example.invalid/a", hash = "sha256:%s" }, { url = "https://example.invalid/b", hash = "sha256:%s" }]\n' \
+    "$LOCK_HEX" "$LOCK_HEX" >"$LOCKFILE_FIXTURE_DIR/uv.lock"
+  multi_hash_filtered=$("$PLUGIN_ROOT/bin/agent-guard" filter-lockfile-hashes \
+    "$LOCKFILE_FIXTURE_DIR/uv.lock" "$LOCKFILE_FIXTURE_DIR/uv.lock")
+  multi_hash_count=$(printf '%s' "$multi_hash_filtered" \
+    | awk -F 'sha256:CHECKSUM' '{ total += NF - 1 } END { print total + 0 }')
+  if [ "$multi_hash_count" -eq 2 ] \
+     && printf '%s' "$multi_hash_filtered" | grep -Fq 'https://example.invalid/a' \
+     && printf '%s' "$multi_hash_filtered" | grep -Fq 'https://example.invalid/b' \
+     && ! printf '%s' "$multi_hash_filtered" | grep -Fq "$LOCK_HEX"; then
+    ok "lockfile filter neutralizes every checksum field on a compact record"
+  else
+    not_ok "lockfile filter neutralizes all compact-record checksums without dropping other text"
+  fi
+  printf 'hash = "sha256:%s"\n' "$LOCK_HEX" >"$LOCKFILE_FIXTURE_DIR/uv.lock"
+
+  printf 'sdist = { url = "https://example.invalid/pkg?api_token=%s", hash = "sha256:%s", size = 1 }\n' \
+    "$LOCK_SECRET" "$LOCK_HEX" >"$LOCKFILE_FIXTURE_DIR/uv.lock"
+  PATH="$(dirname "$REAL_GITLEAKS"):$ORIGINAL_PATH" "$PLUGIN_ROOT/bin/agent-guard" \
+    scan-path "$LOCKFILE_FIXTURE_DIR/uv.lock" >"$OUT" 2>"$ERR"
+  status=$?
+  if [ "$status" -eq 1 ]; then
+    ok "scan-path rescans a credential beside an inline uv.lock checksum"
+  else
+    not_ok "scan-path preserves non-checksum text on an inline uv.lock record (expected 1, got $status)"
+  fi
+  printf 'hash = "sha256:%s"\n' "$LOCK_HEX" >"$LOCKFILE_FIXTURE_DIR/uv.lock"
 
   cp "$LOCKFILE_FIXTURE_DIR/go.sum" "$TMP_ROOT/safe-go-sum"
   printf 'api_token = "%s"\n' "$LOCK_SECRET" >>"$LOCKFILE_FIXTURE_DIR/go.sum"
@@ -3816,6 +3940,23 @@ if [ -n "$REAL_GITLEAKS" ]; then
     sed 's/^/  stderr: /' "$ERR"
   fi
 
+  printf 'example.com/%s/client v1.2.3 %s\n' "$LOCK_PATH_SECRET" "$LOCK_SUM" \
+    >"$LOCK_GIT_DIR/go.sum"
+  (cd "$LOCK_GIT_DIR" && git add go.sum)
+  (
+    cd "$LOCK_GIT_DIR"
+    PATH="$(dirname "$REAL_GITLEAKS"):$ORIGINAL_PATH" \
+      "$PLUGIN_ROOT/bin/agent-guard" scan-staged
+  ) >"$OUT" 2>"$ERR"
+  status=$?
+  if [ "$status" -eq 1 ]; then
+    ok "scan-staged rescans a credential beside a go.sum checksum"
+  else
+    not_ok "scan-staged preserves non-checksum text on a go.sum line (expected 1, got $status)"
+  fi
+  cp "$TMP_ROOT/safe-go-sum" "$LOCK_GIT_DIR/go.sum"
+  (cd "$LOCK_GIT_DIR" && git add go.sum)
+
   printf 'api_token = "%s"\n' "$LOCK_SECRET" >>"$LOCK_GIT_DIR/go.sum"
   (cd "$LOCK_GIT_DIR" && git add go.sum)
   (
@@ -3841,6 +3982,18 @@ if [ -n "$REAL_GITLEAKS" ]; then
     ok "Write scanning preserves go.sum path context for checksum allowlisting"
   else
     not_ok "Write allows a go.sum checksum (expected 0, got $status)"
+  fi
+
+  lock_write=$(jq -nc --arg content "example.com/$LOCK_PATH_SECRET/client v1.2.3 $LOCK_SUM" \
+    '{tool_name:"Write",tool_input:{file_path:"go.sum",content:$content}}')
+  printf '%s' "$lock_write" \
+    | AGENT_GUARD_GITLEAKS_BIN="$REAL_GITLEAKS" PATH="$(dirname "$REAL_GITLEAKS"):$ORIGINAL_PATH" \
+        "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool >"$OUT" 2>"$ERR"
+  status=$?
+  if [ "$status" -eq 2 ]; then
+    ok "Write rescans a credential beside a go.sum checksum"
+  else
+    not_ok "Write preserves non-checksum text on a go.sum line (expected 2, got $status)"
   fi
 
   lock_patch=$(printf '%s\n%s\n%s\n%s\n%s\n' \

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -3950,6 +3950,64 @@ else
   not_ok "untracked malformed package-lock integrity remains scannable (expected 1, got $status)"
 fi
 
+LOCK_INCOMPLETE_TOML_DIR="$TMP_ROOT/lockfile-incomplete-toml-dir"
+mkdir -p "$LOCK_INCOMPLETE_TOML_DIR"
+{
+  printf '%s\n' '[[package]]'
+  printf 'checksum = "%s"\n' "$LOCK_FRAGMENT_HEX"
+  printf '%s\n' 'note = """'
+  printf '%s\n' 'unterminated'
+} >"$LOCK_INCOMPLETE_TOML_DIR/Cargo.lock"
+{
+  printf '%s\n' '[[package]]'
+  printf 'sdist = { url = "https://example.invalid/pkg", hash = "sha256:%s" }\n' \
+    "$LOCK_FRAGMENT_HEX"
+  printf "%s\n" "note = '''"
+  printf '%s\n' 'unterminated'
+} >"$LOCK_INCOMPLETE_TOML_DIR/uv.lock"
+for incomplete_toml_name in Cargo.lock uv.lock; do
+  incomplete_toml_path="$LOCK_INCOMPLETE_TOML_DIR/$incomplete_toml_name"
+  incomplete_toml_filtered="$LOCK_INCOMPLETE_TOML_DIR/$incomplete_toml_name.filtered"
+  "$PLUGIN_ROOT/bin/agent-guard" filter-lockfile-hashes \
+    "$incomplete_toml_path" "$incomplete_toml_path" >"$incomplete_toml_filtered"
+  status=$?
+  if [ "$status" -eq 0 ] \
+      && cmp -s "$incomplete_toml_path" "$incomplete_toml_filtered"; then
+    ok "$incomplete_toml_name filtering falls back to raw incomplete TOML"
+  else
+    not_ok "$incomplete_toml_name filtering must not emit neutralized incomplete TOML"
+  fi
+done
+
+LOCK_INCOMPLETE_TOML_BIN="$TMP_ROOT/lockfile-incomplete-toml-bin"
+mkdir -p "$LOCK_INCOMPLETE_TOML_BIN"
+cat >"$LOCK_INCOMPLETE_TOML_BIN/gitleaks" <<'STUB'
+#!/bin/sh
+case "${1:-}" in
+  stdin)
+    if grep -Eq '[0-9a-f]{64}'; then
+      printf '%s\n' 'Finding: REDACTED'
+      exit 1
+    fi
+    exit 0
+    ;;
+  version) printf '%s\n' '0.0.0-incomplete-toml-test' ;;
+  *) exit 0 ;;
+esac
+STUB
+chmod +x "$LOCK_INCOMPLETE_TOML_BIN/gitleaks"
+for incomplete_toml_name in Cargo.lock uv.lock; do
+  AGENT_GUARD_GITLEAKS_BIN="$LOCK_INCOMPLETE_TOML_BIN/gitleaks" \
+    "$PLUGIN_ROOT/bin/agent-guard" scan-path \
+      "$LOCK_INCOMPLETE_TOML_DIR/$incomplete_toml_name" >"$OUT" 2>"$ERR"
+  status=$?
+  if [ "$status" -eq 1 ]; then
+    ok "scan-path keeps incomplete $incomplete_toml_name checksum bytes scannable"
+  else
+    not_ok "scan-path must detect checksum bytes in incomplete $incomplete_toml_name (expected 1, got $status)"
+  fi
+done
+
 LOCK_SCHEMA_DIR="$TMP_ROOT/lockfile-schema-dir"
 mkdir -p "$LOCK_SCHEMA_DIR"
 {

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -3571,6 +3571,7 @@ LOCK_FRAGMENT_HEX=$(printf '%s%s' \
   '423354b9fffedbc467449a8601ea3269')
 LOCK_FRAGMENT_H1_BODY=$(awk 'BEGIN { for (i = 0; i < 43; i++) printf "A" }')
 LOCK_FRAGMENT_H1="h1:$LOCK_FRAGMENT_H1_BODY="
+LOCK_FRAGMENT_SHA512="${LOCK_FRAGMENT_H1_BODY}${LOCK_FRAGMENT_H1_BODY}=="
 LOCK_FRAGMENT_BIN="$TMP_ROOT/lockfile-fragment-bin"
 mkdir -p "$LOCK_FRAGMENT_BIN"
 cat >"$LOCK_FRAGMENT_BIN/gitleaks" <<'STUB'
@@ -3579,7 +3580,33 @@ case "${1:-}" in
   stdin)
     input=$(cat)
     if printf '%s\n' "$input" \
-      | grep -Eq 'api_token.*(checksum[[:space:]]*=[[:space:]]*"[0-9a-f]{64}"|hash[[:space:]]*=[[:space:]]*"sha256:[0-9a-f]{64}"|h1:[A-Za-z0-9+/]{43}=)'; then
+      | grep -Eq 'api_token.*(checksum[[:space:]]*=[[:space:]]*"[0-9a-f]{64}"|hash[[:space:]]*=[[:space:]]*"sha256:[0-9a-f]{64}"|h1:[A-Za-z0-9+/]{43}=)|integrity"[[:space:]]*:[[:space:]]*"sha512-[A-Za-z0-9+/]{86}=="' \
+      || printf '%s\n' "$input" | awk '
+        $0 == "[credentials]" {
+          inside_credentials = 1
+          next
+        }
+        /^[[:space:]]*\[/ {
+          inside_credentials = 0
+        }
+        inside_credentials \
+            && /^checksum[[:space:]]*=[[:space:]]*"[0-9a-f]+"/ {
+          value = $0
+          sub(/^checksum[[:space:]]*=[[:space:]]*"/, "", value)
+          sub(/".*$/, "", value)
+          if (length(value) == 64 && value !~ /[^0-9a-f]/)
+            found = 1
+        }
+        inside_credentials \
+            && /hash[[:space:]]*=[[:space:]]*"sha256:[0-9a-f]+"/ {
+          value = $0
+          sub(/^.*hash[[:space:]]*=[[:space:]]*"sha256:/, "", value)
+          sub(/".*$/, "", value)
+          if (length(value) == 64 && value !~ /[^0-9a-f]/)
+            found = 1
+        }
+        END { exit found ? 0 : 1 }
+      '; then
       printf '%s\n' 'Finding: REDACTED'
       exit 1
     fi
@@ -3618,6 +3645,27 @@ else
 fi
 
 lock_fragment="api_token = { checksum = \"$LOCK_FRAGMENT_HEX\" }"
+lock_full_cargo=$(printf '%s\n%s\n%s' '[credentials]' \
+  'api_token = "marker"' "checksum = \"$LOCK_FRAGMENT_HEX\"")
+lock_full_uv=$(printf '%s\n%s\n%s' '[credentials]' \
+  'api_token = "marker"' \
+  "sdist = { url = \"https://example.invalid/a\", hash = \"sha256:$LOCK_FRAGMENT_HEX\" }")
+lock_full_package=$(printf '%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s' '{' \
+  '  "packages": {' \
+  '    "node_modules/example": {' \
+  '      "api_token": {' \
+  "        \"integrity\": \"sha512-$LOCK_FRAGMENT_SHA512\"" \
+  '      }' \
+  '    }' \
+  '  }' '}')
+lock_package_fragment=$(printf '%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s' '{' \
+  '  "api_token": {' \
+  '    "packages": {' \
+  '      "node_modules/example": {' \
+  "        \"integrity\": \"sha512-$LOCK_FRAGMENT_SHA512\"" \
+  '      }' \
+  '    }' \
+  '  }' '}')
 lock_edit_input=$(jq -nc --arg content "$lock_fragment" \
   '{tool_name:"Edit",tool_input:{file_path:"Cargo.lock",new_string:$content}}')
 printf '%s' "$lock_edit_input" \
@@ -3681,6 +3729,248 @@ if [ "$status" -eq 2 ]; then
   ok "apply_patch scans structural TOML-looking fragments conservatively"
 else
   not_ok "apply_patch blocks a checksum-shaped credential without surrounding TOML context (expected 2, got $status)"
+fi
+
+lock_package_fragment_patch=$(printf '%s\n' \
+  '*** Begin Patch' '*** Update File: package-lock.json' '@@' \
+  '+{' '+  "api_token": {' '+    "packages": {' \
+  '+      "node_modules/example": {' \
+  "+        \"integrity\": \"sha512-$LOCK_FRAGMENT_SHA512\"" \
+  '+      }' '+    }' '+  }' '+}' '*** End Patch')
+lock_package_fragment_patch_input=$(jq -nc \
+  --arg patch "$lock_package_fragment_patch" \
+  '{tool_name:"apply_patch",tool_input:{patch:$patch}}')
+printf '%s' "$lock_package_fragment_patch_input" \
+  | AGENT_GUARD_GITLEAKS_BIN="$LOCK_FRAGMENT_BIN/gitleaks" \
+      "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool >"$OUT" 2>"$ERR"
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "apply_patch scans package-lock fragments without guessing JSON depth"
+else
+  not_ok "apply_patch keeps fragmentary package-lock integrity scannable (expected 2, got $status)"
+fi
+
+# Complete lockfiles have parser context, but checksum/hash neutralization must
+# still be limited to fields that the actual Cargo and uv schemas generate.
+lock_write_input=$(jq -nc --arg content "$lock_full_cargo" \
+  '{tool_name:"Write",tool_input:{file_path:"Cargo.lock",content:$content}}')
+printf '%s' "$lock_write_input" \
+  | AGENT_GUARD_GITLEAKS_BIN="$LOCK_FRAGMENT_BIN/gitleaks" \
+      "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool >"$OUT" 2>"$ERR"
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "Write preserves Cargo checksum values outside dependency tables"
+else
+  not_ok "Write keeps non-schema Cargo checksum fields scannable (expected 2, got $status)"
+fi
+
+LOCK_FULL_CONTEXT_DIR="$TMP_ROOT/lockfile-full-context-dir"
+mkdir -p "$LOCK_FULL_CONTEXT_DIR"
+printf '%s\n' "$lock_full_cargo" >"$LOCK_FULL_CONTEXT_DIR/Cargo.lock"
+AGENT_GUARD_GITLEAKS_BIN="$LOCK_FRAGMENT_BIN/gitleaks" \
+  "$PLUGIN_ROOT/bin/agent-guard" scan-path "$LOCK_FULL_CONTEXT_DIR" \
+  >"$OUT" 2>"$ERR"
+status=$?
+if [ "$status" -eq 1 ]; then
+  ok "scan-path preserves Cargo checksum values outside dependency tables"
+else
+  not_ok "scan-path keeps non-schema Cargo checksum fields scannable (expected 1, got $status)"
+fi
+
+lock_uv_write_input=$(jq -nc --arg content "$lock_full_uv" \
+  '{tool_name:"Write",tool_input:{file_path:"uv.lock",content:$content}}')
+printf '%s' "$lock_uv_write_input" \
+  | AGENT_GUARD_GITLEAKS_BIN="$LOCK_FRAGMENT_BIN/gitleaks" \
+      "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool >"$OUT" 2>"$ERR"
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "Write preserves uv hash values outside artifact records"
+else
+  not_ok "Write keeps non-schema uv hash fields scannable (expected 2, got $status)"
+fi
+
+printf '%s\n' "$lock_full_uv" >"$LOCK_FULL_CONTEXT_DIR/uv.lock"
+AGENT_GUARD_GITLEAKS_BIN="$LOCK_FRAGMENT_BIN/gitleaks" \
+  "$PLUGIN_ROOT/bin/agent-guard" scan-path "$LOCK_FULL_CONTEXT_DIR/uv.lock" \
+  >"$OUT" 2>"$ERR"
+status=$?
+if [ "$status" -eq 1 ]; then
+  ok "scan-path preserves uv hash values outside artifact records"
+else
+  not_ok "scan-path keeps non-schema uv hash fields scannable (expected 1, got $status)"
+fi
+
+lock_package_write_input=$(jq -nc --arg content "$lock_full_package" \
+  '{tool_name:"Write",tool_input:{file_path:"package-lock.json",content:$content}}')
+printf '%s' "$lock_package_write_input" \
+  | AGENT_GUARD_GITLEAKS_BIN="$LOCK_FRAGMENT_BIN/gitleaks" \
+      "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool >"$OUT" 2>"$ERR"
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "Write preserves package-lock integrity values outside package maps"
+else
+  not_ok "Write keeps non-schema package-lock integrity fields scannable (expected 2, got $status)"
+fi
+
+printf '%s\n' "$lock_full_package" >"$LOCK_FULL_CONTEXT_DIR/package-lock.json"
+AGENT_GUARD_GITLEAKS_BIN="$LOCK_FRAGMENT_BIN/gitleaks" \
+  "$PLUGIN_ROOT/bin/agent-guard" scan-path \
+    "$LOCK_FULL_CONTEXT_DIR/package-lock.json" >"$OUT" 2>"$ERR"
+status=$?
+if [ "$status" -eq 1 ]; then
+  ok "scan-path preserves package-lock integrity values outside package maps"
+else
+  not_ok "scan-path keeps non-schema package-lock integrity fields scannable (expected 1, got $status)"
+fi
+
+LOCK_PACKAGE_FRAGMENT_REPO="$TMP_ROOT/package-lock-fragment-git-dir"
+mkdir -p "$LOCK_PACKAGE_FRAGMENT_REPO"
+(
+  cd "$LOCK_PACKAGE_FRAGMENT_REPO"
+  git init -q
+  git config user.email test@example.com
+  git config user.name "Agent Guard Tests"
+  printf '%s\n' '{"api_token":null}' >package-lock.json
+  git add package-lock.json
+  git commit -q -m init
+  printf '%s\n' "$lock_package_fragment" >package-lock.json
+  git add package-lock.json
+  AGENT_GUARD_GITLEAKS_BIN="$LOCK_FRAGMENT_BIN/gitleaks" \
+    "$PLUGIN_ROOT/bin/agent-guard" scan-staged
+) >"$OUT" 2>"$ERR"
+status=$?
+if [ "$status" -eq 1 ]; then
+  ok "scan-staged scans package-lock fragments without guessing JSON depth"
+else
+  not_ok "scan-staged keeps fragmentary package-lock integrity scannable (expected 1, got $status)"
+fi
+
+LOCK_FULL_CONTEXT_REPO="$TMP_ROOT/lockfile-full-context-repo"
+mkdir -p "$LOCK_FULL_CONTEXT_REPO"
+(
+  cd "$LOCK_FULL_CONTEXT_REPO"
+  git init -q
+  git config user.email test@example.com
+  git config user.name "Agent Guard Tests"
+  printf '%s\n' clean >README.md
+  git add README.md
+  git commit -q -m init
+  printf '%s\n' "$lock_full_cargo" >Cargo.lock
+  AGENT_GUARD_GITLEAKS_BIN="$LOCK_FRAGMENT_BIN/gitleaks" \
+    "$PLUGIN_ROOT/bin/agent-guard" scan-working-tree
+) >"$OUT" 2>"$ERR"
+status=$?
+if [ "$status" -eq 1 ]; then
+  ok "untracked scanning preserves Cargo checksum values outside dependency tables"
+else
+  not_ok "untracked Cargo content keeps non-schema checksum fields scannable (expected 1, got $status)"
+fi
+
+LOCK_SCHEMA_DIR="$TMP_ROOT/lockfile-schema-dir"
+mkdir -p "$LOCK_SCHEMA_DIR"
+{
+  printf '%s\n' '[[package]]'
+  printf 'checksum = "%s"\n' "$LOCK_FRAGMENT_HEX"
+  printf '%s\n' '[root]'
+  printf 'checksum = "%s"\n' "$LOCK_FRAGMENT_HEX"
+  printf '%s\n' '[[patch.unused]]'
+  printf 'checksum = "%s"\n' "$LOCK_FRAGMENT_HEX"
+  printf '%s\n' '[credentials]'
+  printf '%s\n' 'api_token = "marker"'
+  printf 'checksum = "%s"\n' "$LOCK_FRAGMENT_HEX"
+} >"$LOCK_SCHEMA_DIR/Cargo.lock"
+cargo_schema_filtered=$("$PLUGIN_ROOT/bin/agent-guard" filter-lockfile-hashes \
+  "$LOCK_SCHEMA_DIR/Cargo.lock" "$LOCK_SCHEMA_DIR/Cargo.lock")
+cargo_schema_expected=$(printf '[[package]]\nchecksum = "CHECKSUM"\n[root]\nchecksum = "CHECKSUM"\n[[patch.unused]]\nchecksum = "CHECKSUM"\n[credentials]\napi_token = "marker"\nchecksum = "%s"' \
+  "$LOCK_FRAGMENT_HEX")
+if [ "$cargo_schema_filtered" = "$cargo_schema_expected" ]; then
+  ok "Cargo.lock filtering is limited to dependency checksum tables"
+else
+  not_ok "Cargo.lock filtering preserves checksum fields outside its generated schema"
+fi
+
+{
+  printf '%s\n' '[[package]]'
+  printf 'sdist = { url = "https://example.invalid/sdist", hash = "sha256:%s" }\n' \
+    "$LOCK_FRAGMENT_HEX"
+  printf '%s\n' 'wheels = ['
+  printf '    { url = "https://example.invalid/a", hash = "sha256:%s" },\n' \
+    "$LOCK_FRAGMENT_HEX"
+  printf '    { url = "https://example.invalid/b", hash = "sha256:%s" },\n' \
+    "$LOCK_FRAGMENT_HEX"
+  printf '%s\n' ']'
+  printf '%s\n' '[[distribution]]'
+  printf 'sdist = { url = "https://example.invalid/legacy", hash = "sha256:%s" }\n' \
+    "$LOCK_FRAGMENT_HEX"
+  printf '%s\n' '[credentials]'
+  printf '%s\n' 'api_token = "marker"'
+  printf 'sdist = { url = "https://example.invalid/forged", hash = "sha256:%s" }\n' \
+    "$LOCK_FRAGMENT_HEX"
+} >"$LOCK_SCHEMA_DIR/uv.lock"
+uv_schema_filtered=$("$PLUGIN_ROOT/bin/agent-guard" filter-lockfile-hashes \
+  "$LOCK_SCHEMA_DIR/uv.lock" "$LOCK_SCHEMA_DIR/uv.lock")
+uv_schema_expected=$(printf '[[package]]\nsdist = { url = "https://example.invalid/sdist", hash = "sha256:CHECKSUM" }\nwheels = [\n    { url = "https://example.invalid/a", hash = "sha256:CHECKSUM" },\n    { url = "https://example.invalid/b", hash = "sha256:CHECKSUM" },\n]\n[[distribution]]\nsdist = { url = "https://example.invalid/legacy", hash = "sha256:CHECKSUM" }\n[credentials]\napi_token = "marker"\nsdist = { url = "https://example.invalid/forged", hash = "sha256:%s" }' \
+  "$LOCK_FRAGMENT_HEX")
+if [ "$uv_schema_filtered" = "$uv_schema_expected" ]; then
+  ok "uv.lock filtering is limited to URL-bearing artifact records"
+else
+  not_ok "uv.lock filtering preserves hash fields outside generated artifact records"
+fi
+
+{
+  printf '%s\n' '{'
+  printf '%s\n' '  "packages": {'
+  printf '%s\n' '    "node_modules/example": {'
+  printf '      "integrity": "sha512-%s",\n' "$LOCK_FRAGMENT_SHA512"
+  printf '%s\n' '      "api_token": {'
+  printf '        "integrity": "sha512-%s"\n' "$LOCK_FRAGMENT_SHA512"
+  printf '%s\n' '      }'
+  printf '%s\n' '    }'
+  printf '%s\n' '  },'
+  printf '%s\n' '  "dependencies": {'
+  printf '%s\n' '    "example": {'
+  printf '      "integrity": "sha512-%s",\n' "$LOCK_FRAGMENT_SHA512"
+  printf '%s\n' '      "dependencies": {'
+  printf '%s\n' '        "nested": {'
+  printf '          "integrity": "sha512-%s"\n' "$LOCK_FRAGMENT_SHA512"
+  printf '%s\n' '        }'
+  printf '%s\n' '      }'
+  printf '%s\n' '    }'
+  printf '%s\n' '  },'
+  printf '%s\n' '  "api_token": {'
+  printf '    "integrity": "sha512-%s"\n' "$LOCK_FRAGMENT_SHA512"
+  printf '%s\n' '  }'
+  printf '%s\n' '}'
+} >"$LOCK_SCHEMA_DIR/package-lock.json"
+package_schema_filtered=$("$PLUGIN_ROOT/bin/agent-guard" filter-lockfile-hashes \
+  "$LOCK_SCHEMA_DIR/package-lock.json" "$LOCK_SCHEMA_DIR/package-lock.json")
+package_schema_expected=$(printf '{\n  "packages": {\n    "node_modules/example": {\n      "integrity": "CHECKSUM",\n      "api_token": {\n        "integrity": "sha512-%s"\n      }\n    }\n  },\n  "dependencies": {\n    "example": {\n      "integrity": "CHECKSUM",\n      "dependencies": {\n        "nested": {\n          "integrity": "CHECKSUM"\n        }\n      }\n    }\n  },\n  "api_token": {\n    "integrity": "sha512-%s"\n  }\n}' \
+  "$LOCK_FRAGMENT_SHA512" "$LOCK_FRAGMENT_SHA512")
+if [ "$package_schema_filtered" = "$package_schema_expected" ]; then
+  ok "package-lock filtering is limited to package dependency maps"
+else
+  not_ok "package-lock filtering preserves integrity fields outside its generated schema"
+fi
+
+LOCK_JSON_DEEP="$LOCK_SCHEMA_DIR/package-lock-deep.json"
+{
+  json_depth_i=0
+  while [ "$json_depth_i" -lt 260 ]; do
+    printf '%s\n' '{'
+    json_depth_i=$((json_depth_i + 1))
+  done
+  printf '"integrity": "sha512-%s"\n' "$LOCK_FRAGMENT_SHA512"
+} >"$LOCK_JSON_DEEP"
+deep_json_filtered=$("$PLUGIN_ROOT/bin/agent-guard" filter-lockfile-hashes \
+  package-lock.json "$LOCK_JSON_DEEP")
+deep_json_lines=$(wc -l <"$LOCK_JSON_DEEP" | tr -d ' ')
+deep_json_filtered_lines=$(printf '%s\n' "$deep_json_filtered" | wc -l | tr -d ' ')
+if printf '%s' "$deep_json_filtered" \
+     | grep -Fq "sha512-$LOCK_FRAGMENT_SHA512" \
+   && [ "$deep_json_filtered_lines" -eq "$deep_json_lines" ]; then
+  ok "package-lock filtering fails conservative beyond bounded JSON depth"
+else
+  not_ok "package-lock filtering bounds nested parser state without dropping content"
 fi
 
 if [ -n "$REAL_GITLEAKS" ]; then
@@ -3879,10 +4169,20 @@ if [ -n "$REAL_GITLEAKS" ]; then
   LOCKFILE_FIXTURE_DIR="$TMP_ROOT/lockfile-hash-dir"
   mkdir -p "$LOCKFILE_FIXTURE_DIR"
   printf 'example.com/clientapi v1.2.3 %s\n' "$LOCK_SUM" >"$LOCKFILE_FIXTURE_DIR/go.sum"
-  printf '  "integrity": "sha512-%s"\n' "$LOCK_SHA512" >"$LOCKFILE_FIXTURE_DIR/package-lock.json"
+  {
+    printf '%s\n' '{'
+    printf '%s\n' '  "packages": {'
+    printf '%s\n' '    "node_modules/example": {'
+    printf '      "integrity": "sha512-%s"\n' "$LOCK_SHA512"
+    printf '%s\n' '    }'
+    printf '%s\n' '  }'
+    printf '%s\n' '}'
+  } >"$LOCKFILE_FIXTURE_DIR/package-lock.json"
   printf '  integrity sha512-%s\n' "$LOCK_SHA512" >"$LOCKFILE_FIXTURE_DIR/yarn.lock"
-  printf 'checksum = "%s"\n' "$LOCK_HEX" >"$LOCKFILE_FIXTURE_DIR/Cargo.lock"
-  printf 'hash = "sha256:%s"\n' "$LOCK_HEX" >"$LOCKFILE_FIXTURE_DIR/uv.lock"
+  printf '[[package]]\nchecksum = "%s"\n' \
+    "$LOCK_HEX" >"$LOCKFILE_FIXTURE_DIR/Cargo.lock"
+  printf '[[package]]\nsdist = { url = "https://example.invalid/pkg", hash = "sha256:%s" }\n' \
+    "$LOCK_HEX" >"$LOCKFILE_FIXTURE_DIR/uv.lock"
   PATH="$(dirname "$REAL_GITLEAKS"):$ORIGINAL_PATH" "$PLUGIN_ROOT/bin/agent-guard" \
     scan-path "$LOCKFILE_FIXTURE_DIR" >"$OUT" 2>"$ERR"
   status=$?
@@ -3923,7 +4223,8 @@ if [ -n "$REAL_GITLEAKS" ]; then
     printf 'api checksum: %s\n' "$LOCK_HEX"
   } >"$LOCKFILE_FIXTURE_DIR/yarn.lock"
   printf 'api_checksum = "%s"\n' "$LOCK_HEX" >"$LOCKFILE_FIXTURE_DIR/Cargo.lock"
-  printf 'api_hash = "sha256:%s"\n' "$LOCK_HEX" >"$LOCKFILE_FIXTURE_DIR/uv.lock"
+  printf '[[package]]\napi_hash = "sha256:%s"\n' \
+    "$LOCK_HEX" >"$LOCKFILE_FIXTURE_DIR/uv.lock"
   prefixed_yarn=$("$PLUGIN_ROOT/bin/agent-guard" filter-lockfile-hashes \
     "$LOCKFILE_FIXTURE_DIR/yarn.lock" "$LOCKFILE_FIXTURE_DIR/yarn.lock")
   prefixed_cargo=$("$PLUGIN_ROOT/bin/agent-guard" filter-lockfile-hashes \
@@ -3934,7 +4235,7 @@ if [ -n "$REAL_GITLEAKS" ]; then
     "$LOCK_SHA512" "$LOCK_HEX")
   if [ "$prefixed_yarn" = "$prefixed_yarn_expected" ] \
      && [ "$prefixed_cargo" = "api_checksum = \"$LOCK_HEX\"" ] \
-     && [ "$prefixed_uv" = "api_hash = \"sha256:$LOCK_HEX\"" ]; then
+     && [ "$prefixed_uv" = "$(printf '[[package]]\napi_hash = "sha256:%s"' "$LOCK_HEX")" ]; then
     ok "lockfile filter does not neutralize prefixed checksum-like fields"
   else
     not_ok "lockfile filter preserves prefixed checksum-like fields byte-for-byte"
@@ -3945,7 +4246,7 @@ if [ -n "$REAL_GITLEAKS" ]; then
   # neutralizing it would erase a real finding before gitleaks sees the record.
   printf "note = 'api_token = { checksum = \"%s\" }'\n" \
     "$LOCK_HEX" >"$LOCKFILE_FIXTURE_DIR/Cargo.lock"
-  printf "note = 'api_token = { hash = \"sha256:%s\" }'\n" \
+  printf "[[package]]\nnote = 'api_token = { hash = \"sha256:%s\" }'\n" \
     "$LOCK_HEX" >"$LOCKFILE_FIXTURE_DIR/uv.lock"
   printf 'note "api_token = { integrity sha512-%s }"\n' \
     "$LOCK_SHA512" >"$LOCKFILE_FIXTURE_DIR/yarn.lock"
@@ -3969,42 +4270,46 @@ if [ -n "$REAL_GITLEAKS" ]; then
   LOCK_CONTEXT_DIR="$TMP_ROOT/lockfile-context-dir"
   mkdir -p "$LOCK_CONTEXT_DIR"
   {
-    printf "note = 'api_token = { checksum = \"%s\" }', checksum = \"%s\"\n" \
-      "$LOCK_HEX" "$LOCK_HEX"
-    printf 'note = "quoted%s", checksum = "%s"\n' "\\\\" "$LOCK_HEX"
-    printf 'note = "quoted%s", checksum = "%s"\n' "\\" "$LOCK_HEX"
-  } >"$LOCK_CONTEXT_DIR/Cargo.lock"
+    printf '%s\n' '[[package]]'
+    printf 'sdist = { url = "https://example.invalid/pkg?api_token=%s", hash = "sha256:%s" }\n' \
+      "$LOCK_SECRET" "$LOCK_HEX"
+    printf 'sdist = { url = "quoted%s", hash = "sha256:%s" }\n' "\\\\" "$LOCK_HEX"
+    printf 'sdist = { url = "quoted%s", hash = "sha256:%s" }\n' "\\" "$LOCK_HEX"
+  } >"$LOCK_CONTEXT_DIR/uv.lock"
   context_filtered=$("$PLUGIN_ROOT/bin/agent-guard" filter-lockfile-hashes \
-    "$LOCK_CONTEXT_DIR/Cargo.lock" "$LOCK_CONTEXT_DIR/Cargo.lock")
-  context_expected=$(printf "note = 'api_token = { checksum = \"%s\" }', checksum = \"CHECKSUM\"\nnote = \"quoted%s\", checksum = \"CHECKSUM\"\nnote = \"quoted%s\", checksum = \"%s\"" \
-    "$LOCK_HEX" "\\\\" "\\" "$LOCK_HEX")
+    "$LOCK_CONTEXT_DIR/uv.lock" "$LOCK_CONTEXT_DIR/uv.lock")
+  context_expected=$(printf "[[package]]\nsdist = { url = \"https://example.invalid/pkg?api_token=%s\", hash = \"sha256:CHECKSUM\" }\nsdist = { url = \"quoted%s\", hash = \"sha256:CHECKSUM\" }\nsdist = { url = \"quoted%s\", hash = \"sha256:%s\" }" \
+    "$LOCK_SECRET" "\\\\" "\\" "$LOCK_HEX")
   if [ "$context_filtered" = "$context_expected" ]; then
-    ok "lockfile filter continues after quoted text and honors backslash parity"
+    ok "uv.lock filter continues after quoted text and honors backslash parity"
   else
-    not_ok "lockfile quote context preserves odd escapes and finds later real fields"
+    not_ok "uv.lock quote context preserves odd escapes and finds later real hash fields"
   fi
 
   LOCK_MULTILINE_DIR="$TMP_ROOT/lockfile-multiline-dir"
   mkdir -p "$LOCK_MULTILINE_DIR"
   {
+    printf '%s\n' '[[package]]'
     printf '%s\n' 'note = """'
     printf 'api_token = { checksum = "%s" }\n' "$LOCK_HEX"
     printf '%s\n' '"""'
     printf 'checksum = "%s"\n' "$LOCK_HEX"
   } >"$LOCK_MULTILINE_DIR/Cargo.lock"
   {
+    printf '%s\n' '[[package]]'
     printf "%s\n" "note = '''"
     printf 'api_token = { hash = "sha256:%s" }\n' "$LOCK_HEX"
     printf "%s\n" "'''"
-    printf 'hash = "sha256:%s"\n' "$LOCK_HEX"
+    printf 'sdist = { url = "https://example.invalid/pkg", hash = "sha256:%s" }\n' \
+      "$LOCK_HEX"
   } >"$LOCK_MULTILINE_DIR/uv.lock"
   multiline_cargo=$("$PLUGIN_ROOT/bin/agent-guard" filter-lockfile-hashes \
     "$LOCK_MULTILINE_DIR/Cargo.lock" "$LOCK_MULTILINE_DIR/Cargo.lock")
   multiline_uv=$("$PLUGIN_ROOT/bin/agent-guard" filter-lockfile-hashes \
     "$LOCK_MULTILINE_DIR/uv.lock" "$LOCK_MULTILINE_DIR/uv.lock")
-  multiline_cargo_expected=$(printf 'note = """\napi_token = { checksum = "%s" }\n"""\nchecksum = "CHECKSUM"' \
+  multiline_cargo_expected=$(printf '[[package]]\nnote = """\napi_token = { checksum = "%s" }\n"""\nchecksum = "CHECKSUM"' \
     "$LOCK_HEX")
-  multiline_uv_expected=$(printf "note = '''\napi_token = { hash = \"sha256:%s\" }\n'''\nhash = \"sha256:CHECKSUM\"" \
+  multiline_uv_expected=$(printf "[[package]]\nnote = '''\napi_token = { hash = \"sha256:%s\" }\n'''\nsdist = { url = \"https://example.invalid/pkg\", hash = \"sha256:CHECKSUM\" }" \
     "$LOCK_HEX")
   if [ "$multiline_cargo" = "$multiline_cargo_expected" ] \
      && [ "$multiline_uv" = "$multiline_uv_expected" ]; then
@@ -4056,12 +4361,14 @@ if [ -n "$REAL_GITLEAKS" ]; then
     not_ok "lockfile filter does not neutralize a checksum-length prefix"
   fi
   printf '  integrity sha512-%s\n' "$LOCK_SHA512" >"$LOCKFILE_FIXTURE_DIR/yarn.lock"
-  printf 'checksum = "%s"\n' "$LOCK_HEX" >"$LOCKFILE_FIXTURE_DIR/Cargo.lock"
-  printf 'hash = "sha256:%s"\n' "$LOCK_HEX" >"$LOCKFILE_FIXTURE_DIR/uv.lock"
+  printf '[[package]]\nchecksum = "%s"\n' \
+    "$LOCK_HEX" >"$LOCKFILE_FIXTURE_DIR/Cargo.lock"
+  printf '[[package]]\nsdist = { url = "https://example.invalid/pkg", hash = "sha256:%s" }\n' \
+    "$LOCK_HEX" >"$LOCKFILE_FIXTURE_DIR/uv.lock"
 
   # Compact lockfile records can contain more than one recognized hash field.
   # Neutralize every field, not only the first, while preserving both URLs.
-  printf 'wheels = [{ url = "https://example.invalid/a", hash = "sha256:%s" }, { url = "https://example.invalid/b", hash = "sha256:%s" }]\n' \
+  printf '[[package]]\nwheels = [{ url = "https://example.invalid/a", hash = "sha256:%s" }, { url = "https://example.invalid/b", hash = "sha256:%s" }]\n' \
     "$LOCK_HEX" "$LOCK_HEX" >"$LOCKFILE_FIXTURE_DIR/uv.lock"
   multi_hash_filtered=$("$PLUGIN_ROOT/bin/agent-guard" filter-lockfile-hashes \
     "$LOCKFILE_FIXTURE_DIR/uv.lock" "$LOCKFILE_FIXTURE_DIR/uv.lock")
@@ -4077,7 +4384,7 @@ if [ -n "$REAL_GITLEAKS" ]; then
   fi
   printf 'hash = "sha256:%s"\n' "$LOCK_HEX" >"$LOCKFILE_FIXTURE_DIR/uv.lock"
 
-  printf 'sdist = { url = "https://example.invalid/pkg?api_token=%s", hash = "sha256:%s", size = 1 }\n' \
+  printf '[[package]]\nsdist = { url = "https://example.invalid/pkg?api_token=%s", hash = "sha256:%s", size = 1 }\n' \
     "$LOCK_SECRET" "$LOCK_HEX" >"$LOCKFILE_FIXTURE_DIR/uv.lock"
   PATH="$(dirname "$REAL_GITLEAKS"):$ORIGINAL_PATH" "$PLUGIN_ROOT/bin/agent-guard" \
     scan-path "$LOCKFILE_FIXTURE_DIR/uv.lock" >"$OUT" 2>"$ERR"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -4001,6 +4001,47 @@ else
   not_ok "uv.lock filtering preserves hash fields outside generated artifact records"
 fi
 
+LOCK_NUL_UV="$LOCK_SCHEMA_DIR/uv-nul.lock"
+LOCK_NUL_FILTERED="$LOCK_SCHEMA_DIR/uv-nul.filtered"
+{
+  printf '%s\n' '[[package]]'
+  printf 'sdist = { url = "https://example.invalid/nul", hash = "sha256:%s" }' \
+    "$LOCK_FRAGMENT_HEX"
+  printf '\000api_token = "%s"\n' "$LOCK_FRAGMENT_HEX"
+} >"$LOCK_NUL_UV"
+"$PLUGIN_ROOT/bin/agent-guard" filter-lockfile-hashes \
+  uv.lock "$LOCK_NUL_UV" >"$LOCK_NUL_FILTERED"
+if cmp -s "$LOCK_NUL_UV" "$LOCK_NUL_FILTERED"; then
+  ok "lockfile filtering preserves NUL-bearing input byte-for-byte"
+else
+  not_ok "lockfile filtering must not let awk discard bytes after NUL"
+fi
+
+LOCK_INVALID_UTF8_UV="$LOCK_SCHEMA_DIR/uv-invalid-utf8.lock"
+LOCK_INVALID_UTF8_FILTERED="$LOCK_SCHEMA_DIR/uv-invalid-utf8.filtered"
+LOCK_INVALID_UTF8_EXPECTED="$LOCK_SCHEMA_DIR/uv-invalid-utf8.expected"
+{
+  printf '%s\n' '[[package]]'
+  printf 'sdist = { url = "https://example.invalid/invalid", hash = "sha256:%s" }' \
+    "$LOCK_FRAGMENT_HEX"
+  printf '\377api_token = "%s"\n' "$LOCK_FRAGMENT_HEX"
+} >"$LOCK_INVALID_UTF8_UV"
+{
+  printf '%s\n' '[[package]]'
+  printf '%s' \
+    'sdist = { url = "https://example.invalid/invalid", hash = "sha256:CHECKSUM" }'
+  printf '\377api_token = "%s"\n' "$LOCK_FRAGMENT_HEX"
+} >"$LOCK_INVALID_UTF8_EXPECTED"
+"$PLUGIN_ROOT/bin/agent-guard" filter-lockfile-hashes \
+  uv.lock "$LOCK_INVALID_UTF8_UV" >"$LOCK_INVALID_UTF8_FILTERED"
+status=$?
+if [ "$status" -eq 0 ] \
+    && cmp -s "$LOCK_INVALID_UTF8_EXPECTED" "$LOCK_INVALID_UTF8_FILTERED"; then
+  ok "lockfile filtering preserves invalid UTF-8 bytes and their credential suffix"
+else
+  not_ok "lockfile filtering must parse invalid UTF-8 in the byte locale"
+fi
+
 {
   printf '%s\n' '{'
   printf '%s\n' '  "packages": {'
@@ -4321,6 +4362,62 @@ if [ -n "$REAL_GITLEAKS" ]; then
   else
     not_ok "recognized lockfile checksum fields stay clean (expected 0, got $status)"
     sed 's/^/  stderr: /' "$ERR"
+  fi
+
+  {
+    printf '%s\n' '[[package]]'
+    printf 'sdist = { url = "https://example.invalid/nul", hash = "sha256:%s" }' \
+      "$LOCK_HEX"
+    printf '\000AGDEMO_VAR=%s\n' "$LOCK_PATH_SECRET"
+  } >"$LOCKFILE_FIXTURE_DIR/uv.lock"
+  PATH="$(dirname "$REAL_GITLEAKS"):$ORIGINAL_PATH" "$PLUGIN_ROOT/bin/agent-guard" \
+    scan-path "$LOCKFILE_FIXTURE_DIR/uv.lock" >"$OUT" 2>"$ERR"
+  status=$?
+  if [ "$status" -eq 1 ]; then
+    ok "scan-path detects a credential after NUL in a recognized lockfile"
+  else
+    not_ok "NUL-bearing lockfile input remains fully scannable (expected 1, got $status)"
+  fi
+
+  {
+    printf '%s\n' '[[package]]'
+    printf 'sdist = { url = "https://example.invalid/invalid", hash = "sha256:%s" }' \
+      "$LOCK_HEX"
+    printf '\377AGDEMO_VAR=%s\n' "$LOCK_PATH_SECRET"
+  } >"$LOCKFILE_FIXTURE_DIR/uv.lock"
+  PATH="$(dirname "$REAL_GITLEAKS"):$ORIGINAL_PATH" "$PLUGIN_ROOT/bin/agent-guard" \
+    scan-path "$LOCKFILE_FIXTURE_DIR/uv.lock" >"$OUT" 2>"$ERR"
+  status=$?
+  if [ "$status" -eq 1 ]; then
+    ok "scan-path detects a credential after invalid UTF-8 in a recognized lockfile"
+  else
+    not_ok "invalid-UTF-8 lockfile input remains fully scannable (expected 1, got $status)"
+  fi
+
+  LOCK_BINARY_UNTRACKED_REPO="$TMP_ROOT/lockfile-binary-untracked-git-dir"
+  mkdir -p "$LOCK_BINARY_UNTRACKED_REPO"
+  (
+    cd "$LOCK_BINARY_UNTRACKED_REPO"
+    git init -q
+    git config user.email test@example.com
+    git config user.name "Agent Guard Tests"
+    printf '%s\n' clean >README.md
+    git add README.md
+    git commit -q -m init
+    {
+      printf '%s\n' '[[package]]'
+      printf 'sdist = { url = "https://example.invalid/untracked", hash = "sha256:%s" }' \
+        "$LOCK_HEX"
+      printf '\377AGDEMO_VAR=%s\n' "$LOCK_PATH_SECRET"
+    } >uv.lock
+    PATH="$(dirname "$REAL_GITLEAKS"):$ORIGINAL_PATH" \
+      "$PLUGIN_ROOT/bin/agent-guard" scan-working-tree
+  ) >"$OUT" 2>"$ERR"
+  status=$?
+  if [ "$status" -eq 1 ]; then
+    ok "untracked scanning detects a credential after invalid UTF-8 in a lockfile"
+  else
+    not_ok "binary-safe untracked lockfile preparation preserves findings (expected 1, got $status)"
   fi
 
   # go.sum checksums are the third field. An h1-shaped secret in the module

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -3965,18 +3965,50 @@ mkdir -p "$LOCK_INCOMPLETE_TOML_DIR"
   printf "%s\n" "note = '''"
   printf '%s\n' 'unterminated'
 } >"$LOCK_INCOMPLETE_TOML_DIR/uv.lock"
-for incomplete_toml_name in Cargo.lock uv.lock; do
-  incomplete_toml_path="$LOCK_INCOMPLETE_TOML_DIR/$incomplete_toml_name"
-  incomplete_toml_filtered="$LOCK_INCOMPLETE_TOML_DIR/$incomplete_toml_name.filtered"
-  "$PLUGIN_ROOT/bin/agent-guard" filter-lockfile-hashes \
-    "$incomplete_toml_path" "$incomplete_toml_path" >"$incomplete_toml_filtered"
-  status=$?
-  if [ "$status" -eq 0 ] \
-      && cmp -s "$incomplete_toml_path" "$incomplete_toml_filtered"; then
-    ok "$incomplete_toml_name filtering falls back to raw incomplete TOML"
-  else
-    not_ok "$incomplete_toml_name filtering must not emit neutralized incomplete TOML"
-  fi
+
+LOCK_INCOMPLETE_QUOTE_DIR="$TMP_ROOT/lockfile-incomplete-quote-dir"
+LOCK_INCOMPLETE_INLINE_DIR="$TMP_ROOT/lockfile-incomplete-inline-dir"
+LOCK_INCOMPLETE_ARRAY_DIR="$TMP_ROOT/lockfile-incomplete-array-dir"
+mkdir -p "$LOCK_INCOMPLETE_QUOTE_DIR" "$LOCK_INCOMPLETE_INLINE_DIR" \
+  "$LOCK_INCOMPLETE_ARRAY_DIR"
+for incomplete_toml_dir in "$LOCK_INCOMPLETE_QUOTE_DIR" \
+    "$LOCK_INCOMPLETE_INLINE_DIR" "$LOCK_INCOMPLETE_ARRAY_DIR"; do
+  case "$incomplete_toml_dir" in
+    "$LOCK_INCOMPLETE_QUOTE_DIR") incomplete_toml_tail='note = "unterminated' ;;
+    "$LOCK_INCOMPLETE_INLINE_DIR") incomplete_toml_tail='note = { key = "value"' ;;
+    "$LOCK_INCOMPLETE_ARRAY_DIR") incomplete_toml_tail='note = [1, 2' ;;
+  esac
+  {
+    printf '%s\n' '[[package]]'
+    printf 'checksum = "%s"\n' "$LOCK_FRAGMENT_HEX"
+    printf '%s\n' "$incomplete_toml_tail"
+  } >"$incomplete_toml_dir/Cargo.lock"
+  {
+    printf '%s\n' '[[package]]'
+    printf 'sdist = { url = "https://example.invalid/pkg", hash = "sha256:%s" }\n' \
+      "$LOCK_FRAGMENT_HEX"
+    printf '%s\n' "$incomplete_toml_tail"
+  } >"$incomplete_toml_dir/uv.lock"
+done
+
+for incomplete_toml_dir in "$LOCK_INCOMPLETE_TOML_DIR" \
+    "$LOCK_INCOMPLETE_QUOTE_DIR" "$LOCK_INCOMPLETE_INLINE_DIR" \
+    "$LOCK_INCOMPLETE_ARRAY_DIR"; do
+  incomplete_toml_case=${incomplete_toml_dir##*lockfile-incomplete-}
+  incomplete_toml_case=${incomplete_toml_case%-dir}
+  for incomplete_toml_name in Cargo.lock uv.lock; do
+    incomplete_toml_path="$incomplete_toml_dir/$incomplete_toml_name"
+    incomplete_toml_filtered="$incomplete_toml_dir/$incomplete_toml_name.filtered"
+    "$PLUGIN_ROOT/bin/agent-guard" filter-lockfile-hashes \
+      "$incomplete_toml_path" "$incomplete_toml_path" >"$incomplete_toml_filtered"
+    status=$?
+    if [ "$status" -eq 0 ] \
+        && cmp -s "$incomplete_toml_path" "$incomplete_toml_filtered"; then
+      ok "$incomplete_toml_name filtering falls back for incomplete $incomplete_toml_case TOML"
+    else
+      not_ok "$incomplete_toml_name filtering must preserve incomplete $incomplete_toml_case TOML"
+    fi
+  done
 done
 
 LOCK_INCOMPLETE_TOML_BIN="$TMP_ROOT/lockfile-incomplete-toml-bin"
@@ -3996,16 +4028,22 @@ case "${1:-}" in
 esac
 STUB
 chmod +x "$LOCK_INCOMPLETE_TOML_BIN/gitleaks"
-for incomplete_toml_name in Cargo.lock uv.lock; do
-  AGENT_GUARD_GITLEAKS_BIN="$LOCK_INCOMPLETE_TOML_BIN/gitleaks" \
-    "$PLUGIN_ROOT/bin/agent-guard" scan-path \
-      "$LOCK_INCOMPLETE_TOML_DIR/$incomplete_toml_name" >"$OUT" 2>"$ERR"
-  status=$?
-  if [ "$status" -eq 1 ]; then
-    ok "scan-path keeps incomplete $incomplete_toml_name checksum bytes scannable"
-  else
-    not_ok "scan-path must detect checksum bytes in incomplete $incomplete_toml_name (expected 1, got $status)"
-  fi
+for incomplete_toml_dir in "$LOCK_INCOMPLETE_TOML_DIR" \
+    "$LOCK_INCOMPLETE_QUOTE_DIR" "$LOCK_INCOMPLETE_INLINE_DIR" \
+    "$LOCK_INCOMPLETE_ARRAY_DIR"; do
+  incomplete_toml_case=${incomplete_toml_dir##*lockfile-incomplete-}
+  incomplete_toml_case=${incomplete_toml_case%-dir}
+  for incomplete_toml_name in Cargo.lock uv.lock; do
+    AGENT_GUARD_GITLEAKS_BIN="$LOCK_INCOMPLETE_TOML_BIN/gitleaks" \
+      "$PLUGIN_ROOT/bin/agent-guard" scan-path \
+        "$incomplete_toml_dir/$incomplete_toml_name" >"$OUT" 2>"$ERR"
+    status=$?
+    if [ "$status" -eq 1 ]; then
+      ok "scan-path keeps incomplete $incomplete_toml_case $incomplete_toml_name scannable"
+    else
+      not_ok "scan-path must detect bytes in incomplete $incomplete_toml_case $incomplete_toml_name (expected 1, got $status)"
+    fi
+  done
 done
 
 LOCK_MALFORMED_TAIL_DIR="$TMP_ROOT/lockfile-malformed-tail-dir"
@@ -4592,16 +4630,15 @@ if [ -n "$REAL_GITLEAKS" ]; then
     printf 'sdist = { url = "https://example.invalid/pkg?api_token=%s", hash = "sha256:%s" }\n' \
       "$LOCK_SECRET" "$LOCK_HEX"
     printf 'sdist = { url = "quoted%s", hash = "sha256:%s" }\n' "\\\\" "$LOCK_HEX"
-    printf 'sdist = { url = "quoted%s", hash = "sha256:%s" }\n' "\\" "$LOCK_HEX"
   } >"$LOCK_CONTEXT_DIR/uv.lock"
   context_filtered=$("$PLUGIN_ROOT/bin/agent-guard" filter-lockfile-hashes \
     "$LOCK_CONTEXT_DIR/uv.lock" "$LOCK_CONTEXT_DIR/uv.lock")
-  context_expected=$(printf "[[package]]\nsdist = { url = \"https://example.invalid/pkg?api_token=%s\", hash = \"sha256:CHECKSUM\" }\nsdist = { url = \"quoted%s\", hash = \"sha256:CHECKSUM\" }\nsdist = { url = \"quoted%s\", hash = \"sha256:%s\" }" \
-    "$LOCK_SECRET" "\\\\" "\\" "$LOCK_HEX")
+  context_expected=$(printf "[[package]]\nsdist = { url = \"https://example.invalid/pkg?api_token=%s\", hash = \"sha256:CHECKSUM\" }\nsdist = { url = \"quoted%s\", hash = \"sha256:CHECKSUM\" }" \
+    "$LOCK_SECRET" "\\\\")
   if [ "$context_filtered" = "$context_expected" ]; then
-    ok "uv.lock filter continues after quoted text and honors backslash parity"
+    ok "uv.lock filter continues after quoted text and honors even backslash parity"
   else
-    not_ok "uv.lock quote context preserves odd escapes and finds later real hash fields"
+    not_ok "uv.lock quote context finds real hash fields after valid escaped text"
   fi
 
   LOCK_MULTILINE_DIR="$TMP_ROOT/lockfile-multiline-dir"


### PR DESCRIPTION
## Summary

- neutralize only recognized checksum/hash fields in supported lockfiles
- keep URL, module-path, and all other same-line text visible to gitleaks
- keep checksum-shaped text inside quoted values/comments byte-for-byte
- require one complete package-lock JSON snapshot before neutralizing integrity
- add same-line credential regressions for `uv.lock` scan-path and `go.sum` scan-staged/Write paths

## Reproduction

Put a credential and a valid checksum on the same inline `uv.lock` record:

```text
sdist = { url = "https://example.invalid/pkg?api_token=<credential>", hash = "sha256:<64 hex>", size = 1 }
```

On merged #145, `scan-path uv.lock` exits 0 because `filter_lockfile_records()` recognizes the checksum record and drops the entire line. The same credential in a normal file exits 1.

The same bypass applies when a credential-bearing module path and valid `h1:` checksum share a `go.sum` line passed through staged-diff or proposed-Write scanning.

A second boundary case is quoted non-field text such as:

```text
note = 'api_token = { checksum = "<64 hex>" }'
```

A comma or brace inside that string was previously treated as structural, so the nested text was neutralized even though it was not a Cargo checksum field.

The same context loss occurs for staged, `apply_patch`, and Edit/MultiEdit TOML
fragments when the unchanged opening triple quote is outside the fragment. A
supported custom gitleaks rule can detect the raw 64-hex credential but receives
`CHECKSUM` after context-free structural parsing. The bundled default rules do
not independently flag this exact nested sample; the regression covers the
preprocessor boundary for supported custom rules.

## Root cause

The path-specific allowlist correctly recognizes checksum grammar, but its action is `next`, which removes every byte of the recognized record before gitleaks sees it. The first field-only replacement then matched structural delimiters with regular expressions alone, without tracking whether they occurred inside a quoted value or comment.

For complete Cargo content, treating every `checksum` assignment as a package
checksum also exceeded the lockfile schema. The generated checksum field belongs
to `[[package]]`, legacy `[root]`, or `[[patch.unused]]`; a custom table such as
`[credentials]` must remain scannable. Likewise, uv only generates these hashes
inside URL-bearing `sdist` and `wheels` artifact objects, not arbitrary inline
tables. Package-lock integrity fields likewise belong under its top-level
`packages` or `dependencies` maps rather than arbitrary root objects.

The streaming package-lock parser also emitted replacements before it knew that
the complete document was valid. Validating and filtering by reopening the same
caller-owned path would still leave a check/use race: the path could be replaced
with truncated content after validation but before filtering.

## Change

- replace only the matched checksum/hash field with a fixed `CHECKSUM` token
- for `go.sum`, anchor replacement to the third field so an earlier h1-shaped module/path token remains scannable
- require exact recognized field boundaries; `api_checksum`, `api_hash`, and `api_integrity` remain byte-for-byte scannable
- reject whitespace-separated lookalikes such as `api checksum` and require a delimiter/end after the checksum value
- track JSON/TOML/Yarn quote, escape, comment, and TOML triple-quote state so only fields at real structural positions are replaced
- leave staged/apply_patch Cargo and uv TOML fragments fully scannable because unchanged multiline-string context is unavailable; retain physical-line filtering for JSON, Yarn, and `go.sum`
- leave every Edit/MultiEdit lockfile fragment fully scannable, including `go.sum`, while preserving full-file filtering for Write
- neutralize Cargo checksums only within generated dependency tables (`[[package]]`, legacy `[root]`, and `[[patch.unused]]`)
- neutralize uv hashes only within depth-one, URL-bearing artifact objects on generated `sdist`/`wheels` records under `[[package]]` (or the legacy `[[distribution]]` alias), including the generated multi-line wheels array
- snapshot package-lock input once, validate that immutable snapshot as exactly one complete top-level JSON object, then neutralize integrity only as a direct package-entry field inside the generated top-level `packages` map or recursive `dependencies` entry maps
- keep malformed, truncated, multi-document, minified, oversized, and fragmentary JSON fully scannable; missing `jq` also falls back to unchanged content
- if private snapshot copying fails, stream the original package-lock bytes raw instead of letting an empty filter pipeline appear clean
- parse records up to 131,072 characters in one pass with 256-character field lookahead, a 256-level JSON depth bound, and 4 KiB output chunks; larger/deeper/invalid records remain unchanged and fully scannable
- replace every recognized checksum field on a compact record, not only the first
- retain the surrounding record unchanged for the downstream scan
- keep path scoping and existing checksum grammars for `go.sum`, `package-lock.json`, `yarn.lock`, `Cargo.lock`, and `uv.lock`

## Related work

- Follow-up to merged #145
- #150, #153, and #156 are separate display-redaction behavior and do not address lockfile scanning

## Functional verification

- `make test` — 590 passed, 0 failed
  - checksum-only records remain clean
  - prefixed checksum-like fields remain unchanged and detectable shapes still block
  - `api checksum: <64 hex>` remains a finding in `yarn.lock`
  - checksum-length prefixes with a trailing value byte remain unchanged
  - an h1-shaped module token remains a finding while only the harmless third-field `go.sum` checksum is neutralized
  - both checksum fields on one compact `uv.lock` record are neutralized while both URLs remain
  - checksum-shaped text inside quoted Cargo, uv, and Yarn values is preserved byte-for-byte
  - TOML multiline basic/literal strings remain unchanged across physical records while later real checksum fields are still neutralized
  - odd/even backslash parity keeps quoted text distinct from later structural fields
  - inline `uv.lock` URL credential blocks `scan-path`
  - same-line `go.sum` module-path credential blocks `scan-staged`
  - the same proposed `go.sum` Write blocks `hook-pre-tool`
  - staged, Edit/MultiEdit, and apply_patch TOML fragments preserve a nested 64-hex credential for a supported custom scanner rule instead of replacing it with `CHECKSUM`
  - a `go.sum` Edit fragment does not infer absent earlier fields and hide an h1-shaped supported custom finding
  - an `uv.lock` Edit fragment does not infer absent multiline context and hide a hash-shaped supported custom finding
  - full Write, scan-path, and untracked scans preserve a checksum-shaped value in a custom Cargo table for supported custom rules
  - full Write and scan-path scans preserve a hash-shaped value in a non-artifact uv inline table
  - direct schema probes replace Cargo checksums only in generated dependency tables and preserve a custom `[credentials]` table
  - direct schema probes replace uv hashes in compact and multi-line `sdist`/`wheels` artifact objects under `[[package]]`/`[[distribution]]`, while preserving a forged `sdist` in `[credentials]`
  - full Write and scan-path scans preserve an integrity-shaped value in a nested arbitrary package-lock object
  - staged and apply_patch package-lock fragments remain raw instead of guessing missing JSON depth
  - direct schema probes replace package-lock integrity only on package entries (including recursive v1 dependencies) while preserving nested and root arbitrary objects
  - malformed/truncated package-lock content remains unchanged and blocks in direct filtering, proposed Write, scan-path, and untracked scans
  - replacing the original package-lock path with truncated JSON immediately after validation cannot change the immutable bytes subsequently filtered
  - a forced snapshot-copy failure under closed-mode proposed Write falls back to raw scanning and blocks rather than producing clean empty stdin
  - JSON nesting beyond 256 levels switches the rest of the file to unchanged conservative scanning without dropping lines
- direct `filter-lockfile-hashes` probes preserved inline URLs, `api_token`, and prefixed user fields while changing every exact `hash = "sha256:..."` field to `hash = "sha256:CHECKSUM"`
- adversarial exact quoted-candidate probes: 3,000 candidates / 243 KiB and 10,000 candidates / 810 KiB each reported `real 0.06`; both exceed the 131,072-character filter bound and remain unchanged for conservative downstream scanning
- bounded package-lock probe: 20,000 entries / 2,808,913 bytes completed twice in `real 2.46` and `real 2.50`, including immutable snapshot, streamed whole-document validation, and field filtering
- `make smoke-test` — passed
- `scripts/validate-plugin-layout.sh` — passed
- `sh -n plugins/agent-guard/bin/agent-guard`
- `dash -n plugins/agent-guard/bin/agent-guard`
- `sh -n tests/run.sh`
- `dash -n tests/run.sh`
- `git diff --check`
- staged `agent-guard scan-staged` — passed
- `make submission-check` — expected nonzero only because the reviewed marketplace `.source.sha` does not match this unmerged plugin payload; this security PR intentionally does not pre-pin its own unmerged commit

The Makefile has no `fmt` target.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made lockfile scanning more conservative: neutralizes only fully validated checksum/hash fields while preserving surrounding content.
  * Prevents rewriting when lockfile data is malformed, truncated, multi-document, or context is missing.
  * Added safer handling for NUL bytes and invalid UTF-8 during lockfile processing.
  * Improved credential scanning for edit and notebook-style payloads, independent of file paths.
* **Tests**
  * Expanded regression coverage across lockfile formats and many checksum/hash edge cases, including binary-safe inputs and malformed package-lock scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->