### PR TITLE
fix(redaction): gate display masking on the value shape

### DIFF
--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -3092,7 +3092,7 @@ secretish_env_values() {
     # Tradeoff: an unquoted credential that itself contains an opener or an
     # embedded quote is no longer masked by this heuristic. gitleaks still
     # covers every format it knows, and the block/detect path is unaffected.
-    function looks_like_reference(value) {
+    function looks_like_reference(value, assignment, leading, v, ch) {
       # An opener or an embedded quote: call, index, expansion or nested string.
       # An opener only counts past the first character, because a call, an index
       # and an expansion always follow the thing they apply to; a token that
@@ -3103,10 +3103,35 @@ secretish_env_values() {
           || index(value, "{") > 1 || index(value, "\"") \
           || index(value, "'\''") || index(value, "`"))
         return 1
-      # Dotted identifier chain (`a.b`, `process.env.API_KEY`, `config.apiKey`).
-      # Every segment must begin like an identifier, which excludes hex, base64,
-      # base64url, `sk_live_...` and dotted version-shaped credential values.
-      return value ~ /^[A-Za-z_$][A-Za-z0-9_$]*(\.[A-Za-z_$][A-Za-z0-9_$]*)+$/
+      # A trailing `:` (a def/lambda suite ending the line) blocked the outer
+      # closer strip, so `DEFAULT_PASSWORD):` still carries its closers here.
+      # Normalize a local copy for classification only; masking, when it does
+      # happen, still replaces the original extent.
+      v = value
+      sub(/:+$/, "", v)
+      while (length(v) > 0) {
+        ch = substr(v, length(v), 1)
+        if (ch != "}" && ch != "]" && ch != ")") break
+        v = substr(v, 1, length(v) - 1)
+      }
+      # Inside an argument or subscript list (`make(api_key=DEFAULT_API_KEY)`,
+      # `def connect(password=None):`) a bare digit-free identifier or
+      # identifier chain is a default or reference, not a literal. A digit
+      # pushes the token back toward masking: real identifiers named as
+      # defaults rarely carry digits, credential fragments usually do.
+      ch = substr(assignment, 1, 1)
+      if ((ch == "(" || ch == "[") && v ~ /^[A-Za-z_$]+(\.[A-Za-z_$]+)*$/)
+        return 1
+      # Dotted identifier chain (`process.env.API_KEY`, `config.apiKey`), and
+      # only in a code-shaped assignment: whitespace on both sides of `=`, a
+      # lowercase head segment (accessor roots are lowercase in the languages
+      # this bug mangled), no digit in any segment, and at least one uppercase
+      # character somewhere in the chain. Anything short of all four masks, so
+      # dot-separated passphrases (`correct.horse.battery.staple`), dotted
+      # env/YAML/INI values (`PASSWORD=a.b.c`, `password: a.b.c`) and dotted
+      # version- or token-shaped values (`v1.0.x`) keep masking.
+      return assignment ~ /[ \t]=$/ && leading != "" && v ~ /[A-Z]/ \
+        && v ~ /^[a-z_$]+(\.[A-Za-z_$]+)+$/
     }
     function emit_value(source, start, assignment, raw, leading, quote, end, \
                         value, token, trailing, ch) {
@@ -3136,7 +3161,7 @@ secretish_env_values() {
           end--
         }
         value = substr(value, 1, end)
-        if (looks_like_reference(value)) return 0
+        if (looks_like_reference(value, assignment, leading)) return 0
         # Eligibility is based on the complete token. For short values, scope
         # replacement to the complete assignment token so an ordinary
         # one-character literal is not replaced throughout the response.

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -3092,6 +3092,28 @@ secretish_env_values() {
     # Tradeoff: an unquoted credential that itself contains an opener or an
     # embedded quote is no longer masked by this heuristic. gitleaks still
     # covers every format it knows, and the block/detect path is unaffected.
+    # Where the uppercase sits separates an accessor from a passphrase that
+    # happens to be dot-separated. An accessor reads a value OUT of lowercase
+    # roots (`process.env`, `config`, `cfg`), so only its LEAF carries case; a
+    # passphrase capitalizes whole words anywhere in the chain. Past two
+    # segments a real chain ends in a constant or property — SCREAMING_SNAKE,
+    # camelCase, or underscore-bearing — never a plain Capitalized word, which
+    # is what separates `my.secret.Phrase` from `process.env.API_KEY`.
+    #
+    # Residual: a two-segment `head.Word` (`my.Secret`) is the same shape as the
+    # Go/C# exported-field access it mimics (`cfg.Token`), so it still reads as
+    # a reference. Narrowing that too would re-break the source code #169 is
+    # about; gitleaks still covers every format it knows either way.
+    function accessor_chain(v, parts, n, i, leaf) {
+      n = split(v, parts, ".")
+      for (i = 1; i < n; i++)
+        if (parts[i] ~ /[A-Z]/) return 0
+      leaf = parts[n]
+      if (n > 2 && leaf !~ /_/ && leaf !~ /^[A-Z$]+$/ \
+          && leaf !~ /^[a-z_$][A-Za-z_$]*[A-Z]/)
+        return 0
+      return 1
+    }
     function looks_like_reference(value, assignment, leading, v, ch) {
       # An opener or an embedded quote: call, index, expansion or nested string.
       # An opener only counts past the first character, because a call, an index
@@ -3129,9 +3151,13 @@ secretish_env_values() {
       # character somewhere in the chain. Anything short of all four masks, so
       # dot-separated passphrases (`correct.horse.battery.staple`), dotted
       # env/YAML/INI values (`PASSWORD=a.b.c`, `password: a.b.c`) and dotted
-      # version- or token-shaped values (`v1.0.x`) keep masking.
-      return assignment ~ /[ \t]=$/ && leading != "" && v ~ /[A-Z]/ \
-        && v ~ /^[a-z_$]+(\.[A-Za-z_$]+)+$/
+      # version- or token-shaped values (`v1.0.x`) keep masking. Those four
+      # still admit a capitalized passphrase (`my.Secret.phrase`), so where the
+      # uppercase SITS has to decide as well; see accessor_chain.
+      if (!(assignment ~ /[ \t]=$/ && leading != "" && v ~ /[A-Z]/ \
+            && v ~ /^[a-z_$]+(\.[A-Za-z_$]+)+$/))
+        return 0
+      return accessor_chain(v)
     }
     function emit_value(source, start, assignment, raw, leading, quote, end, \
                         value, token, trailing, ch) {

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -2984,13 +2984,18 @@ secretish_env_values() {
       # _pat/_pwd keys keep their intended coverage.
       qualifier = "([_-](id|ids|value|val|hash|b64|base64|hex|enc|encrypted|encoded|raw|str|string|pem|cert|json|prod|production|dev|development|staging|stage|test|local|old|new|current|primary|secondary|backup|main|default|[0-9]+))*"
       key = "[a-z0-9_.-]*(" core "|[_-](pat|pwd))" qualifier
-      equals_assignment = "(^|[ \t,{;])[\"'\''`]?" key "[\"'\''`]?[ \t]*="
+      # `(` and `[` open an argument or subscript list, so an assignment can
+      # begin immediately after one (`wrap(secret_key=<secret>)`). The value gate
+      # below stops treating a whole call expression as a single literal, so a
+      # nested assignment has to be reachable on its own to stay masked.
+      equals_assignment = "(^|[ \t,{;([])[\"'\''`]?" key "[\"'\''`]?[ \t]*="
       # A colon is ambiguous in prose. Accept it at the start of a YAML field,
-      # after a JSON/map delimiter, or after plain whitespace (log lines such as
-      # `10:00:00 password: hunter2`); the loop below rejects the whitespace
-      # form only when the preceding token is a known status word, which marks a
-      # prose chain like `error: password: authentication is disabled`.
-      colon_assignment = "(^[ \t]*|[,{][ \t]*|[ \t]+)[\"'\''`]?" key "[\"'\''`]?[ \t]*:"
+      # after a JSON/map/argument delimiter, or after plain whitespace (log lines
+      # such as `10:00:00 password: hunter2`); the loop below rejects the
+      # whitespace form only when the preceding token is a known status word,
+      # which marks a prose chain like `error: password: authentication is
+      # disabled`.
+      colon_assignment = "(^[ \t]*|[,{([][ \t]*|[ \t]+)[\"'\''`]?" key "[\"'\''`]?[ \t]*:"
       # Skipping after ANY colon-terminated token also let real structured log
       # lines through unmasked (`response: api_key: <secret>`), so only these
       # status words justify the skip. Deliberately short: an unlisted label
@@ -3072,6 +3077,37 @@ secretish_env_values() {
       if (record_mode == "framed") emit_framed(value, "S")
       else print "\"" json_escape(value) "\""
     }
+    # A credential-shaped KEY only tells us the assignment is interesting; it
+    # says nothing about whether the right-hand side IS a credential. Source that
+    # merely READS one (`process.env.API_KEY`, `os.environ["DB_PASSWORD"]`,
+    # `config.apiKey`, `${API_KEY:?required}`) is a reference, so masking it
+    # hides nothing and destroys ordinary code. Decide from the token SHAPE, not
+    # from a list of known accessor spellings: an unfamiliar accessor is still
+    # rejected, and an unfamiliar credential format is still masked.
+    #
+    # Only applies to the bare/unquoted branch. A quoted value is already a
+    # literal, and trailing closers are stripped before this test so a value
+    # such as `abc)evil` is still treated as a value.
+    #
+    # Tradeoff: an unquoted credential that itself contains an opener or an
+    # embedded quote is no longer masked by this heuristic. gitleaks still
+    # covers every format it knows, and the block/detect path is unaffected.
+    function looks_like_reference(value) {
+      # An opener or an embedded quote: call, index, expansion or nested string.
+      # An opener only counts past the first character, because a call, an index
+      # and an expansion always follow the thing they apply to; a token that
+      # BEGINS with a bracket (`[REDACTED]]evil`) is not a reference, so it stays
+      # maskable. `$` alone is deliberately allowed so bcrypt-style `$2b$12$...`
+      # values stay masked; `${...}` is caught by the brace.
+      if (index(value, "(") > 1 || index(value, "[") > 1 \
+          || index(value, "{") > 1 || index(value, "\"") \
+          || index(value, "'\''") || index(value, "`"))
+        return 1
+      # Dotted identifier chain (`a.b`, `process.env.API_KEY`, `config.apiKey`).
+      # Every segment must begin like an identifier, which excludes hex, base64,
+      # base64url, `sk_live_...` and dotted version-shaped credential values.
+      return value ~ /^[A-Za-z_$][A-Za-z0-9_$]*(\.[A-Za-z_$][A-Za-z0-9_$]*)+$/
+    }
     function emit_value(source, start, assignment, raw, leading, quote, end, \
                         value, token, trailing, ch) {
       raw = substr(source, start)
@@ -3100,6 +3136,7 @@ secretish_env_values() {
           end--
         }
         value = substr(value, 1, end)
+        if (looks_like_reference(value)) return 0
         # Eligibility is based on the complete token. For short values, scope
         # replacement to the complete assignment token so an ordinary
         # one-character literal is not replaced throughout the response.
@@ -3117,7 +3154,7 @@ secretish_env_values() {
     }
     function scan_line(line, rest, end, low, eq_start, eq_length, \
                        colon_start, colon_length, start, matched_length, \
-                       chose_colon, skip, first) {
+                       chose_colon, skip, first, expansion) {
       rest = line
       if (open_quote != "") {
         end = quoted_end(rest, open_quote)
@@ -3159,6 +3196,18 @@ secretish_env_values() {
           if ((first == " " || first == "\t") &&
               match(substr(low, 1, start - 1), status_label))
             skip = 1
+          # `${NAME:-default}` / `${NAME:?message}` / `${NAME:=x}` / `${NAME:+x}`
+          # is a shell parameter expansion, not an assignment: the operator makes
+          # the trailing text a fallback, never the value of the variable. The
+          # value gate above rejects the whole `${...}` token; without this
+          # the inner `{NAME:` would still read as a JSON/map assignment.
+          # Requiring the operator keeps `${password: value}` masked.
+          else if (first == "{" && substr(rest, start - 1, 1) == "$") {
+            expansion = substr(rest, start + matched_length, 1)
+            if (expansion == "-" || expansion == "=" \
+                || expansion == "?" || expansion == "+")
+              skip = 1
+          }
         }
 
         # Emit exactly the quoted value or the next unquoted token. Continuing

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -6127,7 +6127,11 @@ for display_case in \
   'API_KEY=${API_KEY:-fallback}' \
   'const k = process.env.API_KEY' \
   'token := os.Getenv("GITHUB_TOKEN")' \
-  'if (!process.env.API_KEY) throw new Error("missing")'; do
+  'if (!process.env.API_KEY) throw new Error("missing")' \
+  'make(api_key=DEFAULT_API_KEY)' \
+  'def connect(password=DEFAULT_PASSWORD):' \
+  'def connect(password=None):' \
+  'fn(password=user_password)'; do
   display_input=$(jq -nc --arg stdout "$display_case" \
     '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
   post_tool_out "$display_input"
@@ -6144,14 +6148,26 @@ done
 # hole: a bare literal still masks, a literal nested in an argument or subscript
 # list still masks (it is now reached on its own instead of by swallowing the
 # whole call), `${NAME: value}` without a shell default operator is a map entry
-# and still masks, and a `$`-bearing bcrypt-shaped value still masks.
+# and still masks, and a `$`-bearing bcrypt-shaped value still masks. A dotted
+# value is a reference only in a code-shaped, whitespace-padded `=` assignment
+# whose chain has a lowercase head, no digits, and an uppercase character:
+# dot-separated passphrases, dotted env/YAML/INI values, and version- or
+# token-shaped dotted values all keep masking (review follow-up on #171).
+DOTTED_SECRET=$(printf '%s.%s.%s.%s' correct horse battery staple)
 for display_case in \
   "DATABASE_PASSWORD=$DISPLAY_SECRET" \
   "password = wrap(secret_key=$DISPLAY_SECRET)" \
   "config[api_key=$DISPLAY_SECRET]" \
   "x=\${password: $DISPLAY_SECRET}" \
   "PASSWORD=\$2b\$12\$$DISPLAY_SECRET" \
-  "API_TOKEN=$DISPLAY_SECRET)"; do
+  "API_TOKEN=$DISPLAY_SECRET)" \
+  "PASSWORD=$DOTTED_SECRET" \
+  "password: $DOTTED_SECRET" \
+  "password = $DOTTED_SECRET" \
+  'password = My.Secret.Phrase' \
+  'password: xxx.yyy.zzz' \
+  'api_key=v1.0.secretpart' \
+  'API_KEY=config.apiKey'; do
   display_input=$(jq -nc --arg stdout "$display_case" \
     '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
   post_tool_out "$display_input"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -6110,6 +6110,118 @@ for display_case in \
   fi
 done
 
+# Display redaction must not mangle credential-handling SOURCE CODE. A
+# credential-shaped key on the left says nothing about the right-hand side: a
+# reference (`process.env.API_KEY`, `os.environ["DB_PASSWORD"]`, `config.apiKey`,
+# `${API_KEY:?required}`) is not a credential literal, so it must pass through
+# untouched instead of becoming a sentinel that also swallowed the closing
+# bracket (`[REDACTED]]`, `[REDACTED])`, `[REDACTED]}`). Refs #169.
+for display_case in \
+  'const apiKey = process.env.API_KEY;' \
+  'password = os.environ["DB_PASSWORD"]' \
+  'password = os.environ.get("DB_PASSWORD")' \
+  'export const API_KEY = config.apiKey;' \
+  'secret = ENV.fetch("SESSION_KEY")' \
+  'String token = config.getToken();' \
+  'API_KEY=${API_KEY:?required}' \
+  'API_KEY=${API_KEY:-fallback}' \
+  'const k = process.env.API_KEY' \
+  'token := os.Getenv("GITHUB_TOKEN")' \
+  'if (!process.env.API_KEY) throw new Error("missing")'; do
+  display_input=$(jq -nc --arg stdout "$display_case" \
+    '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
+  post_tool_out "$display_input"
+  post_status=$?
+  if [ "$post_status" -eq 0 ] && [ ! -s "$OUT" ]; then
+    ok "post-tool leaves a credential reference untouched ($display_case)"
+  else
+    not_ok "post-tool leaves a credential reference untouched ($display_case)"
+    sed 's/^/  out: /' "$OUT"
+  fi
+done
+
+# Must-mask controls for the same gate. Narrowing the value side must not open a
+# hole: a bare literal still masks, a literal nested in an argument or subscript
+# list still masks (it is now reached on its own instead of by swallowing the
+# whole call), `${NAME: value}` without a shell default operator is a map entry
+# and still masks, and a `$`-bearing bcrypt-shaped value still masks.
+for display_case in \
+  "DATABASE_PASSWORD=$DISPLAY_SECRET" \
+  "password = wrap(secret_key=$DISPLAY_SECRET)" \
+  "config[api_key=$DISPLAY_SECRET]" \
+  "x=\${password: $DISPLAY_SECRET}" \
+  "PASSWORD=\$2b\$12\$$DISPLAY_SECRET" \
+  "API_TOKEN=$DISPLAY_SECRET)"; do
+  display_input=$(jq -nc --arg stdout "$display_case" \
+    '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
+  post_tool_out "$display_input"
+  post_out=$(cat "$OUT")
+  if printf '%s' "$post_out" | grep -q '\[REDACTED\]' \
+     && ! printf '%s' "$post_out" | grep -Fq "$DISPLAY_SECRET"; then
+    ok "post-tool still masks a credential literal ($display_case)"
+  else
+    not_ok "post-tool still masks a credential literal ($display_case)"
+    printf '%s\n' "$post_out" | sed 's/^/  out: /'
+  fi
+done
+
+# #169: a nested tool response keeps its JSON shape and every non-detected field
+# byte-identical; only the detected leaf changes, and the reference expression
+# sharing that leaf survives.
+nested_input=$(jq -nc --arg secret "$DISPLAY_SECRET" \
+  '{tool_name:"mcp__fixture__tool",tool_input:{query:"x"},
+    tool_response:{content:[{type:"text",
+      text:("const apiKey = process.env.API_KEY;\ndb_password=" + $secret)}],
+      isError:false,
+      meta:{requestId:"req-1",durationMs:12,tags:["a","b"]}}}')
+post_tool_out "$nested_input"
+post_out=$(cat "$OUT")
+nested_expected=$(printf 'const apiKey = process.env.API_KEY;\ndb_password=[%s]' 'REDACTED')
+if printf '%s' "$post_out" | jq -e --arg expected "$nested_expected" \
+     '.hookSpecificOutput.updatedToolOutput
+      == {content:[{type:"text",text:$expected}],
+          isError:false,
+          meta:{requestId:"req-1",durationMs:12,tags:["a","b"]}}' >/dev/null 2>&1; then
+  ok "post-tool preserves nested response shape and masks only the detected leaf"
+else
+  not_ok "post-tool preserves nested response shape and masks only the detected leaf"
+  printf '%s\n' "$post_out" | sed 's/^/  out: /'
+fi
+
+# The same boundary on the Codex contract: a reference expression produces no
+# block at all, a nested literal produces a block whose additionalContext is
+# sanitized.
+codex_ref_input=$(jq -nc \
+  --arg stdout 'password = os.environ["DB_PASSWORD"]' \
+  '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
+printf '%s' "$codex_ref_input" \
+  | (cd "$TMP_ROOT" && AGENT_GUARD_HOOK_HOST=codex "$PLUGIN_ROOT/bin/agent-guard" hook-post-tool) \
+    >"$OUT" 2>"$ERR"
+codex_ref_status=$?
+if [ "$codex_ref_status" -eq 0 ] && [ ! -s "$OUT" ]; then
+  ok "Codex post-tool leaves a credential reference untouched"
+else
+  not_ok "Codex post-tool leaves a credential reference untouched (status $codex_ref_status)"
+  sed 's/^/  out: /' "$OUT"
+fi
+
+codex_nested_input=$(jq -nc --arg secret "$DISPLAY_SECRET" \
+  '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:("password = wrap(secret_key=" + $secret + ")"),stderr:"",interrupted:false,isImage:false}}')
+printf '%s' "$codex_nested_input" \
+  | (cd "$TMP_ROOT" && AGENT_GUARD_HOOK_HOST=codex "$PLUGIN_ROOT/bin/agent-guard" hook-post-tool) \
+    >"$OUT" 2>"$ERR"
+codex_nested_status=$?
+codex_nested_out=$(cat "$OUT")
+if [ "$codex_nested_status" -eq 0 ] \
+   && printf '%s' "$codex_nested_out" \
+     | jq -e '.decision == "block" and (.hookSpecificOutput.additionalContext | contains("[REDACTED]"))' >/dev/null 2>&1 \
+   && ! printf '%s' "$codex_nested_out" | grep -Fq "$DISPLAY_SECRET"; then
+  ok "Codex post-tool still masks a literal nested in an argument list"
+else
+  not_ok "Codex post-tool still masks a literal nested in an argument list (status $codex_nested_status)"
+  printf '%s\n' "$codex_nested_out" | sed 's/^/  out: /'
+fi
+
 # The comma branch keeps winning the leftmost match, so a status-prefixed log
 # line with a real comma-delimited assignment still masks.
 COMMA_SECRET=$(printf '%s%s' 'hunter2-' 'comma-value')

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -6131,7 +6131,10 @@ for display_case in \
   'make(api_key=DEFAULT_API_KEY)' \
   'def connect(password=DEFAULT_PASSWORD):' \
   'def connect(password=None):' \
-  'fn(password=user_password)'; do
+  'fn(password=user_password)' \
+  'password = cfg.Token' \
+  'password = settings.API_KEY' \
+  'password = app.config.apiKey'; do
   display_input=$(jq -nc --arg stdout "$display_case" \
     '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
   post_tool_out "$display_input"
@@ -6153,6 +6156,13 @@ done
 # whose chain has a lowercase head, no digits, and an uppercase character:
 # dot-separated passphrases, dotted env/YAML/INI values, and version- or
 # token-shaped dotted values all keep masking (review follow-up on #171).
+# Those four conditions still admitted a CAPITALIZED passphrase, so where the
+# uppercase sits decides as well: every non-leaf segment must be lowercase, and
+# past two segments the leaf must be SCREAMING_SNAKE, camelCase, or
+# underscore-bearing rather than a plain Capitalized word. `cfg.Token` (the
+# Go/C# exported-field access) stays a reference while `my.Secret.phrase` and
+# `my.secret.Phrase` mask again. A two-segment `head.Word` stays a documented
+# residual: it is the same shape as the field access it mimics.
 DOTTED_SECRET=$(printf '%s.%s.%s.%s' correct horse battery staple)
 for display_case in \
   "DATABASE_PASSWORD=$DISPLAY_SECRET" \
@@ -6167,7 +6177,12 @@ for display_case in \
   'password = My.Secret.Phrase' \
   'password: xxx.yyy.zzz' \
   'api_key=v1.0.secretpart' \
-  'API_KEY=config.apiKey'; do
+  'API_KEY=config.apiKey' \
+  'password = my.Secret.phrase' \
+  'password = correct.Horse.battery' \
+  'password = my.secret.Phrase' \
+  'password = correct.horse.Battery' \
+  'token = my.Secret.value.phrase'; do
   display_input=$(jq -nc --arg stdout "$display_case" \
     '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
   post_tool_out "$display_input"


### PR DESCRIPTION
## Summary

PostToolUse display redaction masked the right-hand side of an assignment
whenever the left-hand side looked credential-bearing, without ever checking
whether the right-hand side was a credential literal or merely a code
expression. Credential-handling source code was mangled before the model saw
it. This also supplies the reproduction that #169 was blocked on.

Reproduced on `origin/main` (e4bfe15), both host contracts, via `hook-post-tool`:

```
IN : const apiKey = process.env.API_KEY;       OUT: const apiKey = [REDACTED];
IN : password = os.environ["DB_PASSWORD"]      OUT: password = [REDACTED]]
IN : password = os.environ.get("DB_PASSWORD")  OUT: password = [REDACTED])
IN : export const API_KEY = config.apiKey;     OUT: export const API_KEY = [REDACTED];
IN : API_KEY=${API_KEY:?required}              OUT: API_KEY=[REDACTED]}
IN : String token = config.getToken();         OUT: String token = [REDACTED]);
```

## The two defects

1. **Over-masking.** An env-var reference, a property access or a shell
   parameter expansion is not a secret value, yet it was replaced. The model
   loses which variable the code reads, which breaks ordinary code reading.
2. **Wrong match extent.** The closing bracket leaks outside the sentinel
   (`]]`, `)`, `}`, and `);` for a method call). The computed match extent does
   not line up with the token boundary.

## Root cause — one assumption, two symptoms

Both come from a single assumption in `emit_value()`'s unquoted branch
(`plugins/agent-guard/bin/agent-guard`): *the bare token following a
credential-shaped key IS the credential*. Nothing downstream re-tests it.

The trailing-closer strip immediately above normalizes `{"password":abc}` to
`abc` — correct only when those closers belong to an **enclosing** container.
For an expression (`os.environ["DB_PASSWORD"]`, `config.getToken()`) the
closers are part of the token itself, so stripping them lands the extent one
character short and the closer leaks outside `[REDACTED]`. Symptom 2 is
symptom 1 seen through the extent calculation, not an independent bug.

Worth recording, because it looks like an asymmetry and is not: `const apiKey
= ...;` masks while `const k = ...` does not, and the semicolon has nothing to
do with it. The gate keys purely on the **key name** — `apiKey` matches the
credential-term regex, `k` does not. `token := os.Getenv(...)` escapes for a
different reason: the colon match makes the value token `=`, which is below
the 4-character eligibility floor.

## The fix

`looks_like_reference()`, applied in the one shared function every caller
routes through (`secretish_env_values()`, used by the PostToolUse detector,
the `printenv` reconstruction and both probe paths). A bare value is a
reference, not a literal, when it

- carries an opener (`(`, `[`, `{`) **past its first character** — a call, an
  index and an expansion always follow the thing they apply to, so a token
  that *begins* with a bracket (`[REDACTED]]evil`) is still maskable; or
- contains an embedded quote (`"`, `'`, backtick); or
- is a dotted identifier chain (`process.env.API_KEY`, `config.apiKey`) where
  every segment starts like an identifier — which excludes hex, base64,
  base64url, `sk_live_…` and dotted version-shaped credential values.

The decision is made from the **shape of the value**, never from a list of
known accessor spellings, per the #156 framing of the value-side gate. An
unfamiliar accessor is still rejected; an unfamiliar credential format is
still masked. A bare `$` is deliberately *not* an opener, so bcrypt-shaped
`$2b$12$…` values keep masking.

Two consequences of that gate needed handling in the same change:

- `${NAME:-x}` / `${NAME:?x}` / `${NAME:=x}` / `${NAME:+x}` — the value gate
  rejects the whole `${…}` token, but the inner `{NAME:` would still read as a
  JSON/map assignment and mask the fallback text. Skipped at scan level, and
  only when a real expansion operator follows the colon, so `${password: value}`
  still masks.
- A call expression is no longer swallowed whole, so a credential assignment
  nested directly after `(` or `[` has to be reachable on its own. Both
  delimiter classes now accept those two openers. This strictly increases what
  is masked.

Quoted values, the block/detect path, gitleaks, JWT and Bearer detection are
all untouched.

## Verified matrix

Every assertion below is on the **actual rewritten text**, grepped for the
token — never on a helper's return value — and every case was run against the
`origin/main` binary first under identical conditions. Both host contracts
(Claude `updatedToolOutput`, Codex `decision: block` + `additionalContext`)
were checked for every row. Secrets are generated at runtime; nothing
credential-shaped is committed.

**Must still mask** — asserted on the rewritten text of this branch, with the
`origin/main` binary compared first on every row:

| case | result |
| --- | --- |
| `API_KEY=<runtime high-entropy token>` | masked |
| `password: hunter2-long-value` | masked |
| `DATABASE_PASSWORD=<runtime token>` | masked |
| `response: password: hunter2-long-value` (#153) | masked |
| `fatal: api_key: <gitleaks-detectable token>` | masked |
| `{"password":hunter2-long-value}` | masked |
| `API_TOKEN=<secret>)` — closer preserved outside the sentinel | masked |
| `PASSWORD=<secret>)evil` | masked |
| `password = "<secret>"` (quoted branch) | masked |
| `PASSWORD=$2b$12$<token>` | masked |
| `x=${password: <secret>}` (map entry, not an expansion) | masked |
| `PASSWORD=[REDACTED]]evil-suffix` | masked |
| `password = wrap(secret_key=<secret>)` | masked |
| `config[api_key=<secret>]` | masked |

**Must not mask:**

| case | main | this PR |
| --- | --- | --- |
| `error: password: authentication is disabled` (#145/#153) | untouched | untouched |
| `const apiKey = process.env.API_KEY;` | `[REDACTED];` | untouched |
| `password = os.environ["DB_PASSWORD"]` | `[REDACTED]]` | untouched |
| `password = os.environ.get("DB_PASSWORD")` | `[REDACTED])` | untouched |
| `export const API_KEY = config.apiKey;` | `[REDACTED];` | untouched |
| `secret = ENV.fetch("SESSION_KEY")` | `[REDACTED])` | untouched |
| `String token = config.getToken();` | `[REDACTED]);` | untouched |
| `API_KEY=${API_KEY:?required}` | `[REDACTED]}` | untouched |
| `API_KEY=${API_KEY:-fallback}` | `[REDACTED]}` | untouched |
| `const k = process.env.API_KEY` | untouched | untouched |
| `token := os.Getenv("GITHUB_TOKEN")` | untouched | untouched |
| `if (!process.env.API_KEY) throw new Error("missing")` | untouched | untouched |

**Shape preservation (#169).** A nested MCP-shaped response
(`content[]` + `isError` + `meta{requestId, durationMs, tags[]}`) is asserted
equal to the expected object as a whole: only the detected leaf changes, the
reference expression sharing that leaf survives, and every non-detected field
and the JSON structure come through byte-identical.

Controls: each verification run carried a must-pass control (high-entropy
`API_KEY=…`, masked) and a must-fail control (clean prose, untouched). Both
behaved on every run.

## Tests

`tests/run.sh` gains 20 assertions next to the existing display-redaction
block: the reference set above, the must-mask counterparts including the
nested and `${NAME: value}` shapes, the nested-response shape check, and the
Codex-contract pair. Against the `origin/main` binary 11 of them fail; with
this change the suite is green.

```
make test  ->  passed: 853  failed: 0
```

## Known ceiling

An **unquoted** credential that itself contains an opener past its first
character or an embedded quote is no longer masked by this heuristic — the
same shape that makes an expression recognizable. gitleaks still covers every
format it knows, quoted values are unaffected, and the block/detect path does
not use this gate. Any shape-based value gate has this property; the
alternative (a spelling allowlist such as `process.env` / `os.environ`) is a
bypass surface and was deliberately not taken.

Refs #169

## Review follow-up (f6b3635)

Both Codex findings were confirmed empirically and fixed:

- **P1 (leak regression):** the dotted-chain rule accepted any identifier-segment
  chain, so dotted word-shaped credentials (`correct.horse.battery.staple`,
  `xxx.yyy.zzz`) classified as references and were displayed unmasked. A chain
  is now a reference only in a code-shaped assignment: whitespace on both sides
  of `=`, a lowercase head segment, no digit in any segment, and at least one
  uppercase character. Dot-separated passphrases, dotted env/YAML/INI values
  (`API_KEY=config.apiKey` included), and version/token-shaped dotted values all
  mask again; `const apiKey = process.env.API_KEY;` still passes through.
- **P2 (new over-mask):** nested assignments with identifier values
  (`make(api_key=DEFAULT_API_KEY)`, `def connect(password=None):`) were newly
  reachable and over-masked, with the def losing its trailing colon. Inside an
  argument/subscript list a bare digit-free identifier or identifier chain now
  classifies as a default/reference; the classifier locally normalizes a
  trailing `:` plus closers.

Ten regression tests cover both families; all ten fail on the previous head
(`7239408`) and the suite is green on the new one (`make test`: 864/0 locally,
both CI runners green with the new assertions confirmed executed in the logs).
