### PR TITLE
fix(detection): allow env source modules with an intermediate segment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@
 
 ## Unreleased
 
+- fix(detection): allow env source modules that carry an intermediate segment
+  between the `env`/`envrc` stem and a code extension, so ordinary committed
+  files such as `env.d.ts`, `env.server.ts`, `env.config.ts`, and `env.spec.ts`
+  are readable on both the Read and Bash gates. The final extension must still
+  be code: data/config suffixes (`env.json`, `env.local.json`), extension-less
+  names (`env.d`), the leading-dot runtime form (`.env.d.ts`), deny-listed
+  ancestors, and custom deny policies all stay authoritative.
 - fix(detection): allow explicitly named env templates such as `sample.env`,
   `example.envrc`, `.flaskenv.example`, and `.dev.vars.example`, while blocking
   reverse/runtime forms including `local.env`, `env.local`, `env.preview`, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 
 ## Unreleased
 
+- feat(detection): extend the env template marker vocabulary with `tpl`/`tmpl`
+  and accept `-`/`_` marker separators (`.env-example`, `.env_sample`,
+  `.env.tpl`), matching the naming conventions measured on GitHub. The marker
+  must still be final and the stem must stay an env family; `.env.default(s)`
+  stays blocked because dotenv-defaults loads it at runtime.
 - fix(detection): allow env source modules that carry an intermediate segment
   between the `env`/`envrc` stem and a code extension, so ordinary committed
   files such as `env.d.ts`, `env.server.ts`, `env.config.ts`, and `env.spec.ts`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@
   `.env.tpl`), matching the naming conventions measured on GitHub. The marker
   must still be final and the stem must stay an env family; `.env.default(s)`
   stays blocked because dotenv-defaults loads it at runtime.
-- fix(detection): allow env source modules that carry an intermediate segment
-  between the `env`/`envrc` stem and a code extension, so ordinary committed
-  files such as `env.d.ts`, `env.server.ts`, `env.config.ts`, and `env.spec.ts`
+- fix(detection): allow env source modules that carry exactly one intermediate
+  segment between the `env`/`envrc` stem and a code extension, so ordinary
+  committed files such as `env.d.ts`, `env.server.ts`, `env.config.ts`, and `env.spec.ts`
   are readable on both the Read and Bash gates. The final extension must still
   be code: data/config suffixes (`env.json`, `env.local.json`), extension-less
   names (`env.d`), the leading-dot runtime form (`.env.d.ts`), deny-listed

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -1840,17 +1840,20 @@ candidate_is_allowed() {
 # Keep ordinary source modules such as `config.env.ts` readable without opening
 # data/config suffixes such as `config.env.json`. Require a non-empty prefix for
 # reverse-extension forms so `.env.ts` remains a protected runtime variant.
+#
+# The basename must end in a known code extension; the stem in front of it may
+# carry one intermediate segment (`env.d.ts`, `env.server.ts`, `app.env.spec.ts`)
+# because those are ordinary committed modules. A stem with no code extension
+# (`env.d`, `env.local`, `config.env.json`) is never a source module.
 candidate_is_env_source_module() {
   env_source_base=${1##*/}
   case "$env_source_base" in
-    env.ts|env.tsx|env.js|env.jsx|env.mjs|env.cjs|env.py|env.rb|env.go|env.rs|\
-    env.java|env.kt|env.kts|env.swift|envrc.ts|envrc.tsx|envrc.js|envrc.jsx|\
-    envrc.mjs|envrc.cjs|envrc.py|envrc.rb|envrc.go|envrc.rs|envrc.java|envrc.kt|\
-    envrc.kts|envrc.swift|?*.env.ts|?*.env.tsx|?*.env.js|?*.env.jsx|?*.env.mjs|\
-    ?*.env.cjs|?*.env.py|?*.env.rb|?*.env.go|?*.env.rs|?*.env.java|?*.env.kt|\
-    ?*.env.kts|?*.env.swift|?*.envrc.ts|?*.envrc.tsx|?*.envrc.js|?*.envrc.jsx|\
-    ?*.envrc.mjs|?*.envrc.cjs|?*.envrc.py|?*.envrc.rb|?*.envrc.go|?*.envrc.rs|\
-    ?*.envrc.java|?*.envrc.kt|?*.envrc.kts|?*.envrc.swift) return 0 ;;
+    *.ts|*.tsx|*.js|*.jsx|*.mjs|*.cjs|*.py|*.rb|*.go|*.rs|*.java|*.kt|*.kts|\
+    *.swift) ;;
+    *) return 1 ;;
+  esac
+  case "${env_source_base%.*}" in
+    env|envrc|env.?*|envrc.?*|?*.env|?*.envrc|?*.env.?*|?*.envrc.?*) return 0 ;;
     *) return 1 ;;
   esac
 }

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -1846,9 +1846,12 @@ candidate_is_allowed() {
 # reverse-extension forms so `.env.ts` remains a protected runtime variant.
 #
 # The basename must end in a known code extension; the stem in front of it may
-# carry one intermediate segment (`env.d.ts`, `env.server.ts`, `app.env.spec.ts`)
-# because those are ordinary committed modules. A stem with no code extension
-# (`env.d`, `env.local`, `config.env.json`) is never a source module.
+# carry at most ONE intermediate segment (`env.d.ts`, `env.server.ts`,
+# `app.env.spec.ts`) because those are ordinary committed modules. Enforced by
+# stripping the final dot-free segment from the stem: what remains must itself
+# be a bare env stem, so `env.production.backup.ts` and `app.env.local.copy.js`
+# stay on the deny globs. A stem with no code extension (`env.d`, `env.local`,
+# `config.env.json`) is never a source module.
 candidate_is_env_source_module() {
   env_source_base=${1##*/}
   case "$env_source_base" in
@@ -1856,8 +1859,12 @@ candidate_is_env_source_module() {
     *.swift) ;;
     *) return 1 ;;
   esac
-  case "${env_source_base%.*}" in
-    env|envrc|env.?*|envrc.?*|?*.env|?*.envrc|?*.env.?*|?*.envrc.?*) return 0 ;;
+  env_source_stem=${env_source_base%.*}
+  case "$env_source_stem" in
+    env|envrc|?*.env|?*.envrc) return 0 ;;
+  esac
+  case "${env_source_stem%.*}" in
+    env|envrc|?*.env|?*.envrc) return 0 ;;
     *) return 1 ;;
   esac
 }

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -1801,8 +1801,10 @@ candidate_parent_matches_deny() (
 )
 
 # Classify explicitly named environment placeholder templates. Accepted suffix
