### PR TITLE
refactor(hooks): render hook manifests from one template; dedup inline helpers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,7 @@ jobs:
             tests/run.sh \
             bench/run.sh \
             scripts/build-release-tarball.sh \
+            scripts/render-hook-manifests.sh \
             scripts/validate-plugin-layout.sh \
             scripts/validate-submission-readiness.sh \
             scripts/render-submission-entry.sh \

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -75,8 +75,8 @@ refresh_plugin_current_link() {
       candidate_root=${candidate%/bin/agent-guard}
       candidate_version=${candidate_root##*/}
       is_semver_dir "$candidate_version" || continue
-      printf '%s\t%s\n' "$candidate_version" "$candidate_version"
-    done | sort -t. -k1,1n -k2,2n -k3,3n | tail -n 1 | cut -f 2-
+      printf '%s\n' "$candidate_version"
+    done | sort -t. -k1,1n -k2,2n -k3,3n | tail -n 1
   )
   [ -n "$latest" ] || return 1
   # BSD and GNU ln both support -n to replace a symlink-to-directory itself
@@ -280,7 +280,6 @@ check_deps() {
   need_cmd jq
   need_cmd git
   need_gitleaks
-  [ -f "$GITLEAKS_CONFIG" ] || die "gitleaks config not found: $GITLEAKS_CONFIG"
   [ -f "$DENY_READ_PATHS" ] || die "deny read policy not found: $DENY_READ_PATHS"
   [ -f "$DENY_BASH_PATTERNS" ] || die "deny bash policy not found: $DENY_BASH_PATTERNS"
   info "$PROGRAM: dependencies ok"
@@ -1457,10 +1456,9 @@ block_on_scan_status() {
   esac
 }
 
-# Extract only added diff lines, dropping exact checksum fields only when the
-# diff header identifies one of the supported lockfiles.
-extract_added_lines() {
-  LC_ALL=C awk '
+# Shared by both diff extractors below: map a diff path to the (uppercase =
+# fragment-context) lockfile kind byte filter_lockfile_records consumes.
+AWK_LOCKFILE_KIND='
     function lockfile_kind(path, parts, count, name) {
       count = split(path, parts, "/")
       name = parts[count]
@@ -1470,7 +1468,12 @@ extract_added_lines() {
       if (name == "Cargo.lock") return "C"
       if (name == "uv.lock") return "U"
       return "-"
-    }
+    }'
+
+# Extract only added diff lines, dropping exact checksum fields only when the
+# diff header identifies one of the supported lockfiles.
+extract_added_lines() {
+  LC_ALL=C awk "$AWK_LOCKFILE_KIND"'
     /^diff --git / { in_hunk = 0; path = ""; next }
     !in_hunk && /^\+\+\+ b\// { path = substr($0, 7); next }
     /^@@/ { in_hunk = 1; next }
@@ -1479,17 +1482,7 @@ extract_added_lines() {
 }
 # Extract lines introduced by Codex apply_patch envelopes or unified diffs.
 extract_patch_added_lines() {
-  LC_ALL=C awk '
-    function lockfile_kind(path, parts, count, name) {
-      count = split(path, parts, "/")
-      name = parts[count]
-      if (name == "go.sum") return "g"
-      if (name == "package-lock.json") return "P"
-      if (name == "yarn.lock") return "y"
-      if (name == "Cargo.lock") return "C"
-      if (name == "uv.lock") return "U"
-      return "-"
-    }
+  LC_ALL=C awk "$AWK_LOCKFILE_KIND"'
     BEGIN { mode = "none"; in_hunk = 0 }
     /^\*\*\* Begin Patch/ { mode = "none"; in_hunk = 0; next }
     /^\*\*\* End Patch/ { mode = "none"; in_hunk = 0; next }
@@ -2914,6 +2907,14 @@ output_redact_enabled() {
   esac
 }
 
+# One jq tree-walk definition shared by every response rewriter below (it also
+# keeps jq 1.5, which lacks the walk builtin, working). Prepend as
+# `jq -c "$JQ_WALK"'<program>'`.
+JQ_WALK='def walk(f): def w: if type == "object" then map_values(w)
+                    elif type == "array" then map(w)
+                    else . end | f; w;
+'
+
 # Recall booster for the most common leak shape: `KEY=value`, `export KEY=value`
 # or `KEY: value` dumps whose key name looks secret-bearing. gitleaks misses most
 # of these (custom value formats), so emit the VALUE for literal redaction.
@@ -3569,10 +3570,7 @@ redact_tool_response_json() {
   # Redacts string VALUES only; object KEYS are left untouched. Transforming keys
   # could collide two distinct keys onto one placeholder and silently drop an
   # entry; a secret appearing as a JSON key is a documented limitation (README).
-  printf '%s' "$resp" | jq -c --argjson secrets "$secrets" '
-    def walk(f): def w: if type == "object" then map_values(w)
-                        elif type == "array" then map(w)
-                        else . end | f; w;
+  printf '%s' "$resp" | jq -c --argjson secrets "$secrets" "$JQ_WALK"'
     def specs($s):
       $s
       | map(if type == "string"
@@ -3632,10 +3630,7 @@ redact_tool_response_json() {
 # before the ordinary literal detector runs.
 redact_nul_response_json() {
   resp=$1
-  printf '%s' "$resp" | jq -c '
-    def walk(f): def w: if type == "object" then map_values(w)
-                        elif type == "array" then map(w)
-                        else . end | f; w;
+  printf '%s' "$resp" | jq -c "$JQ_WALK"'
     walk(if type == "string" and contains("\u0000")
          then "[REDACTED]" else . end)
   ' 2>/dev/null
@@ -3661,10 +3656,7 @@ large_response_has_secretish_assignment() {
 
 redact_nonempty_response_strings() {
   whole_leaf_response=$1
-  printf '%s' "$whole_leaf_response" | jq -c '
-    def walk(f): def w: if type == "object" then map_values(w)
-                        elif type == "array" then map(w)
-                        else . end | f; w;
+  printf '%s' "$whole_leaf_response" | jq -c "$JQ_WALK"'
     walk(if type == "string" and length > 0
          then "[REDACTED]" else . end)
   ' 2>/dev/null
@@ -3697,7 +3689,7 @@ redact_response_whole_leaf_fail_closed() {
 # nothing on failure (e.g. a jq build without Oniguruma gsub).
 mask_pii_response_json() {
   resp=$1
-  printf '%s' "$resp" | jq -c '
+  printf '%s' "$resp" | jq -c "$JQ_WALK"'
     def mask_pii:
       gsub("[0-9]{4}[ -]?[0-9]{4}[ -]?[0-9]{4}[ -]?[0-9]{4}([ -]?[0-9]{3})?"; "[PII:CREDIT_CARD]")
       | gsub("3[47][0-9]{2}[ -]?[0-9]{6}[ -]?[0-9]{5}"; "[PII:CREDIT_CARD]")
@@ -3707,9 +3699,6 @@ mask_pii_response_json() {
       | gsub("[A-Za-z0-9_%+.-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}"; "[PII:EMAIL]")
       | gsub("01[0-9][ -]?[0-9]{4}[ -]?[0-9]{4}"; "[PII:PHONE]")
       | gsub("(\\+?[0-9][ .-]?)?(\\([0-9]{3}\\)|[0-9]{3})[ .-]?[0-9]{3}[ .-]?[0-9]{4}"; "[PII:PHONE]");
-    def walk(f): def w: if type == "object" then map_values(w)
-                        elif type == "array" then map(w)
-                        else . end | f; w;
     walk(if type == "string" then mask_pii else . end)
   ' 2>/dev/null
 }

--- a/scripts/render-hook-manifests.sh
+++ b/scripts/render-hook-manifests.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env sh
+# Render the canonical plugin hook manifests from ONE command template.
+#
+# plugins/agent-guard/hooks.json (Codex) and plugins/agent-guard/hooks/
+# hooks.json (Claude) embed the same binary-resolver one-liner once per hook
+# event — eight copies that previously had to be edited by hand in lockstep
+# (they differ only in the plugin-root env var, the host tag, and the trailing
+# hook subcommand). This script is the single source of truth: edit TEMPLATE or
+# the per-host tables below, run it, and commit the result.
+#
+#   scripts/render-hook-manifests.sh          # rewrite both manifests
+#   scripts/render-hook-manifests.sh --check  # fail if committed files drift
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd -P)
+PLUGIN_ROOT="$ROOT/plugins/agent-guard"
+
+# @ROOT_VAR@ = plugin-root env var the host exports, @HOST@ = hook-contract
+# host tag, @SUB@ = agent-guard hook subcommand for the event.
+TEMPLATE=$(cat <<'EOF'
+sh -c 'r=${@ROOT_VAR@:-}; b=${r%/*}; s="$b/current/bin/agent-guard"; x=; if [ -n "$r" ]; then x=$(for c in "$b"/*/bin/agent-guard; do [ -x "$c" ] || continue; v=${c%/bin/agent-guard}; printf "%s\\t%s\\n" "${v##*/}" "$c"; done | awk -F "\\t" "\$1 ~ /^[0-9]+\\.[0-9]+\\.[0-9]+$/" | sort -t. -k1,1n -k2,2n -k3,3n | tail -n 1 | cut -f 2-); fi; if [ -x "$x" ]; then v=${x%/bin/agent-guard}; v=${v##*/}; if [ ! -e "$b/current" ] || [ -L "$b/current" ]; then ln -sfn "$v" "$b/current" 2>/dev/null || :; fi; [ -L "$b/current" ] && [ -x "$s" ] && x="$s"; fi; if [ ! -x "$x" ] && [ -x "$r/bin/agent-guard" ]; then x="$r/bin/agent-guard"; fi; if [ ! -x "$x" ]; then mode=${AGENT_GUARD_INFRA_FAILURE_MODE:-open}; case "$mode" in closed) action=blocking ;; *) mode=open; action=continuing ;; esac; d=${AGENT_GUARD_WARNING_DIR:-${TMPDIR:-/tmp}/agent-guard-warnings-${UID:-user}}; p=; while IFS= read -r line || [ -n "$line" ]; do p=$p$line; done; i=${AGENT_GUARD_SESSION_ID:-}; if [ -z "$i" ] && command -v jq >/dev/null 2>&1; then i=$(printf %s "$p" | jq -r ".session_id // empty" 2>/dev/null); fi; if [ -z "$i" ]; then case "$p" in *\"session_id\":\"*) i=${p#*\"session_id\":\"}; i=${i%%\"*}; case "$i" in ""|*[!A-Za-z0-9._:-]*) i= ;; esac ;; esac; fi; if [ -n "$i" ]; then i=$(printf %s "$i" | cksum); else i=ppid-${PPID:-0}; fi; k="$d/manifest-@HOST@-$i-$mode"; warn=1; if mkdir -p "$d" 2>/dev/null; then (umask 077; set -C; : >"$k") 2>/dev/null || warn=0; fi; [ "$warn" -eq 0 ] || echo "agent-guard: @ROOT_VAR@ env not set or no installed binary was found; $action because AGENT_GUARD_INFRA_FAILURE_MODE=$mode" >&2; [ "$mode" = closed ] && exit 2; exit 0; fi; AGENT_GUARD_HOOK_HOST=@HOST@ "$x" @SUB@'
+EOF
+)
+
+render_command() { # $1 = root env var, $2 = host tag, $3 = hook subcommand
+  printf '%s\n' "$TEMPLATE" \
+    | sed -e "s/@ROOT_VAR@/$1/g" -e "s/@HOST@/$2/g" -e "s/@SUB@/$3/g"
+}
+
+render_manifest() { # $1 = root env var, $2 = host tag, $3/$4 = pre/post matcher
+  jq -n \
+    --arg pre_matcher "$3" \
+    --arg post_matcher "$4" \
+    --arg pre "$(render_command "$1" "$2" hook-pre-tool)" \
+    --arg post "$(render_command "$1" "$2" hook-post-tool)" \
+    --arg stop "$(render_command "$1" "$2" hook-stop)" \
+    --arg session "$(render_command "$1" "$2" hook-session-start)" \
+    '{hooks: {
+       PreToolUse: [{matcher: $pre_matcher,
+                     hooks: [{type: "command", command: $pre, timeout: 10}]}],
+       PostToolUse: [{matcher: $post_matcher,
+                      hooks: [{type: "command", command: $post, timeout: 20}]}],
+       Stop: [{matcher: "",
+               hooks: [{type: "command", command: $stop, timeout: 20}]}],
+       SessionStart: [{matcher: "startup|resume|clear|compact",
+                       hooks: [{type: "command", command: $session, timeout: 5}]}]
+     }}'
+}
+
+render_codex() {
+  render_manifest PLUGIN_ROOT codex \
+    'Bash|apply_patch|mcp__.*' \
+    'Bash|apply_patch|mcp__.*'
+}
+
+render_claude() {
+  render_manifest CLAUDE_PLUGIN_ROOT claude \
+    'Write|Edit|MultiEdit|NotebookEdit|Read|NotebookRead|Grep|Glob|Bash|WebFetch|WebSearch|apply_patch|mcp__.*' \
+    'Write|Edit|MultiEdit|NotebookEdit|Bash|apply_patch|Read|NotebookRead|Grep|Glob|WebFetch|WebSearch|mcp__.*'
+}
+
+case "${1:-write}" in
+  write)
+    # Render both manifests fully before replacing either committed file, so a
+    # failing jq/sed cannot leave a truncated or half-updated pair behind.
+    tmp_codex=$(mktemp "$PLUGIN_ROOT/hooks.json.XXXXXX")
+    tmp_claude=$(mktemp "$PLUGIN_ROOT/hooks/hooks.json.XXXXXX")
+    trap 'rm -f "$tmp_codex" "$tmp_claude"' EXIT INT TERM
+    render_codex >"$tmp_codex"
+    render_claude >"$tmp_claude"
+    chmod 644 "$tmp_codex" "$tmp_claude"
+    mv "$tmp_codex" "$PLUGIN_ROOT/hooks.json"
+    mv "$tmp_claude" "$PLUGIN_ROOT/hooks/hooks.json"
+    printf 'rendered %s and %s\n' \
+      "$PLUGIN_ROOT/hooks.json" "$PLUGIN_ROOT/hooks/hooks.json" >&2
+    ;;
+  --check)
+    status=0
+    render_codex | diff -u "$PLUGIN_ROOT/hooks.json" - >&2 || status=1
+    render_claude | diff -u "$PLUGIN_ROOT/hooks/hooks.json" - >&2 || status=1
+    [ "$status" -eq 0 ] || {
+      printf '%s\n' 'hook manifests drifted from the renderer; run scripts/render-hook-manifests.sh' >&2
+      exit 1
+    }
+    ;;
+  *)
+    printf 'usage: %s [--check]\n' "$0" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/render-hook-manifests.sh
+++ b/scripts/render-hook-manifests.sh
@@ -23,18 +23,34 @@ EOF
 )
 
 render_command() { # $1 = root env var, $2 = host tag, $3 = hook subcommand
-  printf '%s\n' "$TEMPLATE" \
-    | sed -e "s/@ROOT_VAR@/$1/g" -e "s/@HOST@/$2/g" -e "s/@SUB@/$3/g"
+  rendered=$(printf '%s\n' "$TEMPLATE" \
+    | sed -e "s/@ROOT_VAR@/$1/g" -e "s/@HOST@/$2/g" -e "s/@SUB@/$3/g") || return 1
+  # A sed that fails to substitute exits 0, so also refuse an empty result or a
+  # leftover placeholder: silently rendering a broken hook command would
+  # disable the protections these manifests install.
+  case "$rendered" in
+    ''|*@ROOT_VAR@*|*@HOST@*|*@SUB@*)
+      printf '%s\n' "render-hook-manifests: bad render for $2 $3" >&2
+      return 1
+      ;;
+  esac
+  printf '%s\n' "$rendered"
 }
 
 render_manifest() { # $1 = root env var, $2 = host tag, $3/$4 = pre/post matcher
+  # Status-checked assignments: a render_command failure inside a jq argument's
+  # command substitution would otherwise be discarded while jq still exits 0.
+  pre=$(render_command "$1" "$2" hook-pre-tool) || return 1
+  post=$(render_command "$1" "$2" hook-post-tool) || return 1
+  stop=$(render_command "$1" "$2" hook-stop) || return 1
+  session=$(render_command "$1" "$2" hook-session-start) || return 1
   jq -n \
     --arg pre_matcher "$3" \
     --arg post_matcher "$4" \
-    --arg pre "$(render_command "$1" "$2" hook-pre-tool)" \
-    --arg post "$(render_command "$1" "$2" hook-post-tool)" \
-    --arg stop "$(render_command "$1" "$2" hook-stop)" \
-    --arg session "$(render_command "$1" "$2" hook-session-start)" \
+    --arg pre "$pre" \
+    --arg post "$post" \
+    --arg stop "$stop" \
+    --arg session "$session" \
     '{hooks: {
        PreToolUse: [{matcher: $pre_matcher,
                      hooks: [{type: "command", command: $pre, timeout: 10}]}],

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -451,9 +451,25 @@ for event in PreToolUse PostToolUse Stop SessionStart; do
   fi
 done
 
+# Both manifests are rendered artifacts: scripts/render-hook-manifests.sh owns
+# the single resolver template and the per-host tables. A hand edit that skips
+# the renderer would reintroduce the copy-drift class the normalization checks
+# above can only partially catch.
+if sh "$ROOT/scripts/render-hook-manifests.sh" --check >/dev/null 2>&1; then
+  ok "hook manifests match scripts/render-hook-manifests.sh output"
+else
+  not_ok "hook manifests match scripts/render-hook-manifests.sh output"
+fi
+
 read_env_payload='{"tool_name":"Read","tool_input":{"file_path":".env"}}'
+# Each invocation that must WARN gets its own TMPDIR: the resolver's warn-once
+# marker would otherwise live in the persistent default
+# /tmp/agent-guard-warnings-$UID, where a marker left by a previous run (or an
+# earlier case in this run, under PID reuse) silently suppresses the warning
+# these greps assert on. TMPDIR (not AGENT_GUARD_WARNING_DIR) keeps the
+# resolver's default warning-dir derivation itself under test.
 printf '%s' "$read_env_payload" \
-  | (cd "$PLUGIN_ROOT" && env -u CLAUDE_PLUGIN_ROOT -u CODEX_PLUGIN_ROOT sh -c "$claude_pre_tool_command") \
+  | (cd "$PLUGIN_ROOT" && TMPDIR="$TESTTMP/rootvar-claude-unset" env -u CLAUDE_PLUGIN_ROOT -u CODEX_PLUGIN_ROOT sh -c "$claude_pre_tool_command") \
   >"$OUT" 2>"$ERR"
 status=$?
 if [ "$status" -eq 0 ]; then
@@ -470,7 +486,7 @@ else
 fi
 
 printf '%s' "$read_env_payload" \
-  | (cd "$PLUGIN_ROOT" && AGENT_GUARD_INFRA_FAILURE_MODE=closed env -u CLAUDE_PLUGIN_ROOT -u CODEX_PLUGIN_ROOT sh -c "$claude_pre_tool_command") \
+  | (cd "$PLUGIN_ROOT" && TMPDIR="$TESTTMP/rootvar-claude-closed" AGENT_GUARD_INFRA_FAILURE_MODE=closed env -u CLAUDE_PLUGIN_ROOT -u CODEX_PLUGIN_ROOT sh -c "$claude_pre_tool_command") \
   >"$OUT" 2>"$ERR"
 status=$?
 if [ "$status" -eq 2 ]; then
@@ -492,7 +508,7 @@ else
 fi
 
 printf '%s' "$read_env_payload" \
-  | (cd "$TMP_ROOT" && CODEX_PLUGIN_ROOT="$PLUGIN_ROOT" sh -c "$claude_pre_tool_command") \
+  | (cd "$TMP_ROOT" && TMPDIR="$TESTTMP/rootvar-claude-codexvar" CODEX_PLUGIN_ROOT="$PLUGIN_ROOT" sh -c "$claude_pre_tool_command") \
   >"$OUT" 2>"$ERR"
 status=$?
 if grep -q 'CLAUDE_PLUGIN_ROOT env not set' "$ERR"; then
@@ -503,7 +519,7 @@ else
 fi
 
 printf '%s' "$read_env_payload" \
-  | (cd "$PLUGIN_ROOT" && env -u PLUGIN_ROOT -u CODEX_PLUGIN_ROOT -u CLAUDE_PLUGIN_ROOT sh -c "$codex_pre_tool_command") \
+  | (cd "$PLUGIN_ROOT" && TMPDIR="$TESTTMP/rootvar-codex-unset" env -u PLUGIN_ROOT -u CODEX_PLUGIN_ROOT -u CLAUDE_PLUGIN_ROOT sh -c "$codex_pre_tool_command") \
   >"$OUT" 2>"$ERR"
 status=$?
 if [ "$status" -eq 0 ]; then
@@ -520,7 +536,7 @@ else
 fi
 
 printf '%s' "$read_env_payload" \
-  | (cd "$PLUGIN_ROOT" && AGENT_GUARD_INFRA_FAILURE_MODE=closed env -u PLUGIN_ROOT -u CODEX_PLUGIN_ROOT -u CLAUDE_PLUGIN_ROOT sh -c "$codex_pre_tool_command") \
+  | (cd "$PLUGIN_ROOT" && TMPDIR="$TESTTMP/rootvar-codex-closed" AGENT_GUARD_INFRA_FAILURE_MODE=closed env -u PLUGIN_ROOT -u CODEX_PLUGIN_ROOT -u CLAUDE_PLUGIN_ROOT sh -c "$codex_pre_tool_command") \
   >"$OUT" 2>"$ERR"
 status=$?
 if [ "$status" -eq 2 ]; then
@@ -542,7 +558,7 @@ else
 fi
 
 printf '%s' "$read_env_payload" \
-  | (cd "$TMP_ROOT" && CODEX_PLUGIN_ROOT="$PLUGIN_ROOT" sh -c "$codex_pre_tool_command") \
+  | (cd "$TMP_ROOT" && TMPDIR="$TESTTMP/rootvar-codex-codexvar" CODEX_PLUGIN_ROOT="$PLUGIN_ROOT" sh -c "$codex_pre_tool_command") \
   >"$OUT" 2>"$ERR"
 status=$?
 if grep -q 'PLUGIN_ROOT env not set' "$ERR"; then
@@ -553,7 +569,7 @@ else
 fi
 
 printf '%s' "$read_env_payload" \
-  | (cd "$TMP_ROOT" && CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" sh -c "$codex_pre_tool_command") \
+  | (cd "$TMP_ROOT" && TMPDIR="$TESTTMP/rootvar-codex-claudevar" CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" sh -c "$codex_pre_tool_command") \
   >"$OUT" 2>"$ERR"
 status=$?
 if grep -q 'PLUGIN_ROOT env not set' "$ERR"; then


### PR DESCRIPTION
## Summary

Whole-repo over-engineering audit (ponytail) applied as a behavior-preserving refactor. No detection rule, block decision, or hook contract changes.

**1. Hook manifests: 8 hand-synced resolver copies → 1 template (`scripts/render-hook-manifests.sh`)**

`plugins/agent-guard/hooks.json` (Codex) and `plugins/agent-guard/hooks/hooks.json` (Claude) embedded the same ~1.9 KB binary-resolver one-liner eight times (4 events × 2 hosts), differing only in the plugin-root env var, the host tag, and the trailing subcommand — kept in sync by hand and policed by normalization tests. The new renderer is the single source of truth:

- renders both manifests **byte-identically** to the previously committed files (verified with `--check` before any regeneration)
- writes atomically (full render to temp files, then `mv`)
- `--check` mode is wired into `tests/run.sh`, so a hand edit that skips the renderer fails the suite

**2. `bin/agent-guard` de-duplication (behavior-identical)**

- one shared jq `walk` definition (`JQ_WALK`) replaces 4 inline copies across the response rewriters
- one shared awk `lockfile_kind` function (`AWK_LOCKFILE_KIND`) replaces 2 copies across the diff extractors
- dropped a gitleaks-config existence check in `check_deps` that `need_gitleaks` already enforces
- simplified the `current`-link version sort (single field; drops the duplicate-field `cut -f 2-` trick)

**3. Test-harness determinism fix**

The missing-binary resolver cases asserted on warn-once output but used the persistent default `/tmp/agent-guard-warnings-$UID`, so markers left by previous runs (under PID reuse) suppressed the asserted warnings — the 3 local baseline failures below. Each case now gets its own `TMPDIR` (not `AGENT_GUARD_WARNING_DIR`, so the default warning-dir derivation itself stays under test).

**4. CI**: shellcheck covers the new renderer script.

## Audit notes (looked at, deliberately not touched)

- The awk lockfile checksum parser, deny-path escape tables, and the printenv GNU/BSD reconstruction are load-bearing security logic pinned by ground-truth tests — left as is.
- The three PII pattern mirrors (awk CLI ×2, jq masker) are cross-language and already documented as an intentional triple.
- `tests/run.sh` (8.1k lines, linear) is the ground-truth suite; restructuring it risks silently weakening coverage.

## Functional verification

- `bash tests/run.sh`: **814 passed / 0 failed** (baseline before this change: 810 passed / 3 failed — the 3 were the pre-existing warn-once flakes fixed here; +1 test is the new renderer drift check)
- `scripts/render-hook-manifests.sh --check`: rendered output byte-identical to both committed manifests; write mode verified idempotent on a copy (no temp leftovers)
- E2E `agent-guard smoke-test` against real gitleaks 8.30.1: all 6 probes green (scan-path allow/block, hook-pre-tool `.env` block, secret-write block, pii-filter, native pre-commit hook block)
- Direct hook probes (mock gitleaks): `DB_PASSWORD=…` masked to `[REDACTED]` via `updatedToolOutput`; clean output passes untouched; PII mask (`AGENT_GUARD_PII_HOOK_MODE=mask`) emits `[PII:EMAIL]`
- Codex adversarial review: no security-behavior regression found; its 3 maintenance findings (atomic renderer writes, TMPDIR-based test isolation, exec bit + shellcheck coverage) are applied in this PR; it independently ran the suite on BSD awk and GNU gawk — 814/814 both
- Codex Cloud inline P2 (swallowed command-substitution failure in the renderer) fixed in 80dbcb5: status-checked assignments + empty/placeholder guard; failing-sed control exits 1 with both manifests untouched

## Not covered

- Ubuntu/GNU CI runners and non-Apple jq builds (Codex flagged UNVERIFIED; CI on this PR will exercise them)
- Live Claude/Codex host hook dispatch (needs the live probe flow in a real session; manifests are byte-identical, so dispatch behavior is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
