### PR TITLE
refactor(submission): render catalog pin after merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,7 @@ jobs:
             scripts/build-release-tarball.sh \
             scripts/validate-plugin-layout.sh \
             scripts/validate-submission-readiness.sh \
+            scripts/render-submission-entry.sh \
             plugins/agent-guard/scripts/gitleaks-checksum.sh
 
       - name: actionlint workflows

--- a/.github/workflows/plugin-validation.yml
+++ b/.github/workflows/plugin-validation.yml
@@ -20,12 +20,6 @@ jobs:
           # No step after checkout authenticates to Git, so do not persist the
           # GITHUB_TOKEN in the local git config.
           persist-credentials: false
-          # Full history: the submission-readiness check below compares the
-          # pinned .source.sha's plugins/agent-guard tree against HEAD, and a
-          # shallow (depth 1) checkout cannot resolve that commit. The check
-          # fails closed when it cannot verify, so this is required, not an
-          # optimisation.
-          fetch-depth: 0
 
       - name: Run tests
         run: make test
@@ -43,7 +37,7 @@ jobs:
         run: scripts/validate-plugin-layout.sh --archive
 
       - name: Validate Marketplace Submission Readiness
-        # Blocking again (#149): .source.sha is re-pinned to the commit whose
-        # plugins/agent-guard tree is currently shipping, so any change to the
-        # payload that forgets to re-pin the submission drafts fails here.
+        # Routine PR validation covers stable manifests, disclosure, and the
+        # placeholder template. A concrete catalog SHA is rendered only from
+        # the merged main checkout when an actual submission requests it.
         run: make submission-check

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Agent Guard — discoverability layer for the existing scripts.
 # Each target is a thin pass-through to install.sh or plugins/agent-guard/bin/agent-guard.
 
-.PHONY: help check install test smoke-test bench scan scan-staged checksum submission-check
+.PHONY: help check install test smoke-test bench scan scan-staged checksum submission-check submission-artifact
 
 help:
 	@printf 'Agent Guard — make targets\n'
@@ -15,7 +15,8 @@ help:
 	@printf '  make scan          Scan the working tree for secrets.\n'
 	@printf '  make scan-staged   Scan staged changes only.\n'
 	@printf '  make checksum [VERSION=X.Y.Z]   Fetch gitleaks-checksum for every supported OS/arch (CI typically picks linux/x64).\n'
-	@printf '  make submission-check  Validate marketplace submission documentation and metadata.\n'
+	@printf '  make submission-check  Validate stable marketplace submission documentation and metadata.\n'
+	@printf '  make submission-artifact SHA=<merged-main-sha>  Render an optional SHA-pinned marketplace entry.\n'
 
 check:
 	@./install.sh check
@@ -43,3 +44,6 @@ checksum:
 
 submission-check:
 	@scripts/validate-submission-readiness.sh
+
+submission-artifact:
+	@AGENT_GUARD_SUBMISSION_SHA="$(SHA)" scripts/render-submission-entry.sh

--- a/docs/claude-marketplace-readiness.md
+++ b/docs/claude-marketplace-readiness.md
@@ -2,6 +2,10 @@
 
 Review date: 2026-07-18
 
+> Historical audit snapshot. This document records the sources and policy state
+> reviewed on the date above; it is not a live CI contract. Resolve any concrete
+> catalog source SHA from the merged `main` commit at actual submission time.
+
 ## Decision
 
 **Official marketplace feasibility: conditional, but not currently