-# markers are `.example`, `.sample`, `.template`, and `.dist`; the marker must
-# be final.
+# markers are `example`, `sample`, `template`, `dist`, `tpl`, and `tmpl`,
+# separated by `.`, `-`, or `_` (`.env.example`, `.env-example`, `.env_sample`,
+# `.env.tpl`); the marker must be final. `.env.default(s)` is deliberately not
+# a marker: dotenv-defaults loads it at runtime, so it may hold real values.
 # `example.env`, `sample.env`, and `template.env` (plus their envrc forms) are
 # also accepted because that prefix convention is common and unambiguous.
 #
@@ -1820,10 +1822,12 @@ candidate_is_allowed() {
     example.env|sample.env|template.env|example.envrc|sample.envrc|template.envrc|\
     .example.env|.sample.env|.template.env|.example.envrc|.sample.envrc|.template.envrc)
       ;;
-    *.example) template_stem=${template_base%.example} ;;
-    *.sample) template_stem=${template_base%.sample} ;;
-    *.template) template_stem=${template_base%.template} ;;
-    *.dist) template_stem=${template_base%.dist} ;;
+    *[._-]example) template_stem=${template_base%[._-]example} ;;
+    *[._-]sample) template_stem=${template_base%[._-]sample} ;;
+    *[._-]template) template_stem=${template_base%[._-]template} ;;
+    *[._-]dist) template_stem=${template_base%[._-]dist} ;;
+    *[._-]tpl) template_stem=${template_base%[._-]tpl} ;;
+    *[._-]tmpl) template_stem=${template_base%[._-]tmpl} ;;
     *) return 1 ;;
   esac
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1444,6 +1444,66 @@ expect_json_status 2 "Bash cat .env.example.bak (suffix not final) is blocked" \
   '{"tool_name":"Bash","tool_input":{"command":"cat .env.example.bak"}}' \
   hook-pre-tool
 
