### PR TITLE
fix(redaction): enforce short-value probe eligibility

### DIFF
--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -3036,14 +3036,13 @@ secretish_env_values() {
     }
     function emit_secret(value, eligible_length) {
       if (already_redacted(value)) return
+      if (eligible_length == 0) eligible_length = length(value)
+      if (eligible_length < 4 || length(value) == 0) return
       if (record_mode == "probe" || record_mode == "probe_raw") {
         if (!probe_found) print "x"
         probe_found = 1
         return
       }
-      if (eligible_length == 0) eligible_length = length(value)
-      if (eligible_length < 4) return
-      if (length(value) == 0) return
       if (record_mode == "framed") emit_framed(value, "S")
       else print "\"" json_escape(value) "\""
     }

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -6388,6 +6388,23 @@ else
   sed 's/^/  out: /' "$OUT"
 fi
 
+# Structural closers make the complete token eligible for contextual mapping,
+# even when the value itself is short. Probe mode must retain that mapping or
+# large responses would leak a token that ordinary redaction masks.
+large_short_contextual_input=$(jq -nc '
+  {tool_name:"Read",tool_input:{file_path:"short-contextual-dump.txt"},
+   tool_response:["TOKEN=123}", ("c" * 300000)]}
+')
+post_tool_out "$large_short_contextual_input"
+if [ -s "$OUT" ] \
+   && jq -e '.hookSpecificOutput.updatedToolOutput
+              == ["[REDACTED]", "[REDACTED]"]' "$OUT" >/dev/null 2>&1; then
+  ok "post-tool large probe retains eligible contextual short mappings"
+else
+  not_ok "post-tool large probe preserves contextual short-value detection"
+  sed 's/^/  out: /' "$OUT"
+fi
+
 # Log/timestamp prefix must not hijack the env-heuristic split: the value is
 # anchored to the matched key's delimiter, not the first ":" (here inside the
 # "12:00:00" timestamp). A clean copy in a SEPARATE leaf (stderr) only gets
@@ -6904,6 +6921,19 @@ if [ "$exec_first_byte" = ff ] \
   ok "exec raw probe ignores ineligible short assignments"
 else
   not_ok "exec raw probe over-masks an ineligible short assignment"
+  LC_ALL=C wc -c "$OUT" | sed 's/^/  bytes: /'
+fi
+
+# As above, a structural closer permits an exact assignment-token mapping.
+# The raw probe must keep detecting it so invalid-byte fallback cannot leak it.
+"$PLUGIN_ROOT/bin/agent-guard" exec -- sh -c '
+  printf "\377\nTOKEN=123}\n"
+  awk "BEGIN { for (i = 0; i < 70000; i++) printf \"z\" }"
+' >"$OUT" 2>/dev/null
+if [ "$(cat "$OUT")" = '[REDACTED]' ]; then
+  ok "exec raw probe retains eligible contextual short mappings"
+else
+  not_ok "exec raw probe preserves contextual short-value detection"
   LC_ALL=C wc -c "$OUT" | sed 's/^/  bytes: /'
 fi
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -6374,6 +6374,20 @@ else
   sed 's/^/  out: /' "$OUT"
 fi
 
+# Probe mode must use the same minimum-value eligibility as ordinary redaction.
+# A short assignment in a large response is not enough to mask unrelated leaves.
+large_short_assignment_input=$(jq -nc '
+  {tool_name:"Read",tool_input:{file_path:"short-assignment-dump.txt"},
+   tool_response:["TOKEN=1", ("b" * 300000)]}
+')
+post_tool_out "$large_short_assignment_input"
+if [ ! -s "$OUT" ]; then
+  ok "post-tool large probe ignores ineligible short assignments"
+else
+  not_ok "post-tool large probe over-masks an ineligible short assignment"
+  sed 's/^/  out: /' "$OUT"
+fi
+
 # Log/timestamp prefix must not hijack the env-heuristic split: the value is
 # anchored to the matched key's delimiter, not the first ":" (here inside the
 # "12:00:00" timestamp). A clean copy in a SEPARATE leaf (stderr) only gets
@@ -6873,6 +6887,23 @@ if [ "$exec_first_byte" = ff ] \
   ok "exec preserves oversized invalid-byte output without secret records"
 else
   not_ok "exec does not over-mask oversized benign invalid-byte output"
+  LC_ALL=C wc -c "$OUT" | sed 's/^/  bytes: /'
+fi
+
+# The raw-byte probe follows the same short-value eligibility rule. Preserve
+# the complete invalid-byte capture instead of replacing it with one sentinel.
+"$PLUGIN_ROOT/bin/agent-guard" exec -- sh -c '
+  printf "\377\nTOKEN=1\n"
+  awk "BEGIN { for (i = 0; i < 70000; i++) printf \"y\" }"
+' >"$OUT" 2>/dev/null
+exec_first_byte=$(LC_ALL=C od -An -tx1 "$OUT" | awk 'NR == 1 { print $1 }')
+if [ "$exec_first_byte" = ff ] \
+   && grep -a -q '^TOKEN=1$' "$OUT" \
+   && [ "$(LC_ALL=C wc -c <"$OUT" | tr -d ' ')" -gt 65536 ] \
+   && ! grep -a -q '\[REDACTED\]' "$OUT"; then
+  ok "exec raw probe ignores ineligible short assignments"
+else
+  not_ok "exec raw probe over-masks an ineligible short assignment"
   LC_ALL=C wc -c "$OUT" | sed 's/^/  bytes: /'
 fi
 


### PR DESCRIPTION
## Summary

- apply the display-redaction minimum-value eligibility rule before large-output probe modes report a candidate
- keep large benign responses byte-for-byte unchanged when their only secret-shaped assignment has a value shorter than four characters
- cover both structured post-tool responses and invalid-byte `exec` captures

## Reproduction

After #157, a large response containing only `TOKEN=1` still enters `probe` / `probe_raw` mode. Those modes reported a secret candidate before `eligible_length < 4` was checked, so the caller masked or replaced unrelated content even though ordinary redaction correctly ignores the short value.

## Root cause

`emit_secret()` applied the minimum-value and empty-value guards only after the early `probe` / `probe_raw` branch. Probe mode therefore had a broader eligibility policy than the redaction pass it was meant to predict.

## Change

- compute the effective eligible length first
- return for values shorter than four characters or empty values before every output mode
- add same-policy regressions for 300 KiB JSON leaves and raw captures containing an invalid byte plus more than 64 KiB of benign output
- pin the existing complete-token exception: a short value followed by structural punctuation remains an eligible contextual mapping in ordinary, probe, and raw-probe modes

## Related work

- follow-up to merged PR #157
- issue #156 concerns allowlisted display labels and is adjacent, not a duplicate of this probe eligibility mismatch
- PR #162 moved marketplace SHA pinning to the post-merge `make submission-artifact SHA=<merged-main-sha>` flow, so this unmerged PR does not add a manual SHA pin commit

## Verification

- `make test` — 802 passed, 0 failed
- `make smoke-test` — passed
- `scripts/validate-plugin-layout.sh` — passed
- `make submission-check` — passed
- `sh -n plugins/agent-guard/bin/agent-guard`
- `dash -n plugins/agent-guard/bin/agent-guard`
- `sh -n tests/run.sh`
- `dash -n tests/run.sh`
- `git diff --check` — passed

The Makefile has no `fmt` target.

## Not covered

- no live Claude Code or Codex host capture was executed; coverage uses deterministic hook and raw-exec fixtures