@@ -30,9 +34,8 @@ source repository that already backs a live marketplace entry.
   which includes merged PR
   [#54](https://github.com/JeongJaeSoon/agent-guard/pull/54) and its shared
   Claude Code/Codex Quick Start.
-- Submission-ready plugin payload: `a49fe30e071b290c25f3002ac42746ff9e50d2ea`,
-  reviewed in Agent Guard
-  [PR #153](https://github.com/JeongJaeSoon/agent-guard/pull/153).
+- Submission payload SHA: intentionally not recorded in this historical report.
+  Resolve a reachable merged `main` commit at actual submission time.
 - Official repository: `anthropics/claude-plugins-official` at
   `f9cb226d81172f53a1787cc3ba90dc9ab51aa169`.
 - The official repository has no root `CONTRIBUTING.md` or `SECURITY.md` at that
@@ -45,7 +48,7 @@ source repository that already backs a live marketplace entry.
 |---|---|---|
 | Registration path | The repository README still links a plugin submission form, but current Claude Code docs clarify that the form targets the community marketplace and that official inclusion has no application process. | **Blocker outside the repo.** Prepare artifacts, but seek curator contact or use the community route. |
 | External PRs | Non-member PRs are closed unless they only add marketplace entries from a repository that already has a live entry. | **Blocker.** `JeongJaeSoon/agent-guard` is not already listed. |
-| Source pinning | External sources use `url` or `git-subdir` and a full commit SHA. Automated jobs later bump the SHA and re-scan. | **Ready.** The `git-subdir` template uses `path: plugins/agent-guard` and pins reachable commit `a49fe30e071b290c25f3002ac42746ff9e50d2ea`. |
+| Source pinning | External sources use `url` or `git-subdir` and a full commit SHA. Automated jobs later bump the SHA and re-scan. | **Prepared on demand.** The `git-subdir` template uses `path: plugins/agent-guard`; a concrete SHA is rendered from merged `main` only for an actual handoff. |
 | Name | Marketplace names are immutable kebab-case slugs. | **Ready.** `agent-guard` is stable and kebab-case. |
 | Manifest | Plugin root contains `.claude-plugin/plugin.json`; components stay at plugin root. New work prefers `skills/`, while `commands/` remains supported as legacy. | **Ready with legacy note.** Manifest is valid; Claude commands remain legacy-compatible and the Codex setup workflow is a skill. |
 | Hook review | External scan enumerates every hook and fails ungated `PreToolUse` or `PostToolUse` hooks. Descriptions must disclose hook scope and data access. | **Blocker.** Agent Guard's broad hooks are core behavior. Descriptions and privacy docs now disclose the scope, but disclosure does not override the scanner's broad-hook failure rule. |
@@ -80,8 +83,9 @@ catalog, not from an unpinned upstream branch.
 
 ### Recommended before any review request
 
-- Keep the pinned commit synchronized with any future plugin-payload change and
-  re-run submission validation before each submission or curator request.
+- Resolve and validate a reachable merged `main` commit immediately before an
+  actual submission or curator request; do not maintain a moving pin in source
+  documentation.
 - Ask Anthropic whether an always-on local security guard can receive an
   explicit policy exception or whether a per-project activation gate is
   required. Do not silently weaken the product to satisfy the scanner.
@@ -100,8 +104,8 @@ catalog, not from an unpinned upstream branch.
 
 ## Submission artifacts
 
-- Official curator entry template:
-  `docs/submission/claude-plugins-official/marketplace-entry.template.json`
+- Neutral on-demand marketplace entry template:
+  `docs/submission/marketplace-entry.template.json`
 - Curator PR/changeset description draft:
   `docs/submission/claude-plugins-official/curator-change-description.md`
 - Community form draft and realistic alternative:

--- a/docs/submission/README.md
+++ b/docs/submission/README.md
@@ -1,26 +1,34 @@
 # Claude Marketplace Submission Sequence
 
-1. Run `make test`, `make smoke-test`, `scripts/validate-plugin-layout.sh --all`,
+## Routine development
+
+Run `make submission-check` with the normal plugin layout and test suite. It
+validates stable manifest, disclosure, policy-document parity, and template
+metadata. It deliberately does not require a concrete `.source.sha`, so normal
+payload PRs do not create documentation-only re-pin commits or need full Git
+history in CI.
+
+The community form draft and neutral marketplace-entry template keep stable
+repository and plugin-path information only. Do not replace the template's
+placeholder with the current branch SHA.
+
+## Actual submission or curator handoff
+
+1. Merge the reviewed payload into `main`, then check out that exact reachable
+   commit in a clean worktree.
+2. Run `make test`, `make smoke-test`, `scripts/validate-plugin-layout.sh --all`,
    `make submission-check`, `claude plugin validate ./plugins/agent-guard`, and
    `claude plugin validate .`.
-2. Commit the preparation changes in Agent Guard. Push and merge them only in
-   the Agent Guard repository, then publish a release if the manifest version
-   changed.
-3. Resolve the reachable 40-character GitHub commit SHA that contains the exact
-   plugin payload under `plugins/agent-guard`. The prepared submission pins
-   `a49fe30e071b290c25f3002ac42746ff9e50d2ea`, reviewed in Agent Guard
-   [PR #153](https://github.com/JeongJaeSoon/agent-guard/pull/153).
-4. Re-run `make submission-check` with
-   `AGENT_GUARD_SUBMISSION_SHA=a49fe30e071b290c25f3002ac42746ff9e50d2ea`.
-   If the plugin payload changes, replace the pinned SHA in both submission
-   drafts and validate the new reachable commit before submitting.
-5. For the public community route, submit the form draft through the Console
-   form (available to individual authors) or the claude.ai Team/Enterprise form.
-   Do not open a PR against the community mirror.
-6. For `claude-plugins-official`, proceed only if Anthropic explicitly invites
-   the plugin or provides a curator path. Send the entry and change-description
-   drafts, and resolve the broad-hook policy question before requesting a
-   catalog change.
+3. Prefer the public community submission form. Anthropic's catalog owns the
+   immutable source pin and subsequent automated pin updates.
+4. If a form or an Anthropic curator explicitly requests a concrete marketplace
+   JSON entry, run `make submission-artifact SHA=<merged-main-sha>`. The command
+   rejects a malformed, stale, non-HEAD, or locally modified plugin payload and
+   renders JSON to standard output. Treat it as a handoff artifact; do not commit
+   the generated entry back to this repository.
+5. For `claude-plugins-official`, proceed only if Anthropic explicitly invites
+   the plugin or provides a curator path. Resolve the broad-hook policy question
+   before requesting a catalog change.
 
 No fork, push, issue, submission, or pull request against an Anthropic
-repository is part of this preparation bundle.
+repository is performed by these repository checks.

--- a/docs/submission/README.md
+++ b/docs/submission/README.md
@@ -14,8 +14,8 @@ placeholder with the current branch SHA.
 
 ## Actual submission or curator handoff
 
-1. Merge the reviewed payload into `main`, then check out that exact reachable
-   commit in a clean worktree.
+1. Merge the reviewed payload into `main`, fetch `origin/main`, then check out
+   that exact remote-reachable commit in a clean worktree.
 2. Run `make test`, `make smoke-test`, `scripts/validate-plugin-layout.sh --all`,
    `make submission-check`, `claude plugin validate ./plugins/agent-guard`, and
    `claude plugin validate .`.
@@ -23,8 +23,9 @@ placeholder with the current branch SHA.
    immutable source pin and subsequent automated pin updates.
 4. If a form or an Anthropic curator explicitly requests a concrete marketplace
    JSON entry, run `make submission-artifact SHA=<merged-main-sha>`. The command
-   rejects a malformed, stale, non-HEAD, or locally modified plugin payload and
-   renders JSON to standard output. Treat it as a handoff artifact; do not commit
+   rejects a malformed, stale, non-HEAD, non-`origin/main`, or dirty worktree and
+   renders JSON to standard output. It also revalidates the stable template and
+   will not overwrite it. Treat the result as a handoff artifact; do not commit
    the generated entry back to this repository.
 5. For `claude-plugins-official`, proceed only if Anthropic explicitly invites
    the plugin or provides a curator path. Resolve the broad-hook policy question

--- a/docs/submission/claude-community/form-draft.md
+++ b/docs/submission/claude-community/form-draft.md
@@ -8,7 +8,8 @@
 
 - Repository: `https://github.com/JeongJaeSoon/agent-guard`
 - Plugin path: `plugins/agent-guard`
-- Commit SHA: `a49fe30e071b290c25f3002ac42746ff9e50d2ea`
+- Commit SHA: resolve the reachable `main` commit only when the submission form
+  requests it; do not keep a moving SHA in this draft.
 
 ## Short description
 

--- a/docs/submission/claude-plugins-official/curator-change-description.md
+++ b/docs/submission/claude-plugins-official/curator-change-description.md
@@ -2,6 +2,9 @@
 
 > Use only after an Anthropic maintainer provides an official-marketplace
 > inclusion path. This is not a request to bypass the submission policy.
+> This optional draft is not routine CI input and intentionally contains no
+> concrete source SHA; render one from the merged `main` checkout only if a
+> curator explicitly requests a catalog entry.
 
 ## Summary
 

--- a/docs/submission/marketplace-entry.template.json
+++ b/docs/submission/marketplace-entry.template.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/JeongJaeSoon/agent-guard.git",
     "path": "plugins/agent-guard",
     "ref": "main",
-    "sha": "a49fe30e071b290c25f3002ac42746ff9e50d2ea"
+    "sha": "<40-character-commit-sha-after-merge>"
   },
   "homepage": "https://github.com/JeongJaeSoon/agent-guard"
 }

--- a/scripts/render-submission-entry.sh
+++ b/scripts/render-submission-entry.sh
@@ -23,28 +23,27 @@ if [ "$submission_sha" != "$head_sha" ]; then
   exit 1
 fi
 
-main_ref=
-for candidate in refs/remotes/origin/main refs/heads/main; do
-  if git -C "$ROOT" rev-parse --verify "$candidate^{commit}" >/dev/null 2>&1; then
-    main_ref=$candidate
-    break
-  fi
-done
-if [ -z "$main_ref" ]; then
-  printf 'error: cannot resolve origin/main or local main in this checkout\n' >&2
-  printf 'Fetch or check out the merged main commit before rendering a submission entry.\n' >&2
+main_ref=refs/remotes/origin/main
+if ! git -C "$ROOT" rev-parse --verify "$main_ref^{commit}" >/dev/null 2>&1; then
+  printf 'error: cannot resolve origin/main in this checkout\n' >&2
+  printf 'Fetch origin/main before rendering a submission entry.\n' >&2
   exit 1
 fi
 
 main_sha=$(git -C "$ROOT" rev-parse "$main_ref^{commit}")
 if [ "$submission_sha" != "$main_sha" ]; then
-  printf 'error: submission SHA %s must equal merged main %s at %s\n' \
+  printf 'error: submission SHA %s must equal fetched remote main %s at %s\n' \
     "$submission_sha" "$main_sha" "$main_ref" >&2
   exit 1
 fi
 
-if [ -n "$(git -C "$ROOT" status --porcelain --untracked-files=all -- plugins/agent-guard)" ]; then
-  printf 'error: plugins/agent-guard has uncommitted changes relative to %s\n' "$submission_sha" >&2
+if ! "$ROOT/scripts/validate-submission-readiness.sh" >/dev/null; then
+  printf 'error: submission template or stable metadata validation failed\n' >&2
+  exit 1
+fi
+
+if [ -n "$(git -C "$ROOT" status --porcelain --untracked-files=all)" ]; then
+  printf 'error: working tree has uncommitted changes relative to %s\n' "$submission_sha" >&2
   exit 1
 fi
 
@@ -54,7 +53,18 @@ if [ -n "$output" ]; then
     printf 'error: output directory does not exist: %s\n' "$output_dir" >&2
     exit 1
   fi
-  tmp_output="$output.tmp.$$"
+
+  output_dir_abs=$(CDPATH= cd -- "$output_dir" && pwd -P)
+  output_abs="$output_dir_abs/$(basename -- "$output")"
+  if [ "$output_abs" = "$ENTRY" ]; then
+    printf 'error: output must not overwrite the tracked submission template\n' >&2
+    exit 1
+  fi
+
+  if ! tmp_output=$(mktemp "$output_dir_abs/.agent-guard-submission.XXXXXX"); then
+    printf 'error: could not create a secure temporary file in %s\n' "$output_dir_abs" >&2
+    exit 1
+  fi
   trap 'rm -f "$tmp_output"' EXIT HUP INT TERM
   jq --arg sha "$submission_sha" '.source.sha = $sha' "$ENTRY" >"$tmp_output"
   mv "$tmp_output" "$output"

--- a/scripts/render-submission-entry.sh
+++ b/scripts/render-submission-entry.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd -P)
+ENTRY="$ROOT/docs/submission/marketplace-entry.template.json"
+submission_sha=${AGENT_GUARD_SUBMISSION_SHA:-}
+output=${AGENT_GUARD_SUBMISSION_OUTPUT:-}
+
+if ! printf '%s\n' "$submission_sha" | grep -Eq '^[0-9a-f]{40}$'; then
+  printf 'error: AGENT_GUARD_SUBMISSION_SHA must be a full 40-character commit SHA\n' >&2
+  exit 1
+fi
+
+if ! git -C "$ROOT" rev-parse "$submission_sha^{commit}" >/dev/null 2>&1; then
+  printf 'error: submission commit %s is not present in this checkout\n' "$submission_sha" >&2
+  exit 1
+fi
+
+head_sha=$(git -C "$ROOT" rev-parse HEAD)
+if [ "$submission_sha" != "$head_sha" ]; then
+  printf 'error: submission SHA %s must match checked-out HEAD %s\n' "$submission_sha" "$head_sha" >&2
+  printf 'Generate the artifact from the merged main commit, not a pre-merge or stale payload.\n' >&2
+  exit 1
+fi
+
+main_ref=
+for candidate in refs/remotes/origin/main refs/heads/main; do
+  if git -C "$ROOT" rev-parse --verify "$candidate^{commit}" >/dev/null 2>&1; then
+    main_ref=$candidate
+    break
+  fi
+done
+if [ -z "$main_ref" ]; then
+  printf 'error: cannot resolve origin/main or local main in this checkout\n' >&2
+  printf 'Fetch or check out the merged main commit before rendering a submission entry.\n' >&2
+  exit 1
+fi
+
+main_sha=$(git -C "$ROOT" rev-parse "$main_ref^{commit}")
+if [ "$submission_sha" != "$main_sha" ]; then
+  printf 'error: submission SHA %s must equal merged main %s at %s\n' \
+    "$submission_sha" "$main_sha" "$main_ref" >&2
+  exit 1
+fi
+
+if [ -n "$(git -C "$ROOT" status --porcelain --untracked-files=all -- plugins/agent-guard)" ]; then
+  printf 'error: plugins/agent-guard has uncommitted changes relative to %s\n' "$submission_sha" >&2
+  exit 1
+fi
+
+if [ -n "$output" ]; then
+  output_dir=$(dirname -- "$output")
+  if [ ! -d "$output_dir" ]; then
+    printf 'error: output directory does not exist: %s\n' "$output_dir" >&2
+    exit 1
+  fi
+  tmp_output="$output.tmp.$$"
+  trap 'rm -f "$tmp_output"' EXIT HUP INT TERM
+  jq --arg sha "$submission_sha" '.source.sha = $sha' "$ENTRY" >"$tmp_output"
+  mv "$tmp_output" "$output"
+  trap - EXIT HUP INT TERM
+  printf 'submission entry written to %s for %s\n' "$output" "$submission_sha"
+else
+  jq --arg sha "$submission_sha" '.source.sha = $sha' "$ENTRY"
+fi