+# Marker vocabulary: `tpl`/`tmpl` markers and `-`/`_` separators are template
+# grammar too (`.env-example` ~20k repos, `.env_example` ~12k, `.env.tpl` ~1.3k
+# on GitHub). The marker must still be final and the stem must stay env-family;
+# `.env.default(s)` stays blocked because dotenv-defaults loads it at runtime.
+expect_json_status 0 "Read .env-example (hyphen separator) is allowed" \
+  '{"tool_name":"Read","tool_input":{"file_path":".env-example"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "Read .env_sample (underscore separator) is allowed" \
+  '{"tool_name":"Read","tool_input":{"file_path":".env_sample"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "Read .env.tpl template marker is allowed" \
+  '{"tool_name":"Read","tool_input":{"file_path":".env.tpl"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "Read .env.tmpl template marker is allowed" \
+  '{"tool_name":"Read","tool_input":{"file_path":".env.tmpl"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "Read .envrc-example (hyphen separator) is allowed" \
+  '{"tool_name":"Read","tool_input":{"file_path":".envrc-example"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Read .env-local (separator without template marker) is blocked" \
+  '{"tool_name":"Read","tool_input":{"file_path":".env-local"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Read .env-example.bak (hyphen marker not final) is blocked" \
+  '{"tool_name":"Read","tool_input":{"file_path":".env-example.bak"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Read .env.tpl.bak (tpl marker not final) is blocked" \
+  '{"tool_name":"Read","tool_input":{"file_path":".env.tpl.bak"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Read .env.defaults (runtime-loaded, not a template) is blocked" \
+  '{"tool_name":"Read","tool_input":{"file_path":".env.defaults"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Read .env.default (runtime-loaded, not a template) is blocked" \
+  '{"tool_name":"Read","tool_input":{"file_path":".env.default"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "Bash cat .env-example is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"cat .env-example"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "Bash cat .env.tpl is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"cat .env.tpl"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Bash cat .env-example .env still blocks on the bare .env token" \
+  '{"tool_name":"Bash","tool_input":{"command":"cat .env-example .env"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Bash cat .env.tpl.bak (tpl marker not final) is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"cat .env.tpl.bak"}}' \
+  hook-pre-tool
+
 # Path-prefixed candidates go through basename stripping before the suffix match.
 expect_json_status 0 "Read config/.env.local.example (path-prefixed template) is allowed" \
   '{"tool_name":"Read","tool_input":{"file_path":"config/.env.local.example"}}' \

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1329,6 +1329,50 @@ expect_json_status 2 "Read schema.env.json data file stays blocked" \
   '{"tool_name":"Read","tool_input":{"file_path":"schema.env.json"}}' \
   hook-pre-tool
 
+# A source module may carry one intermediate segment between the env stem and
+# the code extension: `env.d.ts` (Vite/Next), `env.server.ts`, `env.spec.ts`.
+# The final extension must still be code, so data/config suffixes and a bare
+# `env.d` stay blocked, and `.env.d.ts` keeps the protected leading-dot form.
+expect_json_status 0 "Read env.d.ts source module is allowed" \
+  '{"tool_name":"Read","tool_input":{"file_path":"env.d.ts"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "Read env.server.ts source module is allowed" \
+  '{"tool_name":"Read","tool_input":{"file_path":"env.server.ts"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "Read env.spec.ts source module is allowed" \
+  '{"tool_name":"Read","tool_input":{"file_path":"env.spec.ts"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "Read app.env.config.ts source module is allowed" \
+  '{"tool_name":"Read","tool_input":{"file_path":"app.env.config.ts"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "Bash cat env.d.ts source module is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"cat env.d.ts"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Bash cat env.d.ts plus bare .env still blocks" \
+  '{"tool_name":"Bash","tool_input":{"command":"cat env.d.ts .env"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Read env.d without a code extension stays blocked" \
+  '{"tool_name":"Read","tool_input":{"file_path":"env.d"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Read .env.d.ts runtime variant stays blocked" \
+  '{"tool_name":"Read","tool_input":{"file_path":".env.d.ts"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Read env.local.json data file stays blocked" \
+  '{"tool_name":"Read","tool_input":{"file_path":"env.local.json"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Bash cat env.d without a code extension stays blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"cat env.d"}}' \
+  hook-pre-tool
+
 expect_json_status 2 "Bash cat local.env runtime file is blocked" \
   '{"tool_name":"Bash","tool_input":{"command":"cat local.env"}}' \
   hook-pre-tool
@@ -3347,6 +3391,29 @@ if [ "$status" -eq 2 ]; then
   ok "custom directory deny overrides a nested template exception"
 else
   not_ok "custom directory deny overrides a nested template exception (expected 2, got $status)"
+fi
+
+# The same authority holds for the source-module exception: an operator who
+# deny-lists `env.d.ts` keeps it blocked on both hook surfaces.
+CUSTOM_MODULE_DENY="$TMP_ROOT/custom-module-deny.txt"
+printf '%s\n' 'env.d.ts' >"$CUSTOM_MODULE_DENY"
+printf '%s' '{"tool_name":"Read","tool_input":{"file_path":"env.d.ts"}}' \
+  | AGENT_GUARD_DENY_READ_PATHS="$CUSTOM_MODULE_DENY" \
+    "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool >/dev/null 2>&1
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "custom deny-read policy overrides a Read source-module exception"
+else
+  not_ok "custom deny-read policy overrides a Read source-module exception (expected 2, got $status)"
+fi
+printf '%s' '{"tool_name":"Bash","tool_input":{"command":"cat env.d.ts"}}' \
+  | AGENT_GUARD_DENY_READ_PATHS="$CUSTOM_MODULE_DENY" \
+    "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool >/dev/null 2>&1
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "custom deny-read policy overrides a Bash source-module exception"
+else
+  not_ok "custom deny-read policy overrides a Bash source-module exception (expected 2, got $status)"
 fi
 
 # Loop-level fail-closed: a bad-ERE entry placed AFTER a valid one must still

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1357,6 +1357,25 @@ expect_json_status 2 "Bash cat env.d.ts plus bare .env still blocks" \
   '{"tool_name":"Bash","tool_input":{"command":"cat env.d.ts .env"}}' \
   hook-pre-tool
 
+# The intermediate wildcard is limited to exactly one segment: names with two
+# or more dot segments between the env stem and the code extension stay on the
+# deny globs.
+expect_json_status 2 "Read env.production.backup.ts (two segments) stays blocked" \
+  '{"tool_name":"Read","tool_input":{"file_path":"env.production.backup.ts"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Read app.env.local.copy.js (two segments) stays blocked" \
+  '{"tool_name":"Read","tool_input":{"file_path":"app.env.local.copy.js"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Bash cat env.production.backup.ts (two segments) stays blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"cat env.production.backup.ts"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Bash cat app.env.local.copy.js (two segments) stays blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"cat app.env.local.copy.js"}}' \
+  hook-pre-tool
+
 expect_json_status 2 "Read env.d without a code extension stays blocked" \
   '{"tool_name":"Read","tool_input":{"file_path":"env.d"}}' \
   hook-pre-tool


### PR DESCRIPTION
## The false-positive class

`candidate_is_env_source_module()` allows ordinary source modules past the
`env.*` / `*.env.*` deny globs, but it enumerated only two shapes: bare
`env.<ext>` and `?*.env.<ext>`. It had no notion of an intermediate segment, so
these ordinary committed source files — no secrets in any of them — were blocked
on both the Read gate and the Bash command token gate:

| file | why it exists |
| --- | --- |
| `env.d.ts` | generated by Vite / Next in nearly every TypeScript project |
| `env.config.ts` | config module |
| `env.server.ts` | server-only env accessor |
| `env.schema.ts` | schema definition |
| `env.validation.ts` | validation module |
| `env.test.ts`, `env.spec.ts` | test files |

Reproduced on the `origin/main` binary (`e4bfe15`): all seven exit `2` on Read
and on `cat <file>`.

## The fix

`plugins/agent-guard/bin/agent-guard` — `candidate_is_env_source_module()`
classifies by extension first, then checks the stem, which also shortens the
function:

- the basename must end in one of the **same** code extensions the enumeration
  already used (`ts tsx js jsx mjs cjs py rb go rs java kt kts swift`);
- the stem in front of it may carry one intermediate segment, i.e.
  `env.<segment>.<code-ext>` and `?*.env.<segment>.<code-ext>`.

No new abstraction, no config knob, no new extension. Because the allowlist
feeds both surfaces through `candidate_has_default_env_exception()`, the Read
gate and the Bash token gate are fixed by the same change.

## Security boundaries verified as still blocked

Data/config suffixes are never code extensions, and a stem with no code
extension is never a source module. Verified by driving the real hook binary on
**both** gates (Read `file_path` and Bash `cat <name>`), all exit `2`:

```
.env  .envrc  .env.production  .env.local  local.env  env.local
.env.example.bak  config.env.json  env.json  env.yaml  env.yml
env.local.json  .env.d  env.d  .env.d.ts  .aws/credentials
credentials.json  secrets.json  secrets.yaml  id_rsa  app.pem
private.key  .dev.vars  .flaskenv  local.env/sub/sample.env
```

Plus:

- `cat env.d.ts .env` and `cat config.env.ts .envrc` still exit `2` — the
  allowed module is stripped, the bare runtime token still blocks.
- A custom `AGENT_GUARD_DENY_READ_PATHS` listing `env.d.ts` / `env.server.ts`
  keeps them blocked on both gates: operator policy stays authoritative.
- `.env.d.ts` keeps the protected leading-dot runtime form (the non-empty-prefix
  rule for reverse-extension shapes is unchanged).

## Verification

An out-of-tree harness drove the hook binary — never a helper return value —
with a MUST-PASS control set (must block) and a MUST-FAIL control set (clean
files that must be allowed) in every run:

- `origin/main` baseline, identical conditions: **72/88 as expected, 16
  deviations, all of them the false-positive class**. Every security boundary
  already held on main, and the already-passing controls (`env.ts`, `env.mjs`,
  `envrc.ts`, `vite-env.d.ts`, `next-env.d.ts`, `credentials.go`, `secrets.ts`,
  `config.env.ts`) allowed. That validates the harness before the fix.
- this branch: **88/88 as expected, 0 deviations**.

Both control sets behaved as designed on both runs, so the comparison is valid.

## Tests

10 regression cases added to `tests/run.sh` next to the existing
`config.env.ts` block, following the file's `expect_json_status` convention
(allow cases, block cases, and the mixed-token case), plus 2 custom-deny-policy
cases in the custom deny-read block.

`make test`: **845 passed, 0 failed** (exit 0). `make check`: exit 0.

Refs #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Addendum: template marker vocabulary (second commit, `b12a043`)

GitHub code search (`filename:` qualifier) shows the blocked separator forms are an order of magnitude more common than expected:

| name | repos | before | after |
|---|---:|---|---|
| `.env-example` | 20,160 | blocked | allowed |
| `.env_example` | 12,000 | blocked | allowed |
| `.env-sample` | 5,888 | blocked | allowed |
| `.env_sample` | 4,464 | blocked | allowed |
| `.env.tpl` | 1,306 | blocked | allowed |
| `.env.tmpl` | 1,216 | blocked | allowed |

`candidate_is_allowed()` now accepts the marker words `example`/`sample`/`template`/`dist`/`tpl`/`tmpl` separated by `.`, `-`, or `_`. The grammar is otherwise unchanged: the marker must be final and the stem must classify as an env family, so `.env-local`, `.env-example.bak`, `.env.tpl.bak` stay blocked.

Deliberately excluded: `.env.default(s)` (runtime-loaded by dotenv-defaults — 7k repos but fail-closed wins), `.env.skeleton` (26 repos), `.env.stub` (89 repos).

Verified with a 47-assertion harness (must-allow new + old grammar, must-stay-blocked boundaries, Bash token gate incl. `cat .env-example .env` → still blocks) plus 14 new regression tests. `make test`: 859 passed, 0 failed.


---

## Addendum: one-segment limit (third commit, `6eaf0bd`)

Codex review flagged that the `?*` in the new stem patterns consumes dots, so
arbitrarily many intermediate segments qualified: `env.production.backup.ts`,
`app.env.local.copy.js`, and `env.a.b.c.ts` bypassed the deny globs on both
gates (reproduced on `b12a043`, all exit `0`).

`candidate_is_env_source_module()` now strips the final dot-free segment from
the stem and requires the remainder to be a bare env stem (`env`, `envrc`,
`?*.env`, `?*.envrc`), so exactly one intermediate segment qualifies.
Single-segment modules and bare forms are unchanged; `.env.d.ts` stays blocked
because the empty prefix never matches `?*.env`. Deliberate trade: two-segment
names such as `env.server.test.ts` are blocked again — not in the reported
false-positive class, and the exception must not be wider than its contract.

Harness (94 assertions, both gates, must-pass/must-fail controls): `b12a043`
deviates on exactly the six multi-segment cases, `6eaf0bd` on none. 4 new
regression tests. `make test`: 863 passed, 0 failed.
