### PR TITLE
fix(lockfiles): reject invalid TOML escapes

### DIFF
--- a/docs/claude-marketplace-readiness.md
+++ b/docs/claude-marketplace-readiness.md
@@ -30,7 +30,7 @@ source repository that already backs a live marketplace entry.
   which includes merged PR
   [#54](https://github.com/JeongJaeSoon/agent-guard/pull/54) and its shared
   Claude Code/Codex Quick Start.
-- Submission-ready plugin payload: `9e1f1bacfb91035c634e0e7be040d449179a2501`,
+- Submission-ready plugin payload: `ac0d22eddefd30b8595d648b7dc264029cd45786`,
   reviewed in Agent Guard
   [PR #157](https://github.com/JeongJaeSoon/agent-guard/pull/157).
 - Official repository: `anthropics/claude-plugins-official` at
@@ -45,7 +45,7 @@ source repository that already backs a live marketplace entry.
 |---|---|---|
 | Registration path | The repository README still links a plugin submission form, but current Claude Code docs clarify that the form targets the community marketplace and that official inclusion has no application process. | **Blocker outside the repo.** Prepare artifacts, but seek curator contact or use the community route. |
 | External PRs | Non-member PRs are closed unless they only add marketplace entries from a repository that already has a live entry. | **Blocker.** `JeongJaeSoon/agent-guard` is not already listed. |
-| Source pinning | External sources use `url` or `git-subdir` and a full commit SHA. Automated jobs later bump the SHA and re-scan. | **Ready.** The `git-subdir` template uses `path: plugins/agent-guard` and pins reachable commit `9e1f1bacfb91035c634e0e7be040d449179a2501`. |
+| Source pinning | External sources use `url` or `git-subdir` and a full commit SHA. Automated jobs later bump the SHA and re-scan. | **Ready.** The `git-subdir` template uses `path: plugins/agent-guard` and pins reachable commit `ac0d22eddefd30b8595d648b7dc264029cd45786`. |
 | Name | Marketplace names are immutable kebab-case slugs. | **Ready.** `agent-guard` is stable and kebab-case. |
 | Manifest | Plugin root contains `.claude-plugin/plugin.json`; components stay at plugin root. New work prefers `skills/`, while `commands/` remains supported as legacy. | **Ready with legacy note.** Manifest is valid; Claude commands remain legacy-compatible and the Codex setup workflow is a skill. |
 | Hook review | External scan enumerates every hook and fails ungated `PreToolUse` or `PostToolUse` hooks. Descriptions must disclose hook scope and data access. | **Blocker.** Agent Guard's broad hooks are core behavior. Descriptions and privacy docs now disclose the scope, but disclosure does not override the scanner's broad-hook failure rule. |

--- a/docs/claude-marketplace-readiness.md
+++ b/docs/claude-marketplace-readiness.md
@@ -30,7 +30,7 @@ source repository that already backs a live marketplace entry.
   which includes merged PR
   [#54](https://github.com/JeongJaeSoon/agent-guard/pull/54) and its shared
   Claude Code/Codex Quick Start.
-- Submission-ready plugin payload: `ac0d22eddefd30b8595d648b7dc264029cd45786`,
+- Submission-ready plugin payload: `c752f47ec463059f154f1c40a61dc4a8201b03da`,
   reviewed in Agent Guard
   [PR #157](https://github.com/JeongJaeSoon/agent-guard/pull/157).
 - Official repository: `anthropics/claude-plugins-official` at
@@ -45,7 +45,7 @@ source repository that already backs a live marketplace entry.
 |---|---|---|
 | Registration path | The repository README still links a plugin submission form, but current Claude Code docs clarify that the form targets the community marketplace and that official inclusion has no application process. | **Blocker outside the repo.** Prepare artifacts, but seek curator contact or use the community route. |
 | External PRs | Non-member PRs are closed unless they only add marketplace entries from a repository that already has a live entry. | **Blocker.** `JeongJaeSoon/agent-guard` is not already listed. |
-| Source pinning | External sources use `url` or `git-subdir` and a full commit SHA. Automated jobs later bump the SHA and re-scan. | **Ready.** The `git-subdir` template uses `path: plugins/agent-guard` and pins reachable commit `ac0d22eddefd30b8595d648b7dc264029cd45786`. |
+| Source pinning | External sources use `url` or `git-subdir` and a full commit SHA. Automated jobs later bump the SHA and re-scan. | **Ready.** The `git-subdir` template uses `path: plugins/agent-guard` and pins reachable commit `c752f47ec463059f154f1c40a61dc4a8201b03da`. |
 | Name | Marketplace names are immutable kebab-case slugs. | **Ready.** `agent-guard` is stable and kebab-case. |
 | Manifest | Plugin root contains `.claude-plugin/plugin.json`; components stay at plugin root. New work prefers `skills/`, while `commands/` remains supported as legacy. | **Ready with legacy note.** Manifest is valid; Claude commands remain legacy-compatible and the Codex setup workflow is a skill. |
 | Hook review | External scan enumerates every hook and fails ungated `PreToolUse` or `PostToolUse` hooks. Descriptions must disclose hook scope and data access. | **Blocker.** Agent Guard's broad hooks are core behavior. Descriptions and privacy docs now disclose the scope, but disclosure does not override the scanner's broad-hook failure rule. |

--- a/docs/submission/README.md
+++ b/docs/submission/README.md
@@ -8,10 +8,10 @@
    changed.
 3. Resolve the reachable 40-character GitHub commit SHA that contains the exact
    plugin payload under `plugins/agent-guard`. The prepared submission pins
-   `9e1f1bacfb91035c634e0e7be040d449179a2501`, reviewed in Agent Guard
+   `ac0d22eddefd30b8595d648b7dc264029cd45786`, reviewed in Agent Guard
    [PR #157](https://github.com/JeongJaeSoon/agent-guard/pull/157).
 4. Re-run `make submission-check` with
-   `AGENT_GUARD_SUBMISSION_SHA=9e1f1bacfb91035c634e0e7be040d449179a2501`.
+   `AGENT_GUARD_SUBMISSION_SHA=ac0d22eddefd30b8595d648b7dc264029cd45786`.
    If the plugin payload changes, replace the pinned SHA in both submission
    drafts and validate the new reachable commit before submitting.
 5. For the public community route, submit the form draft through the Console

--- a/docs/submission/README.md
+++ b/docs/submission/README.md
@@ -8,10 +8,10 @@
    changed.
 3. Resolve the reachable 40-character GitHub commit SHA that contains the exact
    plugin payload under `plugins/agent-guard`. The prepared submission pins
-   `ac0d22eddefd30b8595d648b7dc264029cd45786`, reviewed in Agent Guard
+   `c752f47ec463059f154f1c40a61dc4a8201b03da`, reviewed in Agent Guard
    [PR #157](https://github.com/JeongJaeSoon/agent-guard/pull/157).
 4. Re-run `make submission-check` with
-   `AGENT_GUARD_SUBMISSION_SHA=ac0d22eddefd30b8595d648b7dc264029cd45786`.
+   `AGENT_GUARD_SUBMISSION_SHA=c752f47ec463059f154f1c40a61dc4a8201b03da`.
    If the plugin payload changes, replace the pinned SHA in both submission
    drafts and validate the new reachable commit before submitting.
 5. For the public community route, submit the form draft through the Console

--- a/docs/submission/claude-community/form-draft.md
+++ b/docs/submission/claude-community/form-draft.md
@@ -8,7 +8,7 @@
 
 - Repository: `https://github.com/JeongJaeSoon/agent-guard`
 - Plugin path: `plugins/agent-guard`
-- Commit SHA: `9e1f1bacfb91035c634e0e7be040d449179a2501`
+- Commit SHA: `ac0d22eddefd30b8595d648b7dc264029cd45786`
 
 ## Short description
 

--- a/docs/submission/claude-community/form-draft.md
+++ b/docs/submission/claude-community/form-draft.md
@@ -8,7 +8,7 @@
 
 - Repository: `https://github.com/JeongJaeSoon/agent-guard`
 - Plugin path: `plugins/agent-guard`
-- Commit SHA: `ac0d22eddefd30b8595d648b7dc264029cd45786`
+- Commit SHA: `c752f47ec463059f154f1c40a61dc4a8201b03da`
 
 ## Short description
 

--- a/docs/submission/claude-plugins-official/marketplace-entry.template.json
+++ b/docs/submission/claude-plugins-official/marketplace-entry.template.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/JeongJaeSoon/agent-guard.git",
     "path": "plugins/agent-guard",
     "ref": "main",
-    "sha": "ac0d22eddefd30b8595d648b7dc264029cd45786"
+    "sha": "c752f47ec463059f154f1c40a61dc4a8201b03da"
   },
   "homepage": "https://github.com/JeongJaeSoon/agent-guard"
 }

--- a/docs/submission/claude-plugins-official/marketplace-entry.template.json
+++ b/docs/submission/claude-plugins-official/marketplace-entry.template.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/JeongJaeSoon/agent-guard.git",
     "path": "plugins/agent-guard",
     "ref": "main",
-    "sha": "9e1f1bacfb91035c634e0e7be040d449179a2501"
+    "sha": "ac0d22eddefd30b8595d648b7dc264029cd45786"
   },
   "homepage": "https://github.com/JeongJaeSoon/agent-guard"
 }

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -827,6 +827,7 @@ filter_lockfile_records() {
       return substr(line, 1, RSTART - 1) replacement substr(line, RSTART + RLENGTH)
     }
     function hex_digit_value(ch, position) {
+      if (length(ch) != 1) return -1
       position = index("0123456789abcdef", tolower(ch))
       return position ? position - 1 : -1
     }
@@ -849,10 +850,11 @@ filter_lockfile_records() {
       if (escaped_char == "u") return unicode_escape_valid(line, at, 4)
       if (escaped_char == "U") return unicode_escape_valid(line, at, 8)
       # A multiline basic string may fold a physical line ending after a
-      # backslash and optional spaces/tabs. awk has already removed that newline.
+      # backslash and optional spaces/tabs. awk has already removed the LF
+      # record separator, but a CRLF record still has its terminal CR.
       if (multiline) {
         remainder = substr(line, at + 1)
-        if (remainder ~ /^[ \t]*$/) return 1
+        if (remainder ~ /^[ \t]*\r?$/) return 1
       }
       return 0
     }

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -826,6 +826,36 @@ filter_lockfile_records() {
     function replace_match(line, replacement) {
       return substr(line, 1, RSTART - 1) replacement substr(line, RSTART + RLENGTH)
     }
+    function hex_digit_value(ch, position) {
+      position = index("0123456789abcdef", tolower(ch))
+      return position ? position - 1 : -1
+    }
+    function unicode_escape_valid(line, at, width, i, digit, value) {
+      value = 0
+      for (i = 1; i <= width; i++) {
+        digit = hex_digit_value(substr(line, at + 1 + i, 1))
+        if (digit < 0) return 0
+        value = value * 16 + digit
+      }
+      return value <= 1114111 && !(value >= 55296 && value <= 57343)
+    }
+    function basic_escape_valid(line, at, multiline, escaped_char, remainder) {
+      escaped_char = substr(line, at + 1, 1)
+      if (escaped_char == "\"" || escaped_char == "\\" \
+          || escaped_char == "b" || escaped_char == "t" \
+          || escaped_char == "n" || escaped_char == "f" \
+          || escaped_char == "r")
+        return 1
+      if (escaped_char == "u") return unicode_escape_valid(line, at, 4)
+      if (escaped_char == "U") return unicode_escape_valid(line, at, 8)
+      # A multiline basic string may fold a physical line ending after a
+      # backslash and optional spaces/tabs. awk has already removed that newline.
+      if (multiline) {
+        remainder = substr(line, at + 1)
+        if (remainder ~ /^[ \t]*$/) return 1
+      }
+      return 0
+    }
     function toml_incomplete(kind) {
       return (kind == "c" || kind == "u") \
           && (toml_multiline != "" || toml_array_depth != 0 || toml_invalid)
@@ -969,6 +999,8 @@ filter_lockfile_records() {
           triple = chars[i] chars[i + 1] chars[i + 2]
           if (toml_multiline == "\"") {
             if (ch == "\\") {
+              if (!ml_escaped && !basic_escape_valid(line, i, 1))
+                toml_invalid = 1
               ml_escaped = !ml_escaped
               i++
               continue
@@ -991,6 +1023,9 @@ filter_lockfile_records() {
 
         if (quote != "") {
           if (quote == "\"" && ch == "\\") {
+            if (!escaped && (kind == "c" || kind == "u") \
+                && !basic_escape_valid(line, i, 0))
+              toml_invalid = 1
             escaped = !escaped
             i++
             continue

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -4038,6 +4038,82 @@ for invalid_escape_name in Cargo.lock uv.lock; do
   fi
 done
 
+LOCK_INCOMPLETE_UNICODE_DIR="$TMP_ROOT/lockfile-incomplete-unicode-dir"
+mkdir -p "$LOCK_INCOMPLETE_UNICODE_DIR"
+for incomplete_unicode_escape in u u12 U0001F60; do
+  incomplete_unicode_dir="$LOCK_INCOMPLETE_UNICODE_DIR/$incomplete_unicode_escape"
+  mkdir -p "$incomplete_unicode_dir"
+  {
+    printf '%s\n' '[[package]]'
+    printf 'checksum = "%s"\n' "$LOCK_FRAGMENT_HEX"
+    printf 'note = """bad\\%s\n' "$incomplete_unicode_escape"
+    printf '%s\n' '"""'
+  } >"$incomplete_unicode_dir/Cargo.lock"
+  {
+    printf '%s\n' '[[package]]'
+    printf 'sdist = { url = "https://example.invalid/pkg", hash = "sha256:%s" }\n' \
+      "$LOCK_FRAGMENT_HEX"
+    printf 'note = """bad\\%s\n' "$incomplete_unicode_escape"
+    printf '%s\n' '"""'
+  } >"$incomplete_unicode_dir/uv.lock"
+  for incomplete_unicode_name in Cargo.lock uv.lock; do
+    incomplete_unicode_path="$incomplete_unicode_dir/$incomplete_unicode_name"
+    incomplete_unicode_filtered="$incomplete_unicode_path.filtered"
+    "$PLUGIN_ROOT/bin/agent-guard" filter-lockfile-hashes \
+      "$incomplete_unicode_path" "$incomplete_unicode_path" \
+      >"$incomplete_unicode_filtered"
+    status=$?
+    if [ "$status" -eq 0 ] \
+        && cmp -s "$incomplete_unicode_path" "$incomplete_unicode_filtered"; then
+      ok "$incomplete_unicode_name filtering falls back for incomplete \\$incomplete_unicode_escape"
+    else
+      not_ok "$incomplete_unicode_name filtering must preserve incomplete \\$incomplete_unicode_escape bytes"
+    fi
+  done
+done
+
+LOCK_CRLF_FOLD_DIR="$TMP_ROOT/lockfile-crlf-fold-dir"
+mkdir -p "$LOCK_CRLF_FOLD_DIR"
+{
+  printf '%s\r\n' '[[package]]'
+  printf 'checksum = "%s"\r\n' "$LOCK_FRAGMENT_HEX"
+  printf '%s\r\n' 'note = """abc\'
+  printf '%s\r\n' '  def"""'
+} >"$LOCK_CRLF_FOLD_DIR/Cargo.lock"
+{
+  printf '%s\r\n' '[[package]]'
+  printf 'sdist = { url = "https://example.invalid/pkg", hash = "sha256:%s" }\r\n' \
+    "$LOCK_FRAGMENT_HEX"
+  printf '%s\r\n' 'note = """abc\'
+  printf '%s\r\n' '  def"""'
+} >"$LOCK_CRLF_FOLD_DIR/uv.lock"
+{
+  printf '%s\r\n' '[[package]]'
+  printf '%s\r\n' 'checksum = "CHECKSUM"'
+  printf '%s\r\n' 'note = """abc\'
+  printf '%s\r\n' '  def"""'
+} >"$LOCK_CRLF_FOLD_DIR/Cargo.lock.expected"
+{
+  printf '%s\r\n' '[[package]]'
+  printf '%s\r\n' \
+    'sdist = { url = "https://example.invalid/pkg", hash = "sha256:CHECKSUM" }'
+  printf '%s\r\n' 'note = """abc\'
+  printf '%s\r\n' '  def"""'
+} >"$LOCK_CRLF_FOLD_DIR/uv.lock.expected"
+for crlf_fold_name in Cargo.lock uv.lock; do
+  crlf_fold_path="$LOCK_CRLF_FOLD_DIR/$crlf_fold_name"
+  crlf_fold_filtered="$LOCK_CRLF_FOLD_DIR/$crlf_fold_name.filtered"
+  "$PLUGIN_ROOT/bin/agent-guard" filter-lockfile-hashes \
+    "$crlf_fold_path" "$crlf_fold_path" >"$crlf_fold_filtered"
+  status=$?
+  if [ "$status" -eq 0 ] \
+      && cmp -s "$crlf_fold_path.expected" "$crlf_fold_filtered"; then
+    ok "$crlf_fold_name filtering neutralizes the checksum and preserves CRLF bytes"
+  else
+    not_ok "$crlf_fold_name filtering must neutralize checksums across a valid CRLF multiline fold"
+  fi
+done
+
 LOCK_INCOMPLETE_TOML_BIN="$TMP_ROOT/lockfile-incomplete-toml-bin"
 mkdir -p "$LOCK_INCOMPLETE_TOML_BIN"
 cat >"$LOCK_INCOMPLETE_TOML_BIN/gitleaks" <<'STUB'
@@ -4082,6 +4158,33 @@ for invalid_escape_name in Cargo.lock uv.lock; do
     ok "scan-path keeps invalid-escape $invalid_escape_name bytes scannable"
   else
     not_ok "scan-path must detect checksum bytes after invalid TOML in $invalid_escape_name (expected 1, got $status)"
+  fi
+done
+
+for incomplete_unicode_escape in u u12 U0001F60; do
+  incomplete_unicode_dir="$LOCK_INCOMPLETE_UNICODE_DIR/$incomplete_unicode_escape"
+  for incomplete_unicode_name in Cargo.lock uv.lock; do
+    AGENT_GUARD_GITLEAKS_BIN="$LOCK_INCOMPLETE_TOML_BIN/gitleaks" \
+      "$PLUGIN_ROOT/bin/agent-guard" scan-path \
+        "$incomplete_unicode_dir/$incomplete_unicode_name" >"$OUT" 2>"$ERR"
+    status=$?
+    if [ "$status" -eq 1 ]; then
+      ok "scan-path keeps incomplete \\$incomplete_unicode_escape $incomplete_unicode_name bytes scannable"
+    else
+      not_ok "scan-path must detect checksum bytes after incomplete \\$incomplete_unicode_escape in $incomplete_unicode_name (expected 1, got $status)"
+    fi
+  done
+done
+
+for crlf_fold_name in Cargo.lock uv.lock; do
+  AGENT_GUARD_GITLEAKS_BIN="$LOCK_INCOMPLETE_TOML_BIN/gitleaks" \
+    "$PLUGIN_ROOT/bin/agent-guard" scan-path \
+      "$LOCK_CRLF_FOLD_DIR/$crlf_fold_name" >"$OUT" 2>"$ERR"
+  status=$?
+  if [ "$status" -eq 0 ]; then
+    ok "scan-path neutralizes eligible checksums in CRLF-folded $crlf_fold_name"
+  else
+    not_ok "scan-path must not report a false positive for valid CRLF-folded $crlf_fold_name (expected 0, got $status)"
   fi
 done
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -4011,6 +4011,33 @@ for incomplete_toml_dir in "$LOCK_INCOMPLETE_TOML_DIR" \
   done
 done
 
+LOCK_INVALID_ESCAPE_DIR="$TMP_ROOT/lockfile-invalid-escape-dir"
+mkdir -p "$LOCK_INVALID_ESCAPE_DIR"
+{
+  printf '%s\n' '[[package]]'
+  printf 'checksum = "%s"\n' "$LOCK_FRAGMENT_HEX"
+  printf '%s\n' 'note = "bad\q"'
+} >"$LOCK_INVALID_ESCAPE_DIR/Cargo.lock"
+{
+  printf '%s\n' '[[package]]'
+  printf 'sdist = { url = "https://example.invalid/pkg", hash = "sha256:%s" }\n' \
+    "$LOCK_FRAGMENT_HEX"
+  printf '%s\n' 'note = "bad\q"'
+} >"$LOCK_INVALID_ESCAPE_DIR/uv.lock"
+for invalid_escape_name in Cargo.lock uv.lock; do
+  invalid_escape_path="$LOCK_INVALID_ESCAPE_DIR/$invalid_escape_name"
+  invalid_escape_filtered="$LOCK_INVALID_ESCAPE_DIR/$invalid_escape_name.filtered"
+  "$PLUGIN_ROOT/bin/agent-guard" filter-lockfile-hashes \
+    "$invalid_escape_path" "$invalid_escape_path" >"$invalid_escape_filtered"
+  status=$?
+  if [ "$status" -eq 0 ] \
+      && cmp -s "$invalid_escape_path" "$invalid_escape_filtered"; then
+    ok "$invalid_escape_name filtering falls back for an invalid TOML basic-string escape"
+  else
+    not_ok "$invalid_escape_name filtering must preserve invalid TOML escape bytes"
+  fi
+done
+
 LOCK_INCOMPLETE_TOML_BIN="$TMP_ROOT/lockfile-incomplete-toml-bin"
 mkdir -p "$LOCK_INCOMPLETE_TOML_BIN"
 cat >"$LOCK_INCOMPLETE_TOML_BIN/gitleaks" <<'STUB'
@@ -4044,6 +4071,18 @@ for incomplete_toml_dir in "$LOCK_INCOMPLETE_TOML_DIR" \
       not_ok "scan-path must detect bytes in incomplete $incomplete_toml_case $incomplete_toml_name (expected 1, got $status)"
     fi
   done
+done
+
+for invalid_escape_name in Cargo.lock uv.lock; do
+  AGENT_GUARD_GITLEAKS_BIN="$LOCK_INCOMPLETE_TOML_BIN/gitleaks" \
+    "$PLUGIN_ROOT/bin/agent-guard" scan-path \
+      "$LOCK_INVALID_ESCAPE_DIR/$invalid_escape_name" >"$OUT" 2>"$ERR"
+  status=$?
+  if [ "$status" -eq 1 ]; then
+    ok "scan-path keeps invalid-escape $invalid_escape_name bytes scannable"
+  else
+    not_ok "scan-path must detect checksum bytes after invalid TOML in $invalid_escape_name (expected 1, got $status)"
+  fi
 done
 
 LOCK_MALFORMED_TAIL_DIR="$TMP_ROOT/lockfile-malformed-tail-dir"


### PR DESCRIPTION
## Summary
- validate TOML 1.0 basic-string escapes while parsing complete Cargo/uv lockfile snapshots
- reject unknown, truncated/malformed Unicode, surrogate, and out-of-range escapes so partial checksum neutralization falls back to the immutable raw snapshot
- preserve valid multiline line-ending escapes, including CRLF folds, and escaped-backslash parity

## Security context
Follow-up for the unresolved P1 review thread on merged PR #159 (`PRRT_kwDOSTEQPs6VMhrJ`). On current `main`, an eligible checksum followed by `note = "bad\\q"` was neutralized even though the TOML was invalid, potentially hiding a checksum-shaped value from a supported custom gitleaks rule.

## Verification
- `make test` — 722 passed, 0 failed (macOS system awk)
- `PATH=/opt/homebrew/opt/gawk/libexec/gnubin:$PATH make test` — 722 passed, 0 failed
- `make smoke-test`
- `make submission-check`
- `sh -n` / `dash -n`
- Cargo.lock and uv.lock byte-for-byte raw fallback regressions for invalid and truncated escapes
- Cargo.lock and uv.lock exact-CRLF checksum-neutralization regressions
- Cargo.lock and uv.lock `scan-path` custom-scanner regressions

Payload commits `ac0d22e` and `c752f47` and submission re-pin commits `e5eb6a1` and `563b442` are SSH-signed and locally verified.