### PR TITLE
refactor(hosts): keep host-specific surfaces in sync with generic logic

### DIFF
--- a/examples/claude/settings.project.json
+++ b/examples/claude/settings.project.json
@@ -35,6 +35,18 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/absolute/path/to/agent-guard/plugins/agent-guard/bin/agent-guard hook-session-start",
+            "timeout": 5
+          }
+        ]
+      }
     ]
   }
 }

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -238,8 +238,15 @@ handle_hook_infrastructure_failure() {
   return 0
 }
 
+# Which host's hook contract this invocation speaks. Every host-conditional
+# branch routes through this single default so adding a host or changing the
+# fallback is a one-line change, not a grep for scattered ':-claude' defaults.
+hook_host() {
+  printf '%s\n' "${AGENT_GUARD_HOOK_HOST:-claude}"
+}
+
 degraded_hook_message() {
-  case "${AGENT_GUARD_HOOK_HOST:-claude}" in
+  case "$(hook_host)" in
     codex) setup_ref='$setup-agent-guard' ;;
     *) setup_ref='agent-guard:setup-agent-guard' ;;
   esac
@@ -3770,7 +3777,7 @@ redact_tool_output() {
 
   [ "$out" != "$resp" ] || return 0
 
-  case "${AGENT_GUARD_HOOK_HOST:-claude}" in
+  case "$(hook_host)" in
     codex)
       # Keep the potentially large updated output on stdin. Linux limits one
       # exec argument to roughly 128 KiB, so `--argjson ut "$out"` can fail
@@ -3918,7 +3925,7 @@ hook_session_start() {
   # Accept only a digit-led version token drawn from a safe charset: an empty or
   # unparseable marker fails quiet, and the charset keeps the hand-built JSON
   # below injection-safe (no quotes/backslashes/whitespace to escape).
-  if [ "${AGENT_GUARD_HOOK_HOST:-claude}" = claude ]; then
+  if [ "$(hook_host)" = claude ]; then
     case $marker in
       ''|[!0-9]*|*[!0-9A-Za-z.+-]*) ;;
       *)
@@ -3934,13 +3941,13 @@ hook_session_start() {
   # command wrapping is default-on, so an absent marker means the one-time
   # shell setup has not loaded. Keep Codex silent: Claude shell snapshots are
   # not a Codex command boundary.
-  if [ -z "$marker" ] && [ "${AGENT_GUARD_HOOK_HOST:-claude}" = claude ]; then
-    wrapping_setup='agent-guard command wrapping is not loaded. Run /agent-guard:setup-shell, then restart the shell and Claude Code. Use setup-shell --no-command-wrapping for a persistent opt-out.'
+  if [ -z "$marker" ] && [ "$(hook_host)" = claude ]; then
+    wrapping_setup='agent-guard command wrapping is not loaded. Run /agent-guard:setup-shell (or agent-guard setup-shell for a standalone install), then restart the shell and Claude Code. Use setup-shell --no-command-wrapping for a persistent opt-out.'
     if [ -n "$message" ]; then message="$message $wrapping_setup"; else message=$wrapping_setup; fi
   fi
 
   [ -n "$message" ] || return 0
-  case "${AGENT_GUARD_HOOK_HOST:-claude}" in
+  case "$(hook_host)" in
     codex)
       printf '{"systemMessage":"%s","hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"%s"}}\n' "$message" "$message"
       ;;

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -350,6 +350,25 @@ codex_ss_matcher=$(jq -r '.hooks.SessionStart[0].matcher' "$PLUGIN_ROOT/hooks.js
 [ "$codex_ss_matcher" = "$ss_hook_matcher" ] \
   && ok "Codex SessionStart matcher matches the supported lifecycle set" \
   || not_ok "Codex SessionStart matcher matches the supported lifecycle set (got: $codex_ss_matcher)"
+
+# Both standalone examples must carry the same SessionStart coverage as the
+# plugin manifests: the degraded-setup warning is host-neutral, so leaving it
+# out of one host's example is a per-tool coverage gap, not a host difference.
+for file in \
+  "$ROOT/examples/claude/settings.project.json" \
+  "$ROOT/examples/codex/hooks.json"; do
+  ex_ss_matcher=$(jq -r '.hooks.SessionStart[0].matcher // empty' "$file")
+  ex_ss_timeout=$(jq -r '.hooks.SessionStart[0].hooks[0].timeout // empty' "$file")
+  ex_ss_sub=$(jq -r '.hooks.SessionStart[0].hooks[0].command // empty' "$file" \
+    | grep -oE 'hook-session-start' | tail -n1)
+  if [ "$ex_ss_matcher" = "$ss_hook_matcher" ] \
+     && [ "$ex_ss_timeout" = "$ss_hook_timeout" ] \
+     && [ "$ex_ss_sub" = "hook-session-start" ]; then
+    ok "SessionStart hook in $file matches the plugin manifests"
+  else
+    not_ok "SessionStart hook in $file matches the plugin manifests (matcher: $ex_ss_matcher, timeout: $ex_ss_timeout, sub: $ex_ss_sub)"
+  fi
+done
 case "$ss_hook_command" in
   *'CLAUDE_PLUGIN_ROOT'*'/current/bin/agent-guard'*'hook-session-start'*)
     ok "SessionStart command resolves hook-session-start through the stable current path" ;;