--- a/scripts/validate-submission-readiness.sh
+++ b/scripts/validate-submission-readiness.sh
@@ -3,8 +3,7 @@ set -eu
 
 ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd -P)
 PLUGIN="$ROOT/plugins/agent-guard"
-ENTRY="$ROOT/docs/submission/claude-plugins-official/marketplace-entry.template.json"
-REPORT="$ROOT/docs/claude-marketplace-readiness.md"
+ENTRY="$ROOT/docs/submission/marketplace-entry.template.json"
 
 failures=0
 
@@ -15,10 +14,6 @@ ok() {
 fail() {
   printf 'not ok: %s\n' "$1" >&2
   failures=$((failures + 1))
-}
-
-warn() {
-  printf 'warn: %s\n' "$1"
 }
 
 require_file() {
@@ -57,8 +52,6 @@ done
 require_json "$PLUGIN/.claude-plugin/plugin.json"
 require_json "$PLUGIN/hooks/hooks.json"
 require_json "$ENTRY"
-require_file "$REPORT"
-require_file "$ROOT/docs/submission/claude-plugins-official/curator-change-description.md"
 require_file "$ROOT/docs/submission/claude-community/form-draft.md"
 
 for file in LICENSE PRIVACY.md SUPPORT.md THIRD_PARTY_NOTICES.md; do
@@ -111,68 +104,13 @@ if jq -e '
   and .source.url == "https://github.com/JeongJaeSoon/agent-guard.git"
   and .source.path == "plugins/agent-guard"
   and .source.ref == "main"
+  and .source.sha == "<40-character-commit-sha-after-merge>"
   and .homepage == "https://github.com/JeongJaeSoon/agent-guard"
 ' "$ENTRY" >/dev/null; then
-  ok "official marketplace entry template uses the pinned git-subdir form and discloses material behavior"
+  ok "optional marketplace entry template uses stable git-subdir metadata and a post-merge SHA placeholder"
 else
-  fail "official marketplace entry template uses the pinned git-subdir form and discloses material behavior"
+  fail "optional marketplace entry template uses stable git-subdir metadata and a post-merge SHA placeholder"
 fi
-
-entry_sha=$(jq -r '.source.sha // ""' "$ENTRY")
-expected_sha=${AGENT_GUARD_SUBMISSION_SHA:-}
-if [ -n "$expected_sha" ]; then
-  if printf '%s\n' "$expected_sha" | grep -Eq '^[0-9a-f]{40}$'; then
-    ok "AGENT_GUARD_SUBMISSION_SHA is a full commit SHA"
-  else
-    fail "AGENT_GUARD_SUBMISSION_SHA is a full commit SHA"
-  fi
-  if [ "$entry_sha" = "$expected_sha" ]; then
-    ok "entry template is finalized at AGENT_GUARD_SUBMISSION_SHA"
-  else
-    fail "entry template is finalized at AGENT_GUARD_SUBMISSION_SHA"
-  fi
-else
-  case "$entry_sha" in
-    '<40-character-commit-sha-after-push>')
-      ok "entry template keeps an explicit post-push SHA placeholder"
-      ;;
-    *)
-      if printf '%s\n' "$entry_sha" | grep -Eq '^[0-9a-f]{40}$'; then
-        ok "entry template contains a full commit SHA"
-      else
-        fail "entry template contains a full commit SHA or the documented placeholder"
-      fi
-      ;;
-  esac
-fi
-
-# A 40-hex .source.sha is only a safety net if it still resolves to the payload
-# reviewers will actually install. Verifying the format is not enough: if the
-# pinned commit's plugins/agent-guard tree has drifted from the current payload,
-# the submission green-lights a stale snapshot. When the pinned commit is
-# present locally, require its subtree to equal HEAD's; when it is absent
-# (shallow / submission checkouts), FAIL closed — "could not verify" is not a
-# pass, so the caller must fetch full history. The placeholder is handled above.
-if printf '%s\n' "$entry_sha" | grep -Eq '^[0-9a-f]{40}$'; then
-  if git -C "$ROOT" rev-parse "$entry_sha^{commit}" >/dev/null 2>&1; then
-    if git -C "$ROOT" diff --quiet "$entry_sha" HEAD -- plugins/agent-guard; then
-      ok "pinned .source.sha's plugins/agent-guard tree matches the current payload"
-    else
-      fail "pinned .source.sha's plugins/agent-guard tree differs from current payload; re-pin the SHA"
-    fi
-  else
-    # "Could not verify" is not a pass. A shallow checkout (actions/checkout
-    # defaults to fetch-depth 1) cannot resolve a pin that is more than a commit
-    # or two back, which is the ordinary case — so warning and skipping here
-    # would print "validation passed" for a run that never checked anything,
-    # exactly the stale-pin scenario this guard exists to catch.
-    fail "cannot verify the pinned .source.sha tree: commit $entry_sha is not present locally; use a full-history checkout (actions/checkout with fetch-depth: 0)"
-  fi
-fi
-
-contains "$REPORT" 'No public application or direct PR path' 'readiness report records the official submission blocker'
-contains "$REPORT" 'ungated `PreToolUse` or `PostToolUse`' 'readiness report records the broad-hook blocker'
-contains "$REPORT" 'f9cb226d81172f53a1787cc3ba90dc9ab51aa169' 'readiness report pins the reviewed official snapshot'
 
 if [ "$failures" -eq 0 ]; then
   printf 'submission readiness validation passed\n'

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -679,20 +679,22 @@ else
   not_ok "release version drift: bin=$plugin_ver claude=$claude_ver codex=$codex_ver marketplace=$market_ver managed=$managed_claude_ref changelog=$changelog_ver"
 fi
 
