### PR TITLE
chore(ci): cap job runtime on merge-gating workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
   secret-guard:
     name: Agent Guard
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -47,6 +48,9 @@ jobs:
         # may not exist.
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
+    # Normal runs finish in ~2-3 min; the default 6h cap once left a dead
+    # macOS runner blocking the merge queue for an hour before manual cancel.
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -107,6 +111,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     env:
       SHELLCHECK_VERSION: "0.10.0"
       ACTIONLINT_VERSION: "1.7.7"

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -19,6 +19,7 @@ jobs:
   codex:
     name: Review
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     if: github.event.pull_request.draft == false
     env:
       HAS_OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY != '' }}
@@ -74,6 +75,7 @@ jobs:
   post_feedback:
     name: Post feedback
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: codex
     if: needs.codex.outputs.final_message != ''
     permissions:

--- a/.github/workflows/hol-plugin-scanner.yml
+++ b/.github/workflows/hol-plugin-scanner.yml
@@ -26,6 +26,7 @@ jobs:
   scan:
     name: HOL Plugin Scanner
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/plugin-validation.yml
+++ b/.github/workflows/plugin-validation.yml
@@ -13,6 +13,7 @@ jobs:
   plugin-validation:
     name: Plugin Layout
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## What

Adds `timeout-minutes` to every merge-gating workflow job (ci.yml: secret-guard 10 / test 20 / lint 10; plugin-validation 10; hol-plugin-scanner 10; codex-review 15+15).

## Why

Jobs default to GitHub's 6-hour cap. On PR #164 a dead `macos-latest` runner hung the Test job for ~1 hour (it never even uploaded logs) and blocked the merge until it was manually force-cancelled. With caps just above normal runtime (tests ~2-3 min, everything else under 2 min), an infra hang now fails within minutes and can simply be rerun.

## Reviewer notes

No step behavior changes — one `timeout-minutes` line per job. YAML validated locally; actionlint runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)