@@ -397,6 +416,40 @@ case "$codex_pre_tool_command" in
     ok "Codex hook command does not depend on host-specific plugin root env vars"
     ;;
 esac
+
+# The inline hook commands are ONE generic resolver rendered once per host.
+# Only three host tokens may differ: the plugin-root env var, the warning
+# manifest tag, and the AGENT_GUARD_HOOK_HOST pin. Normalize those and require
+# byte-identical commands, so a fix applied to one host's resolver cannot
+# silently miss the other.
+for event in PreToolUse PostToolUse Stop SessionStart; do
+  claude_cmd=$(jq -r ".hooks.${event}[0].hooks[0].command" "$PLUGIN_ROOT/hooks/hooks.json")
+  codex_cmd=$(jq -r ".hooks.${event}[0].hooks[0].command" "$PLUGIN_ROOT/hooks.json")
+  case "$claude_cmd" in
+    *'AGENT_GUARD_HOOK_HOST=claude'*) ok "$event Claude hook command pins AGENT_GUARD_HOOK_HOST=claude" ;;
+    *) not_ok "$event Claude hook command pins AGENT_GUARD_HOOK_HOST=claude" ;;
+  esac
+  case "$codex_cmd" in
+    *'AGENT_GUARD_HOOK_HOST=codex'*) ok "$event Codex hook command pins AGENT_GUARD_HOOK_HOST=codex" ;;
+    *) not_ok "$event Codex hook command pins AGENT_GUARD_HOOK_HOST=codex" ;;
+  esac
+  claude_norm=$(printf '%s' "$claude_cmd" | sed \
+    -e 's/CLAUDE_PLUGIN_ROOT/__HOST_ROOT__/g' \
+    -e 's/manifest-claude/manifest-__HOST__/g' \
+    -e 's/AGENT_GUARD_HOOK_HOST=claude/AGENT_GUARD_HOOK_HOST=__HOST__/g')
+  codex_norm=$(printf '%s' "$codex_cmd" | sed \
+    -e 's/PLUGIN_ROOT/__HOST_ROOT__/g' \
+    -e 's/manifest-codex/manifest-__HOST__/g' \
+    -e 's/AGENT_GUARD_HOOK_HOST=codex/AGENT_GUARD_HOOK_HOST=__HOST__/g')
+  if [ "$claude_norm" = "$codex_norm" ]; then
+    ok "$event hook resolver is identical across hosts after host-token normalization"
+  else
+    not_ok "$event hook resolver is identical across hosts after host-token normalization"
+    printf '%s\n' "$claude_norm" >"$TESTTMP/claude_norm"
+    printf '%s\n' "$codex_norm" >"$TESTTMP/codex_norm"
+    diff "$TESTTMP/claude_norm" "$TESTTMP/codex_norm" | sed 's/^/  diff: /'
+  fi
+done
 
 read_env_payload='{"tool_name":"Read","tool_input":{"file_path":".env"}}'
 printf '%s' "$read_env_payload" \