-# --- submission-readiness pinned-SHA drift ---------------------------------
-# The official marketplace entry template pins .source.sha, but validating only
-# its 40-hex format lets the pin rot: reviewers approve one snapshot while the
-# payload silently moves on. Build a self-contained mirror of the current tree
-# (running THIS worktree's copy of the validator, which carries the fix) so we
-# can drive the pin to a matching, stale, and absent commit deterministically,
-# without touching the repo's real pinned value.
+# --- submission artifact lifecycle -----------------------------------------
+# Routine PR validation keeps a placeholder rather than a moving source SHA.
+# A concrete entry is rendered only from the exact checked-out commit after
+# merge. Build a self-contained mirror so matching, stale, malformed, and dirty
+# inputs can be exercised without modifying the repository's template.
 SUBMIRROR="$TMP_ROOT/submission-mirror"
-SUBENTRY="$SUBMIRROR/docs/submission/claude-plugins-official/marketplace-entry.template.json"
+SUBENTRY="$SUBMIRROR/docs/submission/marketplace-entry.template.json"
 SUBVALIDATOR="$SUBMIRROR/scripts/validate-submission-readiness.sh"
+SUBRENDERER="$SUBMIRROR/scripts/render-submission-entry.sh"
 mkdir -p "$SUBMIRROR"
 if git -C "$ROOT" archive HEAD | tar -x -C "$SUBMIRROR" 2>/dev/null; then
