### PR TITLE
feat(detection): block package-manager credential leak vectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,17 @@
   print-refresh-token` joins the existing gcloud token alternation. The
   command patterns are hardened against realistic variants an agent may emit:
   tool aliases (`bundler`, `npm c`/`npm get`), version-suffixed binaries
-  (`pip3.12`), scope/global flags before the subcommand, non-listed git
-  credential helpers, and `$(...)` subshell prefixes; the `mvn` and `composer`
-  patterns are anchored so prose/filenames and value tokens like
-  `repositories.bearer` do not over-block.
+  (`pip3.12`), leading global options between a binary and its subcommand
+  (`npm --location=user config get`, `bundle config --parseable`,
+  `security -q`, `gcloud --quiet`), wrapper/PHAR invocation forms (`./mvnw`,
+  `php composer.phar`), the direct `git-credential-<helper> get` executable,
+  `pip config debug`, and `$(...)` subshell prefixes; pnpm `config list`
+  (which, unlike npm, does not mask) is blocked, and coverage extends to
+  pnpm/bun. The `mvn` and `composer` patterns are anchored so prose/filenames,
+  value tokens like `repositories.bearer`, and the `showPasswords=false` safe
+  default do not over-block. Adds deny-read for Bun's `.bunfig.toml`; uv and
+  pnpm need no new path (env/.netrc and `.npmrc` respectively already cover
+  them).
 - fix(detection): allow explicitly named env templates such as `sample.env`,
   `example.envrc`, `.flaskenv.example`, and `.dev.vars.example`, while blocking
   reverse/runtime forms including `local.env`, `env.local`, `env.preview`, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,10 @@
   tool aliases (`bundler`, `npm c`/`npm get`), version-suffixed binaries
   (`pip3.12`), leading global options between a binary and its subcommand
   (`npm --location=user config get`, `bundle config --parseable`,
-  `security -q`, `gcloud --quiet`), wrapper/PHAR invocation forms (`./mvnw`,
+  `bundle --verbose config`, `security -q`, `gcloud --quiet`), Composer's
+  documented `global <command>` wrapper, which runs the same config read
+  against COMPOSER_HOME where the stored OAuth token lives
+  (`composer global config`), wrapper/PHAR invocation forms (`./mvnw`,
   `php composer.phar`), the direct `git-credential-<helper> get` executable,
   `pip config debug`, and `$(...)` subshell prefixes; pnpm `config list`
   (which, unlike npm, does not mask) is blocked, and coverage extends to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@
 
 ## Unreleased
 
+- feat(detection): block package-manager credential leak vectors. Deny-read now
+  covers Bundler (`.bundle/config`), RubyGems (`.gem/credentials` and the XDG
+  `gem/credentials` location), Cargo (`.cargo/credentials*`), Composer home
+  `auth.json`, Maven `.m2/settings.xml`, Gradle `.gradle/gradle.properties`,
+  `pip.conf`, Poetry `pypoetry/auth.toml`, and Terraform CLI credentials
+  (`.terraformrc`/`terraform.rc`). Deny-bash now blocks credential dump
+  commands that print stored auth with no path or token in the command text:
+  `bundle config` reads (bare/`list`/`get`/legacy dotted-key read; `set` stays
+  allowed and is gitleaks-scanned), `npm config get` of protected keys,
+  `yarn config get` of npmAuthToken/npmAuthIdent (and the registry/scope maps
+  that nest them), `git credential fill`/any-helper `get`, `pip config
+  list|get`, `composer config` on credential keys or `--list`,
+  `mvn help:effective-settings -DshowPasswords`, and
+  `security find-(generic|internet)-password`; `gcloud auth
+  print-refresh-token` joins the existing gcloud token alternation. The
+  command patterns are hardened against realistic variants an agent may emit:
+  tool aliases (`bundler`, `npm c`/`npm get`), version-suffixed binaries
+  (`pip3.12`), scope/global flags before the subcommand, non-listed git
+  credential helpers, and `$(...)` subshell prefixes; the `mvn` and `composer`
+  patterns are anchored so prose/filenames and value tokens like
+  `repositories.bearer` do not over-block.
 - fix(detection): allow explicitly named env templates such as `sample.env`,
   `example.envrc`, `.flaskenv.example`, and `.dev.vars.example`, while blocking
   reverse/runtime forms including `local.env`, `env.local`, `env.preview`, and

--- a/plugins/agent-guard/config/deny-bash-patterns.txt
+++ b/plugins/agent-guard/config/deny-bash-patterns.txt
@@ -58,7 +58,9 @@ gh[[:space:]]+auth[[:space:]]+token
 # `config <host.key>` (a dotted key with no following value; `--parseable`
 # exposes it). Covers the `bundler` alias, a leading `$(`/backtick subshell,
 # and a trailing fd redirect (`bundle config 2>&1`). `config set` stays allowed.
-(^|[^[:alnum:]_.-])bundler?[[:space:]]+config([[:space:]]+-[^[:space:]]+)*([[:space:]]+(list|get)([^[:alnum:]_-]|$)|[[:space:]]+[^-[:space:]][^[:space:]]*\.[^[:space:]]*[[:space:]]*($|[<>|;&])|[[:space:]]*($|[<>|;&]|[0-9]))
+# Options are accepted on BOTH sides of the subcommand: `bundle --verbose
+# config --parseable` reads the same store as the bare form.
+(^|[^[:alnum:]_.-])bundler?([[:space:]]+-[^[:space:]]+)*[[:space:]]+config([[:space:]]+-[^[:space:]]+)*([[:space:]]+(list|get)([^[:alnum:]_-]|$)|[[:space:]]+[^-[:space:]][^[:space:]]*\.[^[:space:]]*[[:space:]]*($|[<>|;&])|[[:space:]]*($|[<>|;&]|[0-9]))
 # `npm config get` (also the `c` and bare `get` aliases) prints protected
 # values raw; `config list` redacts them and stays allowed. A protected key
 # placed anywhere in the args is matched (npm accepts multiple keys).
@@ -87,7 +89,11 @@ yarn([[:space:]]+-[^[:space:]]+)*[[:space:]]+config[[:space:]]+get[[:space:]]+[^
 # so a value like `repositories.bearer` does not over-block), and the full
 # `--list` dump. Covers the `composer.phar` invocation form. Blocking the set
 # form too: http-basic passwords have no prefix gitleaks could anchor on.
-(^|[^[:alnum:]_-])composer(\.phar)?[[:space:]]+config[[:space:]]+((-[[:alnum:]-]+[[:space:]]+)*(github-oauth|gitlab-token|gitlab-oauth|http-basic|bearer)([[:space:].]|$)|.*(-l|--list)([[:space:]]|$))
+# The `global` wrapper documented as `global <command> [...]` runs the same
+# command against COMPOSER_HOME — where the stored OAuth token actually lives —
+# so it is accepted here alongside leading global options; a wrapper run
+# without a `config` subcommand (`composer global require x`) still passes.
+(^|[^[:alnum:]_-])composer(\.phar)?([[:space:]]+(-[^[:space:]]+|global))*[[:space:]]+config[[:space:]]+((-[[:alnum:]-]+[[:space:]]+)*(github-oauth|gitlab-token|gitlab-oauth|http-basic|bearer)([[:space:].]|$)|.*(-l|--list)([[:space:]]|$))
 # mvn help:effective-settings masks passwords unless showPasswords is enabled
 # (either flag order); `showPasswords=false` is the safe default and stays
 # allowed. Covers the `./mvnw` wrapper; anchored so prose/filenames don't match.

--- a/plugins/agent-guard/config/deny-bash-patterns.txt
+++ b/plugins/agent-guard/config/deny-bash-patterns.txt
@@ -18,7 +18,7 @@
 # shell variable ($$, $BASHPID) the deny-read glob cannot match, so accept any
 # non-space, non-slash segment here.
 /proc/[^[:space:]/]+/environ
-security[[:space:]]+find-generic-password
+security[[:space:]]+find-(generic|internet)-password
 op[[:space:]]+read
 op[[:space:]]+item[[:space:]]+get
 vault[[:space:]]+kv[[:space:]]+get
@@ -27,7 +27,7 @@ aws[[:space:]]+secretsmanager[[:space:]]+get-secret-value
 aws[[:space:]]+ssm[[:space:]]+get-parameter
 aws[[:space:]]+configure[[:space:]]+export-credentials
 gcloud[[:space:]]+secrets[[:space:]]+versions[[:space:]]+access
-gcloud[[:space:]]+auth[[:space:]]+print-(access|identity)-token
+gcloud[[:space:]]+auth[[:space:]]+print-(access|identity|refresh)-token
 az[[:space:]]+account[[:space:]]+get-access-token
 (^|[[:space:];|&])doppler[[:space:]]+(secrets|run)
 # Reading secret material out of kubectl requires a structured output flag;
@@ -43,3 +43,39 @@ kubectl[[:space:]].*get.*[[:space:]]secrets?(/[^[:space:]]+)?[[:space:]].*(-o|--
 kubectl[[:space:]].*get.*(-o|--output)[[:space:]=]*(yaml|json|jsonpath|go-template).*[[:space:]]secrets?(/[^[:space:]]+)?([[:space:]]|$)
 (curl|wget).*(TOKEN|SECRET|PASSWORD|API[_-]?KEY|ACCESS[_-]?KEY)
 gh[[:space:]]+auth[[:space:]]+token
+# Package-manager credential dumps: these print stored auth values with no
+# path or token in the command text, so neither the deny-read scan nor the
+# command gitleaks scan can see them. Write forms (`set`/`unset`, and the
+# legacy `config <host> <value>` set) stay allowed because the secret then
+# appears in the command text and is gitleaks-scanned there. Residual, shared
+# with every entry in this file: obfuscation via `sh -c`, escaped command
+# names, or splitting a command across shell variables is out of scope for a
+# line-oriented regex guard.
+# Bundler reads: bare `config`, `list`, `get`, and the legacy single-key read
+# `config <host.key>` (a dotted key with no following value). Covers the
+# `bundler` alias, a leading `$(`/backtick subshell, and a trailing fd
+# redirect (`bundle config 2>&1`). `config set <host> <value>` stays allowed.
+(^|[^[:alnum:]_.-])bundler?[[:space:]]+config([[:space:]]+(list|get)([^[:alnum:]_-]|$)|[[:space:]]+[^[:space:]]*\.[^[:space:]]*[[:space:]]*($|[<>|;&])|[[:space:]]*($|[<>|;&]|[0-9]))
+# `npm config get` (also the `c` and bare `get` aliases) prints protected
+# values raw; `config list` redacts them and stays allowed. A protected key
+# placed anywhere in the args is matched (npm accepts multiple keys).
+npm[[:space:]]+(config[[:space:]]+get|c[[:space:]]+get|get)[[:space:]].*(_auth|[Aa]uthToken|_password)
+# `yarn config get` of an auth key, or of the registry/scope maps that nest
+# npmAuthToken/npmAuthIdent values.
+yarn[[:space:]]+config[[:space:]]+get[[:space:]]+[^[:space:]]*([Aa]uth(Token|Ident)|npmRegistries|npmScopes)
+# git credential fill / any helper's `get` print password= plaintext; global
+# `-c`/`-C`/`--flag` options before the subcommand are tolerated, and the
+# helper name is matched generically (osxkeychain, libsecret, manager, ...).
+(^|[^[:alnum:]_-])git([[:space:]]+-[^[:space:]]+([[:space:]]+[^-][^[:space:]]*)?)*[[:space:]]+credential(-[[:alnum:]_-]+)?[[:space:]]+(fill|get)
+# pip config reads print index-urls verbatim, including embedded credentials;
+# version-suffixed binaries (`pip3.12`) and scope flags before the subcommand
+# (`pip config --user list`) are covered. `python -m pip config` matches too.
+(^|[^[:alnum:]_-])pip[0-9.]*[[:space:]]+config[[:space:]]+([^[:space:]]+[[:space:]]+)*(list|get)
+# composer config reads/sets of credential keys (anchored to the key argument
+# so a value like `repositories.bearer` does not over-block), and the full
+# `--list` dump. Blocking the set form too: http-basic passwords have no
+# prefix gitleaks could anchor on.
+composer[[:space:]]+config[[:space:]]+((-[[:alnum:]-]+[[:space:]]+)*(github-oauth|gitlab-token|gitlab-oauth|http-basic|bearer)([[:space:].]|$)|.*(-l|--list)([[:space:]]|$))
+# mvn help:effective-settings masks passwords unless showPasswords is set
+# (either flag order); anchored to `mvn` so prose/filenames don't over-block.
+mvn[[:space:]].*(effective-settings.*showPasswords|showPasswords.*effective-settings)

--- a/plugins/agent-guard/config/deny-bash-patterns.txt
+++ b/plugins/agent-guard/config/deny-bash-patterns.txt
@@ -18,7 +18,7 @@
 # shell variable ($$, $BASHPID) the deny-read glob cannot match, so accept any
 # non-space, non-slash segment here.
 /proc/[^[:space:]/]+/environ
-security[[:space:]]+find-(generic|internet)-password
+security([[:space:]]+-[^[:space:]]+)*[[:space:]]+find-(generic|internet)-password
 op[[:space:]]+read
 op[[:space:]]+item[[:space:]]+get
 vault[[:space:]]+kv[[:space:]]+get
@@ -27,7 +27,7 @@ aws[[:space:]]+secretsmanager[[:space:]]+get-secret-value
 aws[[:space:]]+ssm[[:space:]]+get-parameter
 aws[[:space:]]+configure[[:space:]]+export-credentials
 gcloud[[:space:]]+secrets[[:space:]]+versions[[:space:]]+access
-gcloud[[:space:]]+auth[[:space:]]+print-(access|identity|refresh)-token
+gcloud([[:space:]]+-[^[:space:]]+)*[[:space:]]+auth[[:space:]]+print-(access|identity|refresh)-token
 az[[:space:]]+account[[:space:]]+get-access-token
 (^|[[:space:];|&])doppler[[:space:]]+(secrets|run)
 # Reading secret material out of kubectl requires a structured output flag;
@@ -51,31 +51,44 @@ gh[[:space:]]+auth[[:space:]]+token
 # with every entry in this file: obfuscation via `sh -c`, escaped command
 # names, or splitting a command across shell variables is out of scope for a
 # line-oriented regex guard.
+# Every pattern below tolerates a run of leading global options (`-x`/`--flag`)
+# between the binary and its subcommand, since agents routinely emit them
+# (`npm --location=user config get`, `bundle config --parseable`).
 # Bundler reads: bare `config`, `list`, `get`, and the legacy single-key read
-# `config <host.key>` (a dotted key with no following value). Covers the
-# `bundler` alias, a leading `$(`/backtick subshell, and a trailing fd
-# redirect (`bundle config 2>&1`). `config set <host> <value>` stays allowed.
-(^|[^[:alnum:]_.-])bundler?[[:space:]]+config([[:space:]]+(list|get)([^[:alnum:]_-]|$)|[[:space:]]+[^[:space:]]*\.[^[:space:]]*[[:space:]]*($|[<>|;&])|[[:space:]]*($|[<>|;&]|[0-9]))
+# `config <host.key>` (a dotted key with no following value; `--parseable`
+# exposes it). Covers the `bundler` alias, a leading `$(`/backtick subshell,
+# and a trailing fd redirect (`bundle config 2>&1`). `config set` stays allowed.
+(^|[^[:alnum:]_.-])bundler?[[:space:]]+config([[:space:]]+-[^[:space:]]+)*([[:space:]]+(list|get)([^[:alnum:]_-]|$)|[[:space:]]+[^-[:space:]][^[:space:]]*\.[^[:space:]]*[[:space:]]*($|[<>|;&])|[[:space:]]*($|[<>|;&]|[0-9]))
 # `npm config get` (also the `c` and bare `get` aliases) prints protected
 # values raw; `config list` redacts them and stays allowed. A protected key
 # placed anywhere in the args is matched (npm accepts multiple keys).
-npm[[:space:]]+(config[[:space:]]+get|c[[:space:]]+get|get)[[:space:]].*(_auth|[Aa]uthToken|_password)
+npm([[:space:]]+-[^[:space:]]+)*[[:space:]]+(config[[:space:]]+get|c[[:space:]]+get|get)[[:space:]].*(_auth|[Aa]uthToken|_password)
+# pnpm reads config from .npmrc but, unlike npm, does not mask protected keys:
+# `pnpm config list` prints them and `pnpm config get //host/:_authToken` the
+# raw token. (The npm rule above also happens to catch `pnpm config get` as a
+# substring; this rule adds the unmasked `list` dump.)
+(^|[^[:alnum:]_-])pnpm([[:space:]]+-[^[:space:]]+)*[[:space:]]+config[[:space:]]+(list([[:space:]]|$)|get[[:space:]].*(_auth|[Aa]uthToken|_password))
 # `yarn config get` of an auth key, or of the registry/scope maps that nest
-# npmAuthToken/npmAuthIdent values.
-yarn[[:space:]]+config[[:space:]]+get[[:space:]]+[^[:space:]]*([Aa]uth(Token|Ident)|npmRegistries|npmScopes)
+# npmAuthToken/npmAuthIdent values. Residual: Yarn Classic `config list` prints
+# tokens, but modern Yarn (Berry) redacts and the npm_-prefixed value is caught
+# by the output redactor; blocking bare `yarn config list` over-blocks too much.
+yarn([[:space:]]+-[^[:space:]]+)*[[:space:]]+config[[:space:]]+get[[:space:]]+[^[:space:]]*([Aa]uth(Token|Ident)|npmRegistries|npmScopes)
 # git credential fill / any helper's `get` print password= plaintext; global
-# `-c`/`-C`/`--flag` options before the subcommand are tolerated, and the
-# helper name is matched generically (osxkeychain, libsecret, manager, ...).
-(^|[^[:alnum:]_-])git([[:space:]]+-[^[:space:]]+([[:space:]]+[^-][^[:space:]]*)?)*[[:space:]]+credential(-[[:alnum:]_-]+)?[[:space:]]+(fill|get)
+# `-c`/`-C`/`--flag` options before the subcommand are tolerated, the helper is
+# matched generically (osxkeychain, libsecret, manager, ...), and the direct
+# `git-credential-<helper> get` executable form is covered too.
+(^|[^[:alnum:]_-])(git([[:space:]]+-[^[:space:]]+([[:space:]]+[^-][^[:space:]]*)?)*[[:space:]]+credential(-[[:alnum:]_-]+)?|git-credential-[[:alnum:]_-]+)[[:space:]]+(fill|get)
 # pip config reads print index-urls verbatim, including embedded credentials;
-# version-suffixed binaries (`pip3.12`) and scope flags before the subcommand
-# (`pip config --user list`) are covered. `python -m pip config` matches too.
-(^|[^[:alnum:]_-])pip[0-9.]*[[:space:]]+config[[:space:]]+([^[:space:]]+[[:space:]]+)*(list|get)
+# `list`, `get`, and `debug` all reveal them. Version-suffixed binaries
+# (`pip3.12`) and scope flags before the subcommand are covered; `python -m pip
+# config` matches too.
+(^|[^[:alnum:]_-])pip[0-9.]*([[:space:]]+-[^[:space:]]+)*[[:space:]]+config[[:space:]]+([^[:space:]]+[[:space:]]+)*(list|get|debug)
 # composer config reads/sets of credential keys (anchored to the key argument
 # so a value like `repositories.bearer` does not over-block), and the full
-# `--list` dump. Blocking the set form too: http-basic passwords have no
-# prefix gitleaks could anchor on.
-composer[[:space:]]+config[[:space:]]+((-[[:alnum:]-]+[[:space:]]+)*(github-oauth|gitlab-token|gitlab-oauth|http-basic|bearer)([[:space:].]|$)|.*(-l|--list)([[:space:]]|$))
-# mvn help:effective-settings masks passwords unless showPasswords is set
-# (either flag order); anchored to `mvn` so prose/filenames don't over-block.
-mvn[[:space:]].*(effective-settings.*showPasswords|showPasswords.*effective-settings)
+# `--list` dump. Covers the `composer.phar` invocation form. Blocking the set
+# form too: http-basic passwords have no prefix gitleaks could anchor on.
+(^|[^[:alnum:]_-])composer(\.phar)?[[:space:]]+config[[:space:]]+((-[[:alnum:]-]+[[:space:]]+)*(github-oauth|gitlab-token|gitlab-oauth|http-basic|bearer)([[:space:].]|$)|.*(-l|--list)([[:space:]]|$))
+# mvn help:effective-settings masks passwords unless showPasswords is enabled
+# (either flag order); `showPasswords=false` is the safe default and stays
+# allowed. Covers the `./mvnw` wrapper; anchored so prose/filenames don't match.
+(^|[^[:alnum:]_-])mvnw?[[:space:]].*(effective-settings.*showPasswords([^=]|=[^f]|$)|showPasswords([^=]|=[^f]|$).*effective-settings)

--- a/plugins/agent-guard/config/deny-read-paths.txt
+++ b/plugins/agent-guard/config/deny-read-paths.txt
@@ -54,10 +54,10 @@ gcp-sa*.json
 .vault-token
 .dev.vars
 .dev.vars.*
-# Package-manager credential stores. These carry plaintext auth (Bundler
-# BUNDLE_<HOST> keys, RubyGems/Cargo API tokens, Composer github-oauth,
-# Maven server passwords, Gradle publish tokens, pip index-url credentials,
-# Poetry http-basic fallback). A bare `auth.json` glob is deliberately NOT
+# Package-manager credential stores. These carry plaintext auth for Bundler
+# (BUNDLE_<HOST>), RubyGems, Cargo, Composer (github-oauth), Maven server
+# passwords, Gradle publish tokens, pip index-url credentials, and the Poetry
+# http-basic fallback. A bare `auth.json` glob is deliberately NOT
 # listed: the name is too common in fixtures; only Composer's home locations
 # are covered. The explicit XDG path covers the newer RubyGems location
 # ~/.local/share/gem/credentials that the `.gem` glob cannot match, without

--- a/plugins/agent-guard/config/deny-read-paths.txt
+++ b/plugins/agent-guard/config/deny-read-paths.txt
@@ -54,3 +54,25 @@ gcp-sa*.json
 .vault-token
 .dev.vars
 .dev.vars.*
+# Package-manager credential stores. These carry plaintext auth (Bundler
+# BUNDLE_<HOST> keys, RubyGems/Cargo API tokens, Composer github-oauth,
+# Maven server passwords, Gradle publish tokens, pip index-url credentials,
+# Poetry http-basic fallback). A bare `auth.json` glob is deliberately NOT
+# listed: the name is too common in fixtures; only Composer's home locations
+# are covered. The explicit XDG path covers the newer RubyGems location
+# ~/.local/share/gem/credentials that the `.gem` glob cannot match, without
+# the over-block a dotless `gem/credentials` suffix would cause on a vendored
+# `gem/` directory.
+.bundle/config
+.gem/credentials
+.local/share/gem/credentials
+.cargo/credentials*
+.composer/auth.json
+.config/composer/auth.json
+.m2/settings.xml
+.gradle/gradle.properties
+pip.conf
+pypoetry/auth.toml
+# Terraform CLI credentials file: credentials "host" { token = "..." }.
+.terraformrc
+terraform.rc

--- a/plugins/agent-guard/config/deny-read-paths.txt
+++ b/plugins/agent-guard/config/deny-read-paths.txt
@@ -73,6 +73,13 @@ gcp-sa*.json
 .gradle/gradle.properties
 pip.conf
 pypoetry/auth.toml
+# Bun's dot config holds registry tokens in [install.registry]. Like every
+# entry here this is a basename rule (matches `.bunfig.toml` in any directory),
+# but the dotless project-root `bunfig.toml` is the commonly committed,
+# usually-secretless form and stays readable. uv and pnpm need no path here: uv
+# authenticates via env (UV_PUBLISH_TOKEN/UV_INDEX_*) and .netrc, and pnpm
+# reads .npmrc — both already covered.
+.bunfig.toml
 # Terraform CLI credentials file: credentials "host" { token = "..." }.
 .terraformrc
 terraform.rc

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1740,6 +1740,64 @@ expect_json_status 2 "Read terraform.rc is blocked" \
   '{"tool_name":"Read","tool_input":{"file_path":"terraform.rc"}}' \
   hook-pre-tool
 
+expect_json_status 2 "pnpm config get _authToken is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"pnpm config get //npm.pkg.github.com/:_authToken"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "pnpm config list (unmasked) is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"pnpm config list"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "pnpm config get registry is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"pnpm config get registry"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Read ~/.bunfig.toml is blocked" \
+  '{"tool_name":"Read","tool_input":{"file_path":"/home/u/.bunfig.toml"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "project-root bunfig.toml stays readable" \
+  '{"tool_name":"Read","tool_input":{"file_path":"bunfig.toml"}}' \
+  hook-pre-tool
+
+# Codex cross-validation: leading global options and alternate invocation
+# forms an agent may emit, plus the showPasswords=false safe-default control.
+expect_json_status 2 "bundle config with a leading flag before the key is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"bundle config --parseable github.com"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "npm with a global option before config get is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"npm --location=user config get //npm.pkg.github.com/:_authToken"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "direct git-credential helper executable is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"git-credential-osxkeychain get"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "pip config debug is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"pip3 config debug"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "php composer.phar config credential read is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"php composer.phar config -g github-oauth.github.com"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "mvnw wrapper effective-settings showPasswords is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"./mvnw help:effective-settings -DshowPasswords=true"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "mvn effective-settings showPasswords=false is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"mvn help:effective-settings -DshowPasswords=false"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "security with a leading option before the subcommand is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"security -q find-internet-password -s github.com -w"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "gcloud with a global flag before auth print-token is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"gcloud --quiet auth print-refresh-token"}}' \
+  hook-pre-tool
+
 expect_json_status 2 "Read XDG gem/credentials is blocked" \
   '{"tool_name":"Read","tool_input":{"file_path":"/home/u/.local/share/gem/credentials"}}' \
   hook-pre-tool

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1798,6 +1798,50 @@ expect_json_status 2 "gcloud with a global flag before auth print-token is block
   '{"tool_name":"Bash","tool_input":{"command":"gcloud --quiet auth print-refresh-token"}}' \
   hook-pre-tool
 
+# Second Codex pass: the "leading global options" contract above held for npm,
+# pip, pnpm and yarn but NOT for composer and bundler, whose patterns required
+# `config` to follow the binary immediately. Composer's documented
+# `global <command>` wrapper runs against COMPOSER_HOME, which is where the
+# stored OAuth token lives, so these read the credential store with no path and
+# no secret anywhere in the command for a later scan to catch.
+expect_json_status 2 "composer global wrapper before config is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"composer global config github-oauth.github.com"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "composer global wrapper before a config dump is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"composer global config -l"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "composer with a global option before config is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"composer --no-ansi config --global github-oauth.github.com"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "composer.phar global wrapper before config is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"php composer.phar global config http-basic"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "bundle with a global option before config is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"bundle --verbose config --parseable"}}' \
+  hook-pre-tool
+
+# Over-block controls for the widened prefixes: a wrapper or option run that
+# never reaches a `config` subcommand must stay allowed.
+expect_json_status 0 "composer global require is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"composer global require phpunit/phpunit"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "composer require of a config-named package is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"composer require --dev config/foo"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "bundle with a global option before install is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"bundle --verbose install"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "bundle config set is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"bundle config set path vendor/bundle"}}' \
+  hook-pre-tool
+
 expect_json_status 2 "Read XDG gem/credentials is blocked" \
   '{"tool_name":"Read","tool_input":{"file_path":"/home/u/.local/share/gem/credentials"}}' \
   hook-pre-tool

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1484,6 +1484,270 @@ expect_json_status 0 "Read a terraform module file is allowed" \
   '{"tool_name":"Read","tool_input":{"file_path":"main.tf"}}' \
   hook-pre-tool
 
+# Rank 10: package-manager credential stores (deny-read) and credential dump
+# commands (deny-bash). Each blocked case pairs with a nearby benign control.
+expect_json_status 2 "cat ~/.bundle/config is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"cat ~/.bundle/config"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Read project .bundle/config is blocked" \
+  '{"tool_name":"Read","tool_input":{"file_path":".bundle/config"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "cat Gemfile.lock is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"cat Gemfile.lock"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Read .gem/credentials is blocked" \
+  '{"tool_name":"Read","tool_input":{"file_path":".gem/credentials"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "gem list is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"gem list"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "cat ~/.cargo/credentials.toml is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"cat ~/.cargo/credentials.toml"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "cat ~/.cargo/config.toml is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"cat ~/.cargo/config.toml"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "cat ~/.composer/auth.json is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"cat ~/.composer/auth.json"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Read ~/.config/composer/auth.json is blocked" \
+  '{"tool_name":"Read","tool_input":{"file_path":"/home/u/.config/composer/auth.json"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "cat tests/fixtures/auth.json is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"cat tests/fixtures/auth.json"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Read ~/.m2/settings.xml is blocked" \
+  '{"tool_name":"Read","tool_input":{"file_path":"/home/u/.m2/settings.xml"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "cat pom.xml is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"cat pom.xml"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "cat ~/.gradle/gradle.properties is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"cat ~/.gradle/gradle.properties"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "project-root gradle.properties stays readable" \
+  '{"tool_name":"Read","tool_input":{"file_path":"gradle.properties"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Read pip.conf is blocked" \
+  '{"tool_name":"Read","tool_input":{"file_path":"/home/u/.config/pip/pip.conf"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "cat requirements.txt is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"cat requirements.txt"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Read pypoetry/auth.toml is blocked" \
+  '{"tool_name":"Read","tool_input":{"file_path":"/home/u/.config/pypoetry/auth.toml"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "cat pyproject.toml is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"cat pyproject.toml"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Read ~/.terraformrc is blocked" \
+  '{"tool_name":"Read","tool_input":{"file_path":"/home/u/.terraformrc"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "bundle config list is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"bundle config list"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "bare bundle config is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"bundle config"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "bundle config get github.com is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"bundle config get github.com"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "bundle config legacy host read is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"bundle config github.com"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "bundle config set --local path is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"bundle config set --local path vendor/bundle"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "bundle install is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"bundle install"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "npm config get _authToken is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"npm config get //npm.pkg.github.com/:_authToken"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "npm config get registry is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"npm config get registry"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "npm config list is allowed (npm redacts protected keys)" \
+  '{"tool_name":"Bash","tool_input":{"command":"npm config list"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "yarn config get npmAuthToken is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"yarn config get npmAuthToken"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "yarn config get nodeLinker is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"yarn config get nodeLinker"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "git credential fill is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"printf %s url=https://github.com | git credential fill"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "git credential-store get is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"git credential-store get"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "git config credential.helper is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"git config credential.helper"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "pip config list is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"pip config list"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "pip install -r requirements.txt is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"pip install -r requirements.txt"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "composer config github-oauth read is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"composer config -g github-oauth.github.com"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "composer install is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"composer install"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "composer config repositories is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"composer config repositories.foo vcs https://example.com/repo.git"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "mvn effective-settings with showPasswords is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"mvn help:effective-settings -DshowPasswords=true"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "mvn help:effective-settings (masked default) is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"mvn help:effective-settings"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "security find-internet-password is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"security find-internet-password -s github.com -w"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "gcloud auth print-refresh-token is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"gcloud auth print-refresh-token"}}' \
+  hook-pre-tool
+
+# Rank 10 hardening: alias/flag/version/helper bypass variants and the
+# over-block carve-outs the patterns are anchored to avoid.
+expect_json_status 2 "bundler alias config list is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"bundler config list"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "bundle config in a subshell is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"x=$(bundle config list)"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "bundle config with a trailing fd redirect is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"bundle config 2>&1"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "bundle legacy set form (dotted key with value) is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"bundle config github.com user:sometoken"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "bundle config unset is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"bundle config unset github.com"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "npm config get with the key placed second is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"npm config get registry //npm.pkg.github.com/:_authToken"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "npm c alias get of a token is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"npm c get //npm.pkg.github.com/:_authToken"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "npm get alias of a token is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"npm get //npm.pkg.github.com/:_authToken"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "yarn config get npmRegistries (nested tokens) is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"yarn config get npmRegistries"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "git credential-libsecret get is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"git credential-libsecret get"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "git -C dir credential fill is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"git -C /repo credential fill"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "git config credential.helper (read of a non-secret) is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"git config --get credential.helper"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "version-suffixed pip3.12 config list is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"pip3.12 config list"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "pip config with a scope flag before list is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"pip config --user list"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "pipx config is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"pipx config list"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "composer config --list dump is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"composer config -g --list"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "composer repository key containing bearer is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"composer config repositories.bearer vcs https://example.com/x.git"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "mvn effective-settings with reversed flag order is blocked" \
+  '{"tool_name":"Bash","tool_input":{"command":"mvn -DshowPasswords=true help:effective-settings"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "a filename mentioning effective-settings and showPasswords is allowed" \
+  '{"tool_name":"Bash","tool_input":{"command":"cat notes-effective-settings-showPasswords.md"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "security find-generic-password stays blocked after merge" \
+  '{"tool_name":"Bash","tool_input":{"command":"security find-generic-password -s svc -w"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Read terraform.rc is blocked" \
+  '{"tool_name":"Read","tool_input":{"file_path":"terraform.rc"}}' \
+  hook-pre-tool
+
+expect_json_status 2 "Read XDG gem/credentials is blocked" \
+  '{"tool_name":"Read","tool_input":{"file_path":"/home/u/.local/share/gem/credentials"}}' \
+  hook-pre-tool
+
+expect_json_status 0 "a vendored gem/credentials directory stays readable" \
+  '{"tool_name":"Bash","tool_input":{"command":"cat vendor/gem/credentials"}}' \
+  hook-pre-tool
+
 expect_json_status 0 "PII hook mode defaults off" \
   '{"tool_name":"Write","tool_input":{"file_path":"note.txt","content":"email jane@example.com"}}' \
   hook-pre-tool


### PR DESCRIPTION
## What

Package-manager workflows (`npm install`, `bundle install`/`bundle config`, `pip`, `composer`, `mvn`, `gradle`, `cargo`, `poetry`) can surface stored GitHub PATs and other credentials through two paths Agent Guard did not cover:

1. **Reading the plaintext credential file** — `.npmrc` was listed, but not the equivalents for Bundler, RubyGems, Cargo, Composer, Maven, Gradle, pip, Poetry, or the Terraform CLI.
2. **Dump commands that print stored auth to stdout** — `bundle config list`, `npm config get //host/:_authToken`, `git credential fill`, etc. carry neither a path nor a token in the command text, so neither the deny-read scan nor the command gitleaks scan can see them.

## Changes (config only — no `bin/agent-guard` logic touched)

- **`deny-read-paths.txt`**: `.bundle/config`, `.gem/credentials` + XDG `.local/share/gem/credentials`, `.cargo/credentials*`, Composer home `auth.json` (2 locations), `.m2/settings.xml`, `.gradle/gradle.properties`, `pip.conf`, `pypoetry/auth.toml`, `.terraformrc`/`terraform.rc`.
- **`deny-bash-patterns.txt`**: bundle config reads, `npm`/`yarn config get` of protected keys, `git credential fill`/any-helper `get`, `pip config list|get`, `composer config` on credential keys or `--list`, `mvn help:effective-settings -DshowPasswords`; `gcloud auth print-refresh-token` and `security find-(generic|internet)-password` merged with their siblings.

Deliberately **skipped** (over-block risk): bare `auth.json`, `.yarnrc.yml`, `NuGet.Config`, `.condarc`. `set`/write forms stay allowed because the token then sits in the command text and is gitleaks-scanned there.

## Hardening

A multi-angle adversarial review (run through the live hook) found the first-draft patterns leaked on realistic variants. Fixed and regression-tested:

- Tool aliases: `bundler`, `npm c`/`npm get`
- Version-suffixed binaries: `pip3.12`
- Scope/global flags before the subcommand: `pip config --user list`, `git -C dir credential fill`
- Non-listed git credential helpers: `git credential-libsecret get`
- Multi-key: `npm config get registry //host/:_authToken`
- `$(...)` subshell / fd-redirect prefixes on `bundle config`
- Over-block fixes: `mvn` anchored (so `cat notes-…showPasswords.md` is allowed); composer anchored to the key argument (so `repositories.bearer` is allowed)

## Verification

- **Suite: 898 pass / 0 fail** (`bash tests/run.sh`) — added 29 ground-truth controls (14 must-block + 15 must-allow) covering every new pattern and carve-out.
- **False-positive regression**: every new benign allow-control run against the `origin/main` binary under identical input — zero verdict changes.
- **E2E ground truth**: planted a runtime-generated `ghp_…` token in a temp-`HOME` `.bundle/config`, drove `hook-pre-tool` directly, and confirmed `bundle config list` / `cat …/.bundle/config` block (exit 2) while `bundle install` allows (exit 0), with **the token never reaching output**.

### Scope boundary (investigated, deliberately not covered)

A completeness sweep of package/registry auth vectors was done. Covered by this PR (file + dump where applicable): npm, yarn, pnpm, bun, RubyGems/Bundler, pip, Poetry, Composer, Maven, Gradle, Cargo, Terraform. Already covered elsewhere: cargo (`.cargo/credentials*`), go / bazel / apt-embedded (`.netrc`, env), homebrew (`HOMEBREW_GITHUB_API_TOKEN` via env-dump), docker (`.docker/config.json`).

Left out of scope for this PR by decision (niche relative to the mainstream set; can be a follow-up): sbt/Ivy `~/.sbt/.credentials` & `~/.ivy2/.credentials`, helm `~/.config/helm/registry/config.json`, user-level `NuGet.Config`, apt `/etc/apt/auth.conf(.d)`, conda `~/.continuum/anaconda-client/tokens/`. cmake/julia/yum-dnf `.repo` have no meaningful plaintext package-registry credential store worth a rule.

### Not covered (residual, documented)
- Generic obfuscation (`sh -c`, escaped command names, splitting a command across shell variables) — out of scope for a line-oriented regex guard; shared with every existing pattern in the file.
- `npm config list --json` masking is **UNVERIFIED**; `npm config list` stays allowed to avoid over-blocking a very common command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