@@ -7578,6 +7631,14 @@ if [ $? -eq 0 ] \
   ok "Claude SessionStart guides default command-wrapping setup when the marker is absent"
 else
   not_ok "Claude SessionStart guides command-wrapping setup with no marker (got: $vd_out)"
+fi
+# Like the degraded-dependency guidance, the wrapping nudge must offer the CLI
+# form alongside the plugin command: standalone (settings-based) installs have
+# no /agent-guard:* commands to run.
+if printf '%s' "$vd_out" | jq -e '.systemMessage | contains("or agent-guard setup-shell")' >/dev/null 2>&1; then
+  ok "command-wrapping setup guidance offers the standalone CLI form"
+else
+  not_ok "command-wrapping setup guidance offers the standalone CLI form (got: $vd_out)"
 fi
 
 vd_out=$(AGENT_GUARD_HOOK_HOST=codex AGENT_GUARD_GITLEAKS_BIN="$MOCK_BIN/gitleaks" \


### PR DESCRIPTION
## What

Audit of host-specific vs generic surfaces across the Claude Code and Codex integrations, plus fixes for the places where generic logic existed only as unsynchronized per-host copies:

- **Cross-host resolver parity test** (`tests/run.sh`): the inline hook commands in `plugins/agent-guard/hooks/hooks.json` (Claude) and `plugins/agent-guard/hooks.json` (Codex) are one generic resolver rendered per host. The new test normalizes the three legitimate host tokens (plugin-root env var, warning-manifest tag, `AGENT_GUARD_HOOK_HOST` pin) and requires the commands to be byte-identical, and requires each host command to pin its own `AGENT_GUARD_HOOK_HOST` value. Previously only matcher/type/timeout/subcommand were compared, so a fix applied to one host's resolver could silently miss the other.
- **Claude example gains SessionStart** (`examples/claude/settings.project.json`): the Codex example and both plugin manifests already carried it; the degraded-setup warning is host-neutral, so its absence in one host's example was a coverage gap, not a host difference. A new test keeps both standalone examples aligned with the plugin manifests.
- **Command-wrapping guidance no longer assumes a plugin install** (`bin/agent-guard`): the SessionStart nudge now offers `agent-guard setup-shell` (CLI form) next to `/agent-guard:setup-shell`, mirroring the degraded-dependency guidance, so settings-based standalone installs are not pointed at a `/agent-guard:*` command they do not have.
- **`hook_host()` helper** (`bin/agent-guard`): centralizes the five scattered `${AGENT_GUARD_HOOK_HOST:-claude}` defaults into one function; behavior unchanged.

## Why

Generic behavior that lives in per-host copies (hook resolvers, examples, setup guidance) drifts silently when only one copy is edited. This PR makes the per-host renderings either enforced-identical (parity test) or explicitly host-parameterized (`hook_host()`), and removes the one place where guidance assumed a specific install form.

## Reviewer notes

- The parity test was exercised with a must-fail control: a mutated Codex resolver (`tail -n 1` → `tail -n 2`) and a dropped host pin were both reported as failures, then reverted.
- Deliberately left alone: `bootstrap.sh` unconditionally installing the Claude-only shell integration (inert outside Claude Code; changing it to opt-in is a product decision), and the Claude-only `commands/` directory (Codex covers the same surface with skills).
- Three pre-existing tests (`… ignores …_PLUGIN_ROOT`) fail on macOS even on a clean `origin/main` checkout (once-per-session warning-marker sharing between tests); tracked separately, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