-  # Run the working-tree validator (the fix under test), not HEAD's committed copy.
+  # Run the working-tree scripts and template under test, not HEAD's committed
+  # copies. The current worktree may not have been committed yet.
   cp "$ROOT/scripts/validate-submission-readiness.sh" "$SUBVALIDATOR"
+  cp "$ROOT/scripts/render-submission-entry.sh" "$SUBRENDERER"
+  cp "$ROOT/docs/submission/marketplace-entry.template.json" "$SUBENTRY"
   (
     cd "$SUBMIRROR" || exit 2
     git init -q
@@ -700,41 +702,64 @@ if git -C "$ROOT" archive HEAD | tar -x -C "$SUBMIRROR" 2>/dev/null; then
     git config user.name test
     git add -A
     git commit -q -m mirror-base
+    git branch -M main
   )
   match_sha=$(git -C "$SUBMIRROR" rev-parse HEAD)
-  # Pin the template at the current HEAD → tree matches payload → must pass.
-  jq --arg sha "$match_sha" '.source.sha = $sha' "$SUBENTRY" >"$SUBENTRY.tmp" && mv "$SUBENTRY.tmp" "$SUBENTRY"
-  run_expect 0 "submission validator accepts a pin whose plugins/agent-guard tree matches HEAD" \
+  rendered_entry="$TMP_ROOT/rendered-marketplace-entry.json"
+
+  run_expect 0 "routine submission validator accepts the stable post-merge SHA placeholder" \
     env -u AGENT_GUARD_SUBMISSION_SHA "$SUBVALIDATOR"
 
-  # Advance HEAD so the pinned (now-parent) commit's payload no longer matches.
-  printf 'drift\n' >"$SUBMIRROR/plugins/agent-guard/DRIFT_MARKER"
-  (cd "$SUBMIRROR" && git add -A && git commit -q -m drift)
-  run_expect 1 "submission validator rejects a stale pin whose plugins/agent-guard tree differs from HEAD" \
-    env -u AGENT_GUARD_SUBMISSION_SHA "$SUBVALIDATOR"
-  if grep -q 'differs from current payload' "$ERR"; then
-    ok "stale-pin rejection names the payload drift and tells the maintainer to re-pin"
+  run_expect 0 "submission renderer emits an entry for the exact checked-out commit" \
+    env AGENT_GUARD_SUBMISSION_SHA="$match_sha" \
+      AGENT_GUARD_SUBMISSION_OUTPUT="$rendered_entry" "$SUBRENDERER"
+  if [ "$(jq -r '.source.sha' "$rendered_entry")" = "$match_sha" ] \
+     && [ "$(jq -r '.source.sha' "$SUBENTRY")" = '<40-character-commit-sha-after-merge>' ]; then
+    ok "submission renderer pins only the generated artifact and leaves the template stable"
   else
-    not_ok "stale-pin rejection names the payload drift and tells the maintainer to re-pin"
+    not_ok "submission renderer pins only the generated artifact and leaves the template stable"
+  fi
+
+  run_expect 1 "submission renderer rejects a malformed source SHA" \
+    env AGENT_GUARD_SUBMISSION_SHA=not-a-commit "$SUBRENDERER"
+
+  # Advance a feature branch without changing the plugin. Its HEAD is valid and
+  # present, but it has not been merged into main and must not become a catalog
+  # source pin.
+  git -C "$SUBMIRROR" switch -q -c feature
+  printf 'next commit\n' >"$SUBMIRROR/submission-test-marker"
+  (cd "$SUBMIRROR" && git add -A && git commit -q -m drift)
+  feature_sha=$(git -C "$SUBMIRROR" rev-parse HEAD)
+  run_expect 1 "submission renderer rejects an unmerged feature-branch HEAD" \
+    env AGENT_GUARD_SUBMISSION_SHA="$feature_sha" "$SUBRENDERER"
+  if grep -q 'must equal merged main' "$ERR"; then
+    ok "unmerged submission SHA fails with an actionable main-branch message"
+  else
+    not_ok "unmerged submission SHA fails with an actionable main-branch message"
     sed 's/^/  stderr: /' "$ERR"
   fi
 
-  # A syntactically valid SHA that is not a local commit (shallow / submission
-  # checkout) must FAIL closed: "could not verify" is not a pass. Warning and
-  # skipping would print "validation passed" for a run that checked nothing —
-  # exactly the stale-pin scenario this guard exists to catch.
-  absent_sha=1234567890123456789012345678901234567890
-  jq --arg sha "$absent_sha" '.source.sha = $sha' "$SUBENTRY" >"$SUBENTRY.tmp" && mv "$SUBENTRY.tmp" "$SUBENTRY"
-  run_expect 1 "submission validator fails closed when the pinned commit is not available locally" \
-    env -u AGENT_GUARD_SUBMISSION_SHA "$SUBVALIDATOR"
-  if grep -q 'is not present locally' "$OUT" "$ERR"; then
-    ok "history-unavailable pin fails with an actionable full-history message"
+  run_expect 1 "submission renderer rejects a reachable SHA that is not checked-out HEAD" \
+    env AGENT_GUARD_SUBMISSION_SHA="$match_sha" "$SUBRENDERER"
+  if grep -q 'must match checked-out HEAD' "$ERR"; then
+    ok "stale submission SHA fails with an actionable post-merge message"
   else
-    not_ok "history-unavailable pin fails with an actionable full-history message"
-    sed 's/^/  stdout: /' "$OUT"; sed 's/^/  stderr: /' "$ERR"
+    not_ok "stale submission SHA fails with an actionable post-merge message"
+    sed 's/^/  stderr: /' "$ERR"
+  fi
+
+  git -C "$SUBMIRROR" switch -q main
+  printf 'dirty payload\n' >"$SUBMIRROR/plugins/agent-guard/DRIFT_MARKER"
+  run_expect 1 "submission renderer rejects uncommitted plugin payload changes" \
+    env AGENT_GUARD_SUBMISSION_SHA="$match_sha" "$SUBRENDERER"
+  if grep -q 'has uncommitted changes' "$ERR"; then
+    ok "dirty submission payload fails before rendering a catalog entry"
+  else
+    not_ok "dirty submission payload fails before rendering a catalog entry"
+    sed 's/^/  stderr: /' "$ERR"
   fi
 else
-  say "git archive unavailable; skipped submission-readiness drift tests"
+  say "git archive unavailable; skipped submission artifact lifecycle tests"
 fi
 
 expect_json_status 2 "Claude Write secret is blocked" \

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -688,6 +688,7 @@ SUBMIRROR="$TMP_ROOT/submission-mirror"
 SUBENTRY="$SUBMIRROR/docs/submission/marketplace-entry.template.json"
 SUBVALIDATOR="$SUBMIRROR/scripts/validate-submission-readiness.sh"
 SUBRENDERER="$SUBMIRROR/scripts/render-submission-entry.sh"
+SUBREMOTE="$TMP_ROOT/submission-remote.git"
 mkdir -p "$SUBMIRROR"
 if git -C "$ROOT" archive HEAD | tar -x -C "$SUBMIRROR" 2>/dev/null; then
   # Run the working-tree scripts and template under test, not HEAD's committed
@@ -703,6 +704,9 @@ if git -C "$ROOT" archive HEAD | tar -x -C "$SUBMIRROR" 2>/dev/null; then
     git add -A
     git commit -q -m mirror-base
     git branch -M main
+    git init -q --bare "$SUBREMOTE"
+    git remote add origin "$SUBREMOTE"
+    git push -q -u origin main
   )
   match_sha=$(git -C "$SUBMIRROR" rev-parse HEAD)
   rendered_entry="$TMP_ROOT/rendered-marketplace-entry.json"
@@ -723,6 +727,17 @@ if git -C "$ROOT" archive HEAD | tar -x -C "$SUBMIRROR" 2>/dev/null; then
   run_expect 1 "submission renderer rejects a malformed source SHA" \
     env AGENT_GUARD_SUBMISSION_SHA=not-a-commit "$SUBRENDERER"
 
+  git -C "$SUBMIRROR" update-ref -d refs/remotes/origin/main
+  run_expect 1 "submission renderer rejects a checkout without origin/main" \
+    env AGENT_GUARD_SUBMISSION_SHA="$match_sha" "$SUBRENDERER"
+  if grep -q 'cannot resolve origin/main' "$ERR"; then
+    ok "missing remote main fails with actionable fetch guidance"
+  else
+    not_ok "missing remote main fails with actionable fetch guidance"
+    sed 's/^/  stderr: /' "$ERR"
+  fi
+  git -C "$SUBMIRROR" fetch -q origin main:refs/remotes/origin/main
+
   # Advance a feature branch without changing the plugin. Its HEAD is valid and
   # present, but it has not been merged into main and must not become a catalog
   # source pin.
@@ -732,10 +747,10 @@ if git -C "$ROOT" archive HEAD | tar -x -C "$SUBMIRROR" 2>/dev/null; then
   feature_sha=$(git -C "$SUBMIRROR" rev-parse HEAD)
   run_expect 1 "submission renderer rejects an unmerged feature-branch HEAD" \
     env AGENT_GUARD_SUBMISSION_SHA="$feature_sha" "$SUBRENDERER"
-  if grep -q 'must equal merged main' "$ERR"; then
-    ok "unmerged submission SHA fails with an actionable main-branch message"
+  if grep -q 'must equal fetched remote main' "$ERR"; then
+    ok "unmerged submission SHA fails with an actionable remote-main message"
   else
-    not_ok "unmerged submission SHA fails with an actionable main-branch message"
+    not_ok "unmerged submission SHA fails with an actionable remote-main message"
     sed 's/^/  stderr: /' "$ERR"
   fi
 
@@ -749,10 +764,32 @@ if git -C "$ROOT" archive HEAD | tar -x -C "$SUBMIRROR" 2>/dev/null; then
   fi
 
   git -C "$SUBMIRROR" switch -q main
+  printf '\n' >>"$SUBENTRY"
+  run_expect 1 "submission renderer rejects uncommitted template changes" \
+    env AGENT_GUARD_SUBMISSION_SHA="$match_sha" "$SUBRENDERER"
+  if grep -q 'working tree has uncommitted changes' "$ERR"; then
+    ok "dirty submission template fails before rendering a catalog entry"
+  else
+    not_ok "dirty submission template fails before rendering a catalog entry"
+    sed 's/^/  stderr: /' "$ERR"
+  fi
+  git -C "$SUBMIRROR" checkout -q -- docs/submission/marketplace-entry.template.json
+
+  run_expect 1 "submission renderer refuses to overwrite its tracked template" \
+    env AGENT_GUARD_SUBMISSION_SHA="$match_sha" \
+      AGENT_GUARD_SUBMISSION_OUTPUT="$SUBENTRY" "$SUBRENDERER"
+  if grep -q 'must not overwrite' "$ERR" \
+     && [ "$(jq -r '.source.sha' "$SUBENTRY")" = '<40-character-commit-sha-after-merge>' ]; then
+    ok "tracked template remains unchanged when selected as the output"
+  else
+    not_ok "tracked template remains unchanged when selected as the output"
+    sed 's/^/  stderr: /' "$ERR"
+  fi
+
   printf 'dirty payload\n' >"$SUBMIRROR/plugins/agent-guard/DRIFT_MARKER"
   run_expect 1 "submission renderer rejects uncommitted plugin payload changes" \
     env AGENT_GUARD_SUBMISSION_SHA="$match_sha" "$SUBRENDERER"
-  if grep -q 'has uncommitted changes' "$ERR"; then
+  if grep -q 'working tree has uncommitted changes' "$ERR"; then
     ok "dirty submission payload fails before rendering a catalog entry"
   else
     not_ok "dirty submission payload fails before rendering a catalog entry"


### PR DESCRIPTION
## Summary

- stop committing a moving Anthropic catalog `.source.sha` in routine Agent Guard payload PRs
- keep a stable marketplace-entry template with a post-merge SHA placeholder
- render a concrete catalog entry only from the exact fetched `origin/main` commit
- remove full-history checkout from routine Plugin Validation
- keep the community form draft stable and treat curator/readiness documents as optional or historical context

## Why

The previous repository-local rule required every plugin payload change to update the same SHA in several submission documents before merge. That created documentation-only re-pin commits, forced full Git history in normal CI, and could pin a feature-branch commit that becomes unreachable after squash or rebase merging.

The immutable SHA is appropriate in Anthropic's downstream catalog, but it is not useful as a moving value duplicated throughout this upstream repository. Routine CI should validate the shipped plugin and stable submission metadata; a concrete catalog artifact should be produced only when an actual handoff needs one.

## Implementation

- move the template to the route-neutral `docs/submission/marketplace-entry.template.json`
- replace the committed SHA with `<40-character-commit-sha-after-merge>`
- add `scripts/render-submission-entry.sh` and `make submission-artifact SHA=<merged-main-sha>`
- require the requested SHA to:
  - be a full 40-character commit
  - match checked-out `HEAD`
  - equal fetched `origin/main`
  - come from a completely clean working tree
  - pass stable template and disclosure validation
- reject attempts to overwrite the tracked template and use an atomic `mktemp` file beside the requested output
- keep generated JSON out of the repository
- remove pin/tree drift checks and `fetch-depth: 0` from routine Plugin Validation
- stop treating the dated readiness report and optional curator description as CI truth

## Impact

Normal plugin PRs no longer need a second documentation-only re-pin commit or a full-history checkout. Actual submission handoffs still fail closed if the SHA is malformed, stale, not on fetched `origin/main`, generated from a dirty worktree, or based on invalid template metadata.

Runtime plugin behavior and the self-hosted Claude/Codex marketplace manifests are unchanged.

## Verification

- `make test`: **747 passed / 0 failed**
- `make submission-check`: pass
- `scripts/validate-plugin-layout.sh --all`: pass
- `git diff --check`: pass
- shell syntax checks: pass

The new regression coverage verifies successful remote-main rendering and rejects malformed SHA, missing `origin/main`, unmerged feature-branch HEAD, stale non-HEAD SHA, dirty template/plugin inputs, and attempts to overwrite the tracked template.

Follow-up to #153.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command to generate marketplace submission entries using a validated merged-commit reference.
  * Added safeguards to reject invalid, stale, unmerged, or locally modified plugin source states.

* **Documentation**
  * Updated marketplace submission guidance to distinguish routine validation from curator handoff.
  * Replaced fixed commit references with post-merge placeholders and clarified when submission artifacts should be generated.

* **Tests**
  * Added coverage for submission artifact generation and validation throughout its lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->