### PR TITLE
fix(redaction): close the status-label display leak (#156)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,10 @@
   (`response: error: api_key: <value>`) is covered by the same gate. Display
   redaction only; the block/detect path is unchanged. An unterminated quoted
   value (truncated output) is captured and classified when the leaf ends rather
-  than skipped, so a credential-shaped one still masks. Residual: an
+  than skipped, so a credential-shaped one still masks. A captured value is recorded in
+  both its literal and its edge-trimmed form, so a bare recurrence of a
+  credential that was padded or split across a newline behind its label
+  masks as well. Residual: an
   all-lowercase alphabetic secret shorter than 24 characters is indistinguishable
   from a prose word on this path and stays visible.
 - fix(detection): stop the deny-read Bash gate from blocking words that merely

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,24 +27,20 @@
   masks as well. Residual: an
   all-lowercase alphabetic secret shorter than 24 characters is indistinguishable
   from a prose word on this path and stays visible.
-- fix(detection): stop the deny-read Bash gate from blocking words that merely
-  end in a deny-listed extension (#99). `echo foo.key`, `echo see also foo.pem`
-  and `jq -r .key data.json` were reported as `blocked shell command
-  referencing a deny-listed path` although nothing was read and no such file
-  existed. Word operands of `echo` and `printf` are now dropped before the deny
-  scan, and only those: both are shell builtins, so bash runs the builtin
-  whatever sits on PATH, which makes naming them a claim the gate can actually
-  keep. An external binary cannot be named safely — it resolves through PATH at
-  execution time, so a wrapper earlier in PATH inherits the exception — which is
-  why `jq`, `yq`, `gojq` and `jaq` get none, and `jq -r .key data.json` keeps
-  its false positive. Stripping happens only inside ONE simple command: a
-  newline, `&`, `|`, `;`, grouping, redirection, substitution or expansion
-  anywhere in the command and nothing is stripped at all. The command word must
-  be the raw token — no path, no quotes — and only clean literals are ever
-  dropped, so `echo $(cat .env)`, `./echo .env` and `'echo foo' .env` all still
-  block. Deliberately not narrowed by file existence: that would also unblock
-  `cat .env` in a directory without one, and refusing that read by name is the
-  documented behaviour.
+- docs: record why the deny-read Bash gate is NOT narrowed (#99). `echo
+  foo.key`, `echo see also foo.pem` and `jq -r .key data.json` are reported as
+  `blocked shell command referencing a deny-listed path` although nothing is
+  read and no such file exists. A command-position narrowing that dropped word
+  operands of commands which take no file operands was written, measured and
+  removed again: every revision of it let a real read through. A newline or `&`
+  starts another command, `|` hands the dropped word to `xargs cat`, a path- or
+  quote-qualified name resolves to a different program than the one compared, an
+  external binary resolves through PATH at execution time so a wrapper inherits
+  the exception, and an exported Bash function named `echo` or `printf` beats
+  the builtin — so even a builtin name does not identify what will run. A text
+  gate that cannot name the program cannot safely drop its operands. #99 stays
+  open as an accepted false positive; the counter-examples are pinned as tests
+  so any re-attempt has to answer them.
 - fix(hooks): drop the undefined `\"` escape from the shell-parser awk bracket
   expression (#99). gawk warned `regexp escape sequence \" is not a known
   regexp operator` on every `hook-pre-tool` run, including runs that passed. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,11 @@
   alphabetic run longer than any ordinary word) masks, while a word, path,
   number, clock time or date stays visible. The chained shape
   (`response: error: api_key: <value>`) is covered by the same gate. Display
-  redaction only; the block/detect path is unchanged. Residual: an all-lowercase
-  alphabetic secret below the compound threshold is indistinguishable from prose
-  on this path, and an unterminated quoted value keeps the previous skip.
+  redaction only; the block/detect path is unchanged. An unterminated quoted
+  value (truncated output) is captured and classified when the leaf ends rather
+  than skipped, so a credential-shaped one still masks. Residual: an
+  all-lowercase alphabetic secret shorter than 24 characters is indistinguishable
+  from a prose word on this path and stays visible.
 - fix(detection): stop the deny-read Bash gate from blocking words that merely
   end in a deny-listed extension (#99). `echo foo.key`, `echo see also foo.pem`
   and `jq -r .key data.json` were reported as `blocked shell command

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,18 +28,20 @@
   end in a deny-listed extension (#99). `echo foo.key`, `echo see also foo.pem`
   and `jq -r .key data.json` were reported as `blocked shell command
   referencing a deny-listed path` although nothing was read and no such file
-  existed. Operands are now narrowed by command position, and only inside ONE
-  simple command: if the command contains a newline, `&`, `|`, `;`, grouping,
-  redirection, substitution or expansion, nothing is stripped at all. Within
-  that, every word operand of `echo`/`printf`, which take no file operands, and
-  `jq`'s first non-option operand, which is the filter program, are dropped
-  before the deny scan. The command word must be the token exactly — no path,
-  no quotes — and only clean literals are ever dropped, so `echo $(cat .env)`,
-  `./echo .env` and `'echo foo' .env` all still block. `yq`, `gojq` and `jaq`
-  get no exception: yq treats its first argument as a file when one exists, and
-  the other two were never verified against. Deliberately not narrowed by file
-  existence: that would also unblock `cat .env` in a directory without one, and
-  refusing that read by name is the documented behaviour.
+  existed. Word operands of `echo` and `printf` are now dropped before the deny
+  scan, and only those: both are shell builtins, so bash runs the builtin
+  whatever sits on PATH, which makes naming them a claim the gate can actually
+  keep. An external binary cannot be named safely — it resolves through PATH at
+  execution time, so a wrapper earlier in PATH inherits the exception — which is
+  why `jq`, `yq`, `gojq` and `jaq` get none, and `jq -r .key data.json` keeps
+  its false positive. Stripping happens only inside ONE simple command: a
+  newline, `&`, `|`, `;`, grouping, redirection, substitution or expansion
+  anywhere in the command and nothing is stripped at all. The command word must
+  be the raw token — no path, no quotes — and only clean literals are ever
+  dropped, so `echo $(cat .env)`, `./echo .env` and `'echo foo' .env` all still
+  block. Deliberately not narrowed by file existence: that would also unblock
+  `cat .env` in a directory without one, and refusing that read by name is the
+  documented behaviour.
 - fix(hooks): drop the undefined `\"` escape from the shell-parser awk bracket
   expression (#99). gawk warned `regexp escape sequence \" is not a known
   regexp operator` on every `hook-pre-tool` run, including runs that passed. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@
 
 ## Unreleased
 
+- fix(redaction): close the status-label display-redaction leak (#156). The
+  seven-word status allowlist (`error`, `warning`, `info`, `note`, `debug`,
+  `fatal`, `hint`) let a secret that gitleaks does not recognise reach the model
+  unmasked whenever it sat behind one of those labels — `error: password:
+  <value>` and `warning: db_password: <value>` were displayed in full. The label
+  cannot settle it, because it is identical in the prose chain the allowlist
+  exists to protect (`error: password: authentication is disabled`), so the
+  VALUE now decides: a token whose shape reads as a credential (a digit beside a
+  letter, an uppercase run starting past the first character, or a single-case
+  alphabetic run longer than any ordinary word) masks, while a word, path,
+  number, clock time or date stays visible. The chained shape
+  (`response: error: api_key: <value>`) is covered by the same gate. Display
+  redaction only; the block/detect path is unchanged. Residual: an all-lowercase
+  alphabetic secret below the compound threshold is indistinguishable from prose
+  on this path, and an unterminated quoted value keeps the previous skip.
+- fix(detection): stop the deny-read Bash gate from blocking words that merely
+  end in a deny-listed extension (#99). `echo foo.key`, `echo see also foo.pem`
+  and `jq -r .key data.json` were reported as `blocked shell command
+  referencing a deny-listed path` although nothing was read and no such file
+  existed. Operands are now narrowed by command position: every word operand of
+  `echo`/`printf`, which take no file operands, and the jq family's first
+  non-option operand, which is the filter program, are dropped before the deny
+  scan. Only clean literals are dropped, so `echo $(cat .env)` still blocks, and
+  a redirection stops the stripping for the rest of that segment. Deliberately
+  not narrowed by file existence: that would also unblock `cat .env` in a
+  directory without one, and refusing that read by name is the documented
+  behaviour.
+- fix(hooks): drop the undefined `\"` escape from the shell-parser awk bracket
+  expression (#99). gawk warned `regexp escape sequence \" is not a known
+  regexp operator` on every `hook-pre-tool` run, including runs that passed. The
+  class already contains a literal backslash via `\\`, so it is unchanged.
 - ci: remove the `codex-review` workflow. It has never produced a review in
   this repository: with no `OPENAI_API_KEY` Actions secret every step is
   skipped, the job reports success in a few seconds, and the feedback job is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,14 +28,18 @@
   end in a deny-listed extension (#99). `echo foo.key`, `echo see also foo.pem`
   and `jq -r .key data.json` were reported as `blocked shell command
   referencing a deny-listed path` although nothing was read and no such file
-  existed. Operands are now narrowed by command position: every word operand of
-  `echo`/`printf`, which take no file operands, and the jq family's first
-  non-option operand, which is the filter program, are dropped before the deny
-  scan. Only clean literals are dropped, so `echo $(cat .env)` still blocks, and
-  a redirection stops the stripping for the rest of that segment. Deliberately
-  not narrowed by file existence: that would also unblock `cat .env` in a
-  directory without one, and refusing that read by name is the documented
-  behaviour.
+  existed. Operands are now narrowed by command position, and only inside ONE
+  simple command: if the command contains a newline, `&`, `|`, `;`, grouping,
+  redirection, substitution or expansion, nothing is stripped at all. Within
+  that, every word operand of `echo`/`printf`, which take no file operands, and
+  `jq`'s first non-option operand, which is the filter program, are dropped
+  before the deny scan. The command word must be the token exactly — no path,
+  no quotes — and only clean literals are ever dropped, so `echo $(cat .env)`,
+  `./echo .env` and `'echo foo' .env` all still block. `yq`, `gojq` and `jaq`
+  get no exception: yq treats its first argument as a file when one exists, and
+  the other two were never verified against. Deliberately not narrowed by file
+  existence: that would also unblock `cat .env` in a directory without one, and
+  refusing that read by name is the documented behaviour.
 - fix(hooks): drop the undefined `\"` escape from the shell-parser awk bracket
   expression (#99). gawk warned `regexp escape sequence \" is not a known
   regexp operator` on every `hook-pre-tool` run, including runs that passed. The

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -3245,6 +3245,17 @@ secretish_env_values() {
           "\",\"contextual\":true}"
       }
     }
+    # A multiline capture keeps the newline that separated the label from the
+    # value, so the global literal is `<newline><secret>` and a BARE recurrence
+    # of the credential later in the output does not match it. Emit the trimmed
+    # token as a second record so global masking still reaches those.
+    function emit_captured(v, trimmed) {
+      emit_secret(v)
+      trimmed = v
+      sub(/^[ \t\n]+/, "", trimmed)
+      sub(/[ \t\n]+$/, "", trimmed)
+      if (trimmed != v) emit_secret(trimmed)
+    }
     function emit_secret(value, eligible_length) {
       if (already_redacted(value)) return
       if (eligible_length == 0) eligible_length = length(value)
@@ -3464,7 +3475,7 @@ secretish_env_values() {
         }
         closed_value = open_value "\n" substr(rest, 1, end - 1)
         if (!open_guard || credential_shaped(closed_value))
-          emit_secret(closed_value)
+          emit_captured(closed_value)
         open_quote = ""
         open_value = ""
         open_guard = 0
@@ -3540,7 +3551,7 @@ secretish_env_values() {
       scan_line(value)
       # Truncated output can omit a closing quote. Redact the leaf remainder.
       if (open_quote != "" && (!open_guard || credential_shaped(open_value)))
-        emit_secret(open_value)
+        emit_captured(open_value)
       open_quote = ""
       open_value = ""
       open_guard = 0
@@ -3596,7 +3607,12 @@ secretish_env_values() {
         # A truncated multiline quote is evaluated only after the complete raw
         # capture has been scanned. This mirrors scan_leaf without resetting
         # open_quote/open_value at every physical newline.
-        if (!probe_found && open_quote != "") emit_secret(open_value)
+        # Same status-label gate as the scan_leaf termination above: without
+        # it a >64 KiB invalid-UTF-8 capture ending in an unterminated prose
+        # chain was replaced wholesale, contradicting the gate everywhere else.
+        if (!probe_found && open_quote != "" \
+            && (!open_guard || credential_shaped(open_value)))
+          emit_captured(open_value)
         exit
       }
       # Valid framed input always terminates each leaf with RS. Preserve a final

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -2277,21 +2277,6 @@ bash_strip_allowed_tokens() {
   )
 }
 
-# jq options that never consume a following value. Anything outside this list
-# — `-f`, `--from-file`, `-L`, `--arg`, a combined cluster such as `-rf` — may
-# take the NEXT token as a value, and for the file-taking ones that token is a
-# path jq reads. Treating it as the filter and dropping it was a read bypass, so
-# an unrecognised option stops the filter search instead of consuming it.
-jq_option_is_valueless() {
-  case "$1" in
-    -r|-c|-n|-e|-j|-a|-s|-S|-R|-M|-C|-h|\
-    --raw-output|--join-output|--compact-output|--null-input|--exit-status|\
-    --ascii-output|--slurp|--sort-keys|--raw-input|--tab|--monochrome-output|\
-    --color-output|--help|--version|--stream|--seq) return 0 ;;
-    *) return 1 ;;
-  esac
-}
-
 # The deny-read patterns are basename globs, and matching them against every
 # word of a command makes any word that merely ends in a listed extension a
 # block: `echo foo.key`, `jq -r .key data.json`, `echo see also foo.pem` (#99).
@@ -2322,19 +2307,25 @@ jq_option_is_valueless() {
 # Within one simple command, drop only operands the command cannot read:
 #
 #   - every word operand of `echo` / `printf`, which take no file operands;
-#   - `jq`'s first non-option operand, which is the filter program
-#     (`jq -r .key data.json` reads data.json; `.key` selects a field). A
-#     leading `./` or `../` marks a path and is kept, `--` ends the search, and
-#     an option that might take a value stops it (see jq_option_is_valueless).
+# `echo` and `printf` and nothing else, and the reason is what they ARE rather
+# than what they do with their operands: both are shell builtins, so bash runs
+# the builtin whatever sits on PATH. Naming a command here is a claim about the
+# program that will actually run, and for a builtin that claim holds.
 #
-# `jq` and nothing else, on purpose. `yq` was in this list and was a read
-# bypass: Mike Farah yq autodetects its first argument, treating it as an
-# expression only when no file of that name exists, so `yq .env` in a directory
-# that has one READS it. `gojq` and `jaq` were added on the assumption that they
-# copy jq's grammar, which was never checked against either tool. An unverified
-# assumption is what produced the yq hole, so they are out too: the reported
-# false positive is about jq, and jq is what this covers. Everything else keeps
-# today's false positive, which is the safe direction.
+# It does not hold for an external binary, which is why `jq` is no longer here.
+# jq had the same exception for its first non-option operand — always its filter
+# program — and that was sound about jq itself and useless in practice: jq
+# resolves through PATH at execution time, so a wrapper or shadow earlier in
+# PATH inherits the exception meant for the real one. Reproduced: a `jq` script
+# running `cat .env` for `jq .env` was allowed here and read the file, where the
+# baseline blocked it. A text gate cannot know what PATH will resolve to, and
+# checking at hook time would not bind what runs a moment later. `yq`, `gojq`
+# and `jaq` were removed earlier for narrower reasons; this argument covers
+# them too.
+#
+# The cost is that `jq -r .key data.json` keeps the #99 false positive. That is
+# the trade, and it is the right way round: a false positive is an annoyance,
+# and this exception was a read.
 #
 # Only a clean literal is ever dropped (env_exception_literal_shell_token
 # rejects quoting that survives unquoting, expansion, globs, redirection and
@@ -2389,7 +2380,7 @@ bash_strip_non_path_tokens() {
     # not a shape worth widening the gate for.
     strip_command=$1
     case "$strip_command" in
-      echo|printf|jq) ;;
+      echo|printf) ;;
       *)
         printf '%s' "$strip_input"
         return 0
@@ -2398,32 +2389,11 @@ bash_strip_non_path_tokens() {
 
     result=$1
     shift
-    strip_seen_operand=0
 
     for token in "$@"; do
       strip_literal=$(env_exception_literal_shell_token "$token" 2>/dev/null \
         || true)
-      if [ -n "$strip_literal" ]; then
-        case "$strip_command" in
-          echo|printf)
-            continue
-            ;;
-          *)
-            if [ "$strip_seen_operand" -eq 0 ]; then
-              case "$strip_literal" in
-                --) strip_seen_operand=1 ;;
-                -*)
-                  jq_option_is_valueless "$strip_literal" \
-                    || strip_seen_operand=1
-                  ;;
-                ./*|../*) strip_seen_operand=1 ;;
-                .*) strip_seen_operand=1; continue ;;
-                *) strip_seen_operand=1 ;;
-              esac
-            fi
-            ;;
-        esac
-      fi
+      [ -n "$strip_literal" ] && continue
       result="$result $token"
     done
     printf '%s' "$result"
@@ -3285,9 +3255,13 @@ secretish_env_values() {
       scan_leaf(v)
       guard_rescan = 0
     }
+    # `\r` counts as edge whitespace: scan_leaf splits on `\n` and keeps the
+    # preceding `\r`, so CRLF output left a carriage return glued to the value.
+    # The capture then recorded `\r\n<secret>` as its literal and a bare
+    # recurrence of the credential further down matched nothing.
     function edge_trim(v) {
-      sub(/^[ \t\n]+/, "", v)
-      sub(/[ \t\n]+$/, "", v)
+      sub(/^[ \t\r\n]+/, "", v)
+      sub(/[ \t\r\n]+$/, "", v)
       return v
     }
     function emit_captured(v, trimmed) {

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -2371,8 +2371,13 @@ bash_strip_non_path_tokens() {
       return 0
     fi
 
-    strip_command=${1##*/}
-    strip_command=$(printf '%s' "$strip_command" | tr -d "'\"")
+    # The token EXACTLY, with no basename strip. Reducing `./echo` to `echo`
+    # handed the exception to any executable that merely shares the name —
+    # `./echo .env`, `/tmp/printf .env` and `./jq .env` all passed the gate, and
+    # those programs can read the denied file. A path-qualified invocation keeps
+    # today false positive instead. Quotes are still removed: quoting changes
+    # nothing about which program runs.
+    strip_command=$(printf '%s' "$1" | tr -d "'\"")
     case "$strip_command" in
       echo|printf|jq) ;;
       *)
@@ -3249,11 +3254,14 @@ secretish_env_values() {
     # value, so the global literal is `<newline><secret>` and a BARE recurrence
     # of the credential later in the output does not match it. Emit the trimmed
     # token as a second record so global masking still reaches those.
+    function edge_trim(v) {
+      sub(/^[ \t\n]+/, "", v)
+      sub(/[ \t\n]+$/, "", v)
+      return v
+    }
     function emit_captured(v, trimmed) {
       emit_secret(v)
-      trimmed = v
-      sub(/^[ \t\n]+/, "", trimmed)
-      sub(/[ \t\n]+$/, "", trimmed)
+      trimmed = edge_trim(v)
       if (trimmed != v) emit_secret(trimmed)
     }
     function emit_secret(value, eligible_length) {
@@ -3474,7 +3482,11 @@ secretish_env_values() {
           return
         }
         closed_value = open_value "\n" substr(rest, 1, end - 1)
-        if (!open_guard || credential_shaped(closed_value))
+        # Classify the EDGE-trimmed capture: an indented continuation line
+        # carries leading spaces into closed_value, and the whitespace test
+        # would reject the credential before emit_captured could trim it.
+        # Internal whitespace is untouched, so it still marks prose.
+        if (!open_guard || credential_shaped(edge_trim(closed_value)))
           emit_captured(closed_value)
         open_quote = ""
         open_value = ""
@@ -3550,7 +3562,8 @@ secretish_env_values() {
       }
       scan_line(value)
       # Truncated output can omit a closing quote. Redact the leaf remainder.
-      if (open_quote != "" && (!open_guard || credential_shaped(open_value)))
+      if (open_quote != "" \
+          && (!open_guard || credential_shaped(edge_trim(open_value))))
         emit_captured(open_value)
       open_quote = ""
       open_value = ""
@@ -3611,7 +3624,7 @@ secretish_env_values() {
         # it a >64 KiB invalid-UTF-8 capture ending in an unterminated prose
         # chain was replaced wholesale, contradicting the gate everywhere else.
         if (!probe_found && open_quote != "" \
-            && (!open_guard || credential_shaped(open_value)))
+            && (!open_guard || credential_shaped(edge_trim(open_value))))
           emit_captured(open_value)
         exit
       }

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -3367,8 +3367,11 @@ secretish_env_values() {
       # leading capital alone is ordinary sentence case (`Authentication`).
       if (v ~ /[0-9][A-Za-z]/ || v ~ /[A-Za-z][0-9]/) return 1
       if (v ~ /[a-z]/ && substr(v, 2) ~ /[A-Z]/) return 1
-      # A single-case alphabetic run longer than any ordinary word.
-      if (length(v) >= 24 && v ~ /^[A-Za-z]+$/) return 1
+      # A single-case alphabetic run longer than any ordinary word, joined by
+      # `.`/`-`/`_` or not. Requiring a PURELY alphabetic value let a
+      # delimiter-separated passphrase (`correct-horse-battery-staple`) through,
+      # although it is far less prose-like than the bare-word residual below it.
+      if (length(v) >= 24 && v ~ /^[A-Za-z]+([._-][A-Za-z]+)*$/) return 1
       return 0
     }
     function emit_value(source, start, assignment, require_credential, \
@@ -3383,10 +3386,14 @@ secretish_env_values() {
         raw = substr(raw, 2)
         end = quoted_end(raw, quote)
         if (end == 0) {
-          # An unterminated quote gives no complete value to classify, so the
-          # status-label path keeps its pre-#156 behaviour and skips rather than
-          # opening multiline capture over what may be prose.
-          if (require_credential) return 0
+          # Truncated or malformed output after an opening quote. There is no
+          # complete value to classify, but skipping outright restored the #156
+          # bypass for exactly the case where output was cut short. Classify the
+          # fragment that IS available: a credential-shaped one opens multiline
+          # capture like every other path, so the leaf remainder is masked,
+          # while prose (`error: password: "authentication is disabled`) still
+          # falls through untouched.
+          if (require_credential && !credential_shaped(raw)) return 0
           open_quote = quote
           open_value = raw
           return 1
@@ -3411,15 +3418,17 @@ secretish_env_values() {
         # replacement to the complete assignment token so an ordinary
         # one-character literal is not replaced throughout the response.
         #
-        # The status-label path scopes for a different reason: there the shape
-        # gate, not a detector, decided this is a credential, and a wrong guess
-        # is expected rather than exceptional. A global literal would erase the
-        # value from EVERY line of the response, so one bad call on
-        # `error: token: v1.2.3` also scrubs the `v1.2.3` in the release note
-        # three lines down, and `Error: secret: prod-db-secret-v2 not found`
-        # takes the name out of the `kubectl create secret` hint that follows.
-        # Scoped, a false positive costs the one label line it was found on.
-        if (require_credential || (length(value) < 4 && length(token) >= 4)) {
+        # The status-label path deliberately does NOT scope: a value that has
+        # passed credential_shaped is masked globally, exactly like one found
+        # behind any other label. Scoping it left a recurrence visible —
+        # `error: password: <secret>` followed by `retrying with <secret>`
+        # masked only the labelled line. The false positives that scoping would
+        # contain (a version string or a resource name scrubbed from a later
+        # line) are not specific to this path: `response: token: v1.2.3` already
+        # scrubs every v1.2.3 in the response on main. Consistency with the
+        # other paths is worth more here than containing a bad guess, because a
+        # displayed secret costs more than a mangled log line.
+        if (length(value) < 4 && length(token) >= 4) {
           trailing = substr(token, end + 1)
           emit_mapping(assignment leading token,
                        assignment leading "[REDACTED]" trailing)

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -2371,13 +2371,23 @@ bash_strip_non_path_tokens() {
       return 0
     fi
 
-    # The token EXACTLY, with no basename strip. Reducing `./echo` to `echo`
-    # handed the exception to any executable that merely shares the name —
-    # `./echo .env`, `/tmp/printf .env` and `./jq .env` all passed the gate, and
-    # those programs can read the denied file. A path-qualified invocation keeps
-    # today false positive instead. Quotes are still removed: quoting changes
-    # nothing about which program runs.
-    strip_command=$(printf '%s' "$1" | tr -d "'\"")
+    # The token EXACTLY: no basename strip, and no quote removal either.
+    #
+    # Stripping the directory handed the exception to any executable that merely
+    # shares the name — `./echo .env`, `/tmp/printf .env` and `./jq .env` all
+    # passed while reading the denied file.
+    #
+    # Removing quotes was worse, because shell_command_words splits on
+    # whitespace BEFORE quotes are resolved: a command name containing quoted
+    # whitespace arrives here as its first fragment, so `'\''echo foo'\'' .env`
+    # reduced to `echo` and took the exception, while the shell resolved an
+    # executable literally named `echo foo` that read the file. Comparing the
+    # raw token is the only form that cannot be talked into a false match.
+    #
+    # `'\''echo'\'' .env` therefore keeps its false positive. That is the same
+    # trade every other narrowing here makes, and quoting a bare command name is
+    # not a shape worth widening the gate for.
+    strip_command=$1
     case "$strip_command" in
       echo|printf|jq) ;;
       *)

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -3529,10 +3529,19 @@ secretish_env_values() {
           open_quote = ""
           open_value = ""
           open_guard = 0
+          rest = substr(rest, end + 1)
         } else {
-          guard_rescan_leaf(closed_value)
+          # The capture scans forward for ANY matching quote, so the one it
+          # closed on often belongs to something else entirely — typically the
+          # OPENING quote of a credential further down. Re-scanning only what
+          # was absorbed then leaves that credential stranded on the far side
+          # of a quote the capture ate, with its key consumed too, so nothing
+          # masks it. Hand the re-scan the absorbed text AND the rest of this
+          # line starting at that quote, which reconstructs the original text
+          # exactly, and consume the line here.
+          guard_rescan_leaf(closed_value substr(rest, end))
+          rest = ""
         }
-        rest = substr(rest, end + 1)
       }
       while (length(rest) > 0) {
         low = tolower(rest)

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -3346,14 +3346,26 @@ secretish_env_values() {
     # label, and the block/detect path is unaffected either way.
     function credential_shaped(v) {
       if (length(v) < 6) return 0
+      # A credential is a single token. The unquoted branch has already cut at
+      # whitespace, so this only bites on a QUOTED value — where a multi-word
+      # string behind a status label is a message, not a secret. Without it
+      # `error: password: "must be at least 8 characters"` masks, because the
+      # class tests below would find a letter and a digit somewhere in the
+      # sentence and never ask whether they were part of the same token.
+      if (v ~ /[ \t]/) return 0
       # Dates, timestamps and clock times are the ordinary log values that would
-      # otherwise satisfy the mixed-class test below.
-      if (v ~ /^[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]/) return 0
+      # otherwise satisfy the mixed-class tests. Anchored at BOTH ends: a date
+      # only tells us this value is a date when the value is nothing else, and a
+      # prefix match let `2026-08-30-A1b2C3d4-token` through unmasked.
+      if (v ~ /^[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]$/) return 0
+      if (v ~ /^[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9][T][0-9][0-9]:[0-9][0-9](:[0-9][0-9])?([.][0-9]+)?(Z|[+-][0-9][0-9]:?[0-9][0-9])?$/) return 0
       if (v ~ /^[0-9]+:[0-9]+(:[0-9]+)?$/) return 0
-      # Mixed character classes: a digit beside a letter, or an uppercase run
-      # starting past the first character. A leading capital alone is ordinary
-      # sentence case (`Authentication`), not a credential.
-      if (v ~ /[0-9]/ && v ~ /[A-Za-z]/) return 1
+      # Mixed character classes. The digit test requires the digit and the
+      # letter to be ADJACENT: `hunter2-long-value` is a credential, `least 8
+      # characters` and `expires in 3600 seconds` are prose that merely contain
+      # both. An uppercase run must start past the first character, since a
+      # leading capital alone is ordinary sentence case (`Authentication`).
+      if (v ~ /[0-9][A-Za-z]/ || v ~ /[A-Za-z][0-9]/) return 1
       if (v ~ /[a-z]/ && substr(v, 2) ~ /[A-Z]/) return 1
       # A single-case alphabetic run longer than any ordinary word.
       if (length(v) >= 24 && v ~ /^[A-Za-z]+$/) return 1
@@ -3398,7 +3410,16 @@ secretish_env_values() {
         # Eligibility is based on the complete token. For short values, scope
         # replacement to the complete assignment token so an ordinary
         # one-character literal is not replaced throughout the response.
-        if (length(value) < 4 && length(token) >= 4) {
+        #
+        # The status-label path scopes for a different reason: there the shape
+        # gate, not a detector, decided this is a credential, and a wrong guess
+        # is expected rather than exceptional. A global literal would erase the
+        # value from EVERY line of the response, so one bad call on
+        # `error: token: v1.2.3` also scrubs the `v1.2.3` in the release note
+        # three lines down, and `Error: secret: prod-db-secret-v2 not found`
+        # takes the name out of the `kubectl create secret` hint that follows.
+        # Scoped, a false positive costs the one label line it was found on.
+        if (require_credential || (length(value) < 4 && length(token) >= 4)) {
           trailing = substr(token, end + 1)
           emit_mapping(assignment leading token,
                        assignment leading "[REDACTED]" trailing)

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -2277,6 +2277,96 @@ bash_strip_allowed_tokens() {
   )
 }
 
+# The deny-read patterns are basename globs, and matching them against every
+# word of a command makes any word that merely ends in a listed extension a
+# block: `echo foo.key`, `jq -r .key data.json`, `echo see also foo.pem` (#99).
+# Nothing has to exist on disk and nothing has to be read, so the gate stops
+# deciding what is sensitive and starts inheriting whatever the glob does. It
+# surfaces as `blocked shell command referencing a deny-listed path`, which
+# reads in the transcript as if the agent had tried to open a private key.
+#
+# The narrowing is deliberately by command POSITION, not by whether the named
+# file exists. An existence test would also unblock `cat .env` in a directory
+# without one, and refusing that read by name — before anything is created — is
+# the behaviour the README quick start verifies and the deny-read tests pin.
+#
+# So drop only operands that the command in front of them cannot read:
+#
+#   - every word operand of `echo` / `printf`, which take no file operands at
+#     all (their only file contact is a redirection, and a redirection token
+#     stops the stripping for the rest of that segment);
+#   - the first non-option operand of the jq family, which is the filter
+#     program. `jq -r .key data.json` reads data.json; `.key` selects a field.
+#     A leading `./` or `../` marks a path rather than a filter and is kept.
+#
+# Only a clean literal is ever dropped (env_exception_literal_shell_token
+# rejects quoting that survives unquoting, expansion, globs, redirection and
+# whitespace), so `echo $(cat .env)` keeps both substitution tokens and stays
+# blocked. The list is minimal and additive on purpose: a command missing from
+# it merely keeps today's false positive, it can never turn a real read into a
+# pass. Broader shapes — a deny-listed basename inside a commit message, a grep
+# pattern — are not covered here.
+bash_strip_non_path_tokens() {
+  (
+    set -f
+    words=$(shell_command_words "$1")
+    # shellcheck disable=SC2086
+    set -- $words
+    result= strip_command= strip_seen_operand=0 strip_redirected=0
+
+    keep_policy_token() {
+      if [ -z "$result" ]; then result=$1; else result="$result $1"; fi
+    }
+
+    for token in "$@"; do
+      if is_shell_command_separator "$token"; then
+        strip_command= strip_seen_operand=0 strip_redirected=0
+        keep_policy_token "$token"
+        continue
+      fi
+
+      if [ -z "$strip_command" ]; then
+        if is_assignment_token "$token" || is_noop_wrapper "${token##*/}"; then
+          keep_policy_token "$token"
+          continue
+        fi
+        strip_command=${token##*/}
+        strip_command=$(printf '%s' "$strip_command" | tr -d "'\"")
+        keep_policy_token "$token"
+        continue
+      fi
+
+      case "$token" in
+        *'<'*|*'>'*) strip_redirected=1 ;;
+      esac
+
+      if [ "$strip_redirected" -eq 0 ]; then
+        strip_literal=$(env_exception_literal_shell_token "$token" 2>/dev/null \
+          || true)
+        if [ -n "$strip_literal" ]; then
+          case "$strip_command" in
+            echo|printf)
+              continue
+              ;;
+            jq|gojq|jaq|yq)
+              if [ "$strip_seen_operand" -eq 0 ]; then
+                case "$strip_literal" in
+                  -*) ;;
+                  ./*|../*) strip_seen_operand=1 ;;
+                  .*) strip_seen_operand=1; continue ;;
+                  *) strip_seen_operand=1 ;;
+                esac
+              fi
+              ;;
+          esac
+        fi
+      fi
+      keep_policy_token "$token"
+    done
+    printf '%s' "$result"
+  )
+}
+
 # POSIX sh has no locals: this function must NOT assign the bare name `cmd`, or
 # it clobbers the caller's command in check_bash_command. The strip helpers
 # rejoin tokens with single spaces (dropping a real newline separator), so a
@@ -2286,6 +2376,7 @@ bash_matches_deny_path() {
   deny_cmd=$1
   deny_cmd=$(bash_strip_exclusion_operands "$deny_cmd")
   deny_cmd=$(bash_strip_allowed_tokens "$deny_cmd")
+  deny_cmd=$(bash_strip_non_path_tokens "$deny_cmd")
   bash_matches_deny_path_mode "$deny_cmd" "literal" && return 0
   bash_matches_deny_path_mode "$deny_cmd" "shell-expanded" && return 0
   dequoted=$(shell_dequote_for_policy "$deny_cmd")
@@ -2357,7 +2448,11 @@ git_command_records() {
         }
         if (quote == "double") {
           if (c == "\"") { quote = ""; started = 1; continue }
-          if (c == "\\" && n ~ /^[\"\\$`]$/) {
+          # `"` needs no backslash inside a bracket expression, and `\"` is not
+          # a defined escape there: gawk warns on every hook run and another awk
+          # is free to read the class differently. `\\` already puts a literal
+          # backslash in the set, so the class is unchanged (#99).
+          if (c == "\\" && n ~ /^["\\$`]$/) {
             word = word n; started = 1; i++; continue
           }
           if (c == "$" || c == "`") dynamic = 1
@@ -3196,7 +3291,37 @@ secretish_env_values() {
         return 0
       return accessor_chain(v)
     }
-    function emit_value(source, start, assignment, raw, leading, quote, end, \
+    # Value-side gate for the status-label colon path (#156). A status label on
+    # its own cannot separate `error: password: authentication is disabled`
+    # (prose, must not mask) from `error: password: hunter2-long-value`
+    # (assignment, must mask): the label is identical in both, so the VALUE has
+    # to decide. Mask only a token whose shape reads as a credential; an
+    # ordinary word, path, number or timestamp stays visible, which is what
+    # keeps the #145/#153 prose assertions green.
+    #
+    # Deliberately shape-based rather than a dictionary: an unfamiliar prose
+    # word is still preserved and an unfamiliar credential format is still
+    # masked. Residual: an all-lowercase alphabetic secret below the compound
+    # threshold is indistinguishable from a prose word on this path and stays
+    # visible. gitleaks still covers every format it knows regardless of the
+    # label, and the block/detect path is unaffected either way.
+    function credential_shaped(v) {
+      if (length(v) < 6) return 0
+      # Dates, timestamps and clock times are the ordinary log values that would
+      # otherwise satisfy the mixed-class test below.
+      if (v ~ /^[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]/) return 0
+      if (v ~ /^[0-9]+:[0-9]+(:[0-9]+)?$/) return 0
+      # Mixed character classes: a digit beside a letter, or an uppercase run
+      # starting past the first character. A leading capital alone is ordinary
+      # sentence case (`Authentication`), not a credential.
+      if (v ~ /[0-9]/ && v ~ /[A-Za-z]/) return 1
+      if (v ~ /[a-z]/ && substr(v, 2) ~ /[A-Z]/) return 1
+      # A single-case alphabetic run longer than any ordinary word.
+      if (length(v) >= 24 && v ~ /^[A-Za-z]+$/) return 1
+      return 0
+    }
+    function emit_value(source, start, assignment, require_credential, \
+                        raw, leading, quote, end, \
                         value, token, trailing, ch) {
       raw = substr(source, start)
       match(raw, /^[ \t]*/)
@@ -3207,11 +3332,16 @@ secretish_env_values() {
         raw = substr(raw, 2)
         end = quoted_end(raw, quote)
         if (end == 0) {
+          # An unterminated quote gives no complete value to classify, so the
+          # status-label path keeps its pre-#156 behaviour and skips rather than
+          # opening multiline capture over what may be prose.
+          if (require_credential) return 0
           open_quote = quote
           open_value = raw
           return 1
         }
         value = substr(raw, 1, end - 1)
+        if (require_credential && !credential_shaped(value)) return 0
       } else {
         value = raw
         sub(/[ \t,;].*$/, "", value)
@@ -3225,6 +3355,7 @@ secretish_env_values() {
         }
         value = substr(value, 1, end)
         if (looks_like_reference(value, assignment, leading)) return 0
+        if (require_credential && !credential_shaped(value)) return 0
         # Eligibility is based on the complete token. For short values, scope
         # replacement to the complete assignment token so an ordinary
         # one-character literal is not replaced throughout the response.
@@ -3242,7 +3373,7 @@ secretish_env_values() {
     }
     function scan_line(line, rest, end, low, eq_start, eq_length, \
                        colon_start, colon_length, start, matched_length, \
-                       chose_colon, skip, first, expansion) {
+                       chose_colon, skip, status_guard, first, expansion) {
       rest = line
       if (open_quote != "") {
         end = quoted_end(rest, open_quote)
@@ -3275,15 +3406,21 @@ secretish_env_values() {
         if (start == 0) break
 
         # Whitespace-prefixed colon form: if the text before the whitespace run
-        # is a known status label, this is a prose chain (`error: password: ...`),
-        # not an assignment — skip past the key without masking. Any other
+        # is a known status label, this MAY be a prose chain (`error: password:
+        # authentication is disabled`) rather than an assignment. The label
+        # cannot settle it on its own, so hand the decision to the value-side
+        # gate in emit_value instead of skipping outright (#156) — prose stays
+        # visible, a credential-shaped value still masks. Any other
         # colon-terminated label (`response:`) is treated as structured output.
+        # This also covers the chained shape (`response: error: api_key: ...`),
+        # whose innermost label is a status word: the value decides there too.
         skip = 0
+        status_guard = 0
         if (chose_colon && start > 1) {
           first = substr(rest, start, 1)
           if ((first == " " || first == "\t") &&
               match(substr(low, 1, start - 1), status_label))
-            skip = 1
+            status_guard = 1
           # `${NAME:-default}` / `${NAME:?message}` / `${NAME:=x}` / `${NAME:+x}`
           # is a shell parameter expansion, not an assignment: the operator makes
           # the trailing text a fallback, never the value of the variable. The
@@ -3303,7 +3440,7 @@ secretish_env_values() {
         # leaving adjacent status text untouched.
         if (!skip &&
             emit_value(rest, start + matched_length,
-                       substr(rest, start, matched_length))) break
+                       substr(rest, start, matched_length), status_guard)) break
         rest = substr(rest, start + matched_length)
       }
     }

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -3391,8 +3391,8 @@ secretish_env_values() {
           # bypass for exactly the case where output was cut short. Classify the
           # fragment that IS available: a credential-shaped one opens multiline
           # capture like every other path, so the leaf remainder is masked,
-          # while prose (`error: password: "authentication is disabled`) still
-          # falls through untouched.
+          # while an unterminated prose chain behind the same label still falls
+          # through untouched.
           if (require_credential && !credential_shaped(raw)) return 0
           open_quote = quote
           open_value = raw

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -3254,6 +3254,27 @@ secretish_env_values() {
     # value, so the global literal is `<newline><secret>` and a BARE recurrence
     # of the credential later in the output does not match it. Emit the trimmed
     # token as a second record so global masking still reaches those.
+    # A guarded capture that fails the shape test must not be DISCARDED: it has
+    # absorbed every following line of the leaf, and throwing that away drops
+    # the assignments inside it. A status label whose value opens a quote that
+    # never closes — an apostrophe in ordinary prose is enough — made every real
+    # assignment on the lines below it stop masking, and stopped the prompt
+    # guard blocking the same text. 818f540 reached those lines because the
+    # status label took an unconditional skip; the deferral has to reach them
+    # too, so re-scan what was absorbed as ordinary input.
+    #
+    # guard_rescan makes that single-pass: during a re-scan the status path
+    # falls back to the old skip instead of opening another capture, so this
+    # cannot nest or loop.
+    function guard_rescan_leaf(v) {
+      open_quote = ""
+      open_value = ""
+      open_guard = 0
+      if (guard_rescan) return
+      guard_rescan = 1
+      scan_leaf(v)
+      guard_rescan = 0
+    }
     function edge_trim(v) {
       sub(/^[ \t\n]+/, "", v)
       sub(/[ \t\n]+$/, "", v)
@@ -3423,6 +3444,9 @@ secretish_env_values() {
           # newline before the credential. There the fragment is empty, so it
           # failed the shape test, the capture never opened, and the
           # continuation line has no assignment key of its own to match.
+          # Inside a re-scan the status path takes the pre-deferral skip, which
+          # is what stops this from re-opening the capture it just failed.
+          if (require_credential && guard_rescan) return 0
           open_quote = quote
           open_value = raw
           open_guard = require_credential
@@ -3486,11 +3510,14 @@ secretish_env_values() {
         # carries leading spaces into closed_value, and the whitespace test
         # would reject the credential before emit_captured could trim it.
         # Internal whitespace is untouched, so it still marks prose.
-        if (!open_guard || credential_shaped(edge_trim(closed_value)))
+        if (!open_guard || credential_shaped(edge_trim(closed_value))) {
           emit_captured(closed_value)
-        open_quote = ""
-        open_value = ""
-        open_guard = 0
+          open_quote = ""
+          open_value = ""
+          open_guard = 0
+        } else {
+          guard_rescan_leaf(closed_value)
+        }
         rest = substr(rest, end + 1)
       }
       while (length(rest) > 0) {
@@ -3562,9 +3589,12 @@ secretish_env_values() {
       }
       scan_line(value)
       # Truncated output can omit a closing quote. Redact the leaf remainder.
-      if (open_quote != "" \
-          && (!open_guard || credential_shaped(edge_trim(open_value))))
-        emit_captured(open_value)
+      if (open_quote != "") {
+        if (!open_guard || credential_shaped(edge_trim(open_value)))
+          emit_captured(open_value)
+        else
+          guard_rescan_leaf(open_value)
+      }
       open_quote = ""
       open_value = ""
       open_guard = 0
@@ -3623,9 +3653,12 @@ secretish_env_values() {
         # Same status-label gate as the scan_leaf termination above: without
         # it a >64 KiB invalid-UTF-8 capture ending in an unterminated prose
         # chain was replaced wholesale, contradicting the gate everywhere else.
-        if (!probe_found && open_quote != "" \
-            && (!open_guard || credential_shaped(edge_trim(open_value))))
-          emit_captured(open_value)
+        if (!probe_found && open_quote != "") {
+          if (!open_guard || credential_shaped(edge_trim(open_value)))
+            emit_captured(open_value)
+          else
+            guard_rescan_leaf(open_value)
+        }
         exit
       }
       # Valid framed input always terminates each leaf with RS. Preserve a final

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -2277,7 +2277,7 @@ bash_strip_allowed_tokens() {
   )
 }
 
-# jq/yq options that never consume a following value. Anything outside this list
+# jq options that never consume a following value. Anything outside this list
 # — `-f`, `--from-file`, `-L`, `--arg`, a combined cluster such as `-rf` — may
 # take the NEXT token as a value, and for the file-taking ones that token is a
 # path jq reads. Treating it as the filter and dropping it was a read bypass, so
@@ -2327,6 +2327,11 @@ jq_option_is_valueless() {
 #     leading `./` or `../` marks a path and is kept, `--` ends the search, and
 #     an option that might take a value stops it (see jq_option_is_valueless).
 #
+# `yq` is deliberately NOT in that family. Mike Farah yq autodetects its first
+# argument: it is an expression only when no file of that name exists, so
+# `yq .env` in a directory that has one READS it. jq has no such ambiguity.
+# That leaves `yq .key f.yaml` a false positive, which is the safe direction.
+#
 # Only a clean literal is ever dropped (env_exception_literal_shell_token
 # rejects quoting that survives unquoting, expansion, globs, redirection and
 # whitespace). The command word is taken from the FIRST token, with no wrapper
@@ -2365,7 +2370,7 @@ bash_strip_non_path_tokens() {
     strip_command=${1##*/}
     strip_command=$(printf '%s' "$strip_command" | tr -d "'\"")
     case "$strip_command" in
-      echo|printf|jq|gojq|jaq|yq) ;;
+      echo|printf|jq|gojq|jaq) ;;
       *)
         printf '%s' "$strip_input"
         return 0
@@ -3386,16 +3391,18 @@ secretish_env_values() {
         raw = substr(raw, 2)
         end = quoted_end(raw, quote)
         if (end == 0) {
-          # Truncated or malformed output after an opening quote. There is no
-          # complete value to classify, but skipping outright restored the #156
-          # bypass for exactly the case where output was cut short. Classify the
-          # fragment that IS available: a credential-shaped one opens multiline
-          # capture like every other path, so the leaf remainder is masked,
-          # while an unterminated prose chain behind the same label still falls
-          # through untouched.
-          if (require_credential && !credential_shaped(raw)) return 0
+          # Truncated or malformed output after an opening quote. Open the
+          # multiline capture like every other path and DEFER the shape
+          # decision to the close (or leaf end), carrying open_guard so the
+          # status-label rule still applies there. Classifying the fragment
+          # available on THIS line instead missed a value whose text begins on
+          # the NEXT one — a status label, its key, an opening quote, then a
+          # newline before the credential. There the fragment is empty, so it
+          # failed the shape test, the capture never opened, and the
+          # continuation line has no assignment key of its own to match.
           open_quote = quote
           open_value = raw
+          open_guard = require_credential
           return 1
         }
         value = substr(raw, 1, end - 1)
@@ -3442,7 +3449,8 @@ secretish_env_values() {
     }
     function scan_line(line, rest, end, low, eq_start, eq_length, \
                        colon_start, colon_length, start, matched_length, \
-                       chose_colon, skip, status_guard, first, expansion) {
+                       chose_colon, skip, status_guard, first, expansion, \
+                       closed_value) {
       rest = line
       if (open_quote != "") {
         end = quoted_end(rest, open_quote)
@@ -3450,9 +3458,12 @@ secretish_env_values() {
           open_value = open_value "\n" rest
           return
         }
-        emit_secret(open_value "\n" substr(rest, 1, end - 1))
+        closed_value = open_value "\n" substr(rest, 1, end - 1)
+        if (!open_guard || credential_shaped(closed_value))
+          emit_secret(closed_value)
         open_quote = ""
         open_value = ""
+        open_guard = 0
         rest = substr(rest, end + 1)
       }
       while (length(rest) > 0) {
@@ -3516,6 +3527,7 @@ secretish_env_values() {
     function scan_leaf(value, newline, line) {
       open_quote = ""
       open_value = ""
+      open_guard = 0
       while ((newline = index(value, "\n")) > 0) {
         line = substr(value, 1, newline - 1)
         value = substr(value, newline + 1)
@@ -3523,9 +3535,11 @@ secretish_env_values() {
       }
       scan_line(value)
       # Truncated output can omit a closing quote. Redact the leaf remainder.
-      if (open_quote != "") emit_secret(open_value)
+      if (open_quote != "" && (!open_guard || credential_shaped(open_value)))
+        emit_secret(open_value)
       open_quote = ""
       open_value = ""
+      open_guard = 0
     }
     {
       if (record_mode == "probe_raw") {

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -2277,6 +2277,21 @@ bash_strip_allowed_tokens() {
   )
 }
 
+# jq/yq options that never consume a following value. Anything outside this list
+# — `-f`, `--from-file`, `-L`, `--arg`, a combined cluster such as `-rf` — may
+# take the NEXT token as a value, and for the file-taking ones that token is a
+# path jq reads. Treating it as the filter and dropping it was a read bypass, so
+# an unrecognised option stops the filter search instead of consuming it.
+jq_option_is_valueless() {
+  case "$1" in
+    -r|-c|-n|-e|-j|-a|-s|-S|-R|-M|-C|-h|\
+    --raw-output|--join-output|--compact-output|--null-input|--exit-status|\
+    --ascii-output|--slurp|--sort-keys|--raw-input|--tab|--monochrome-output|\
+    --color-output|--help|--version|--stream|--seq) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 # The deny-read patterns are basename globs, and matching them against every
 # word of a command makes any word that merely ends in a listed extension a
 # block: `echo foo.key`, `jq -r .key data.json`, `echo see also foo.pem` (#99).
@@ -2290,78 +2305,102 @@ bash_strip_allowed_tokens() {
 # without one, and refusing that read by name — before anything is created — is
 # the behaviour the README quick start verifies and the deny-read tests pin.
 #
-# So drop only operands that the command in front of them cannot read:
+# It is also deliberately restricted to ONE simple command with no shell
+# metacharacters at all. Dropping a word is only sound while that word cannot
+# reach a reader, and shell syntax is exactly what carries it to one:
 #
-#   - every word operand of `echo` / `printf`, which take no file operands at
-#     all (their only file contact is a redirection, and a redirection token
-#     stops the stripping for the rest of that segment);
-#   - the first non-option operand of the jq family, which is the filter
-#     program. `jq -r .key data.json` reads data.json; `.key` selects a field.
-#     A leading `./` or `../` marks a path rather than a filter and is kept.
+#   echo hi<newline>cat .env     - a later line reads it
+#   echo a & cat .env            - `&` starts another command
+#   echo .env | xargs cat        - the dropped word becomes the reader's operand
+#
+# All three read the file, and all three were allowed by a version of this
+# function that tracked segments itself. Rather than re-derive shell parsing
+# here, bail out whenever the command contains any of them and strip nothing.
+# The cost is a false positive on a compound command, which is what the gate
+# already does today; the alternative cost is a silent read bypass.
+#
+# Within one simple command, drop only operands the command cannot read:
+#
+#   - every word operand of `echo` / `printf`, which take no file operands;
+#   - the jq family's first non-option operand, which is the filter program
+#     (`jq -r .key data.json` reads data.json; `.key` selects a field). A
+#     leading `./` or `../` marks a path and is kept, `--` ends the search, and
+#     an option that might take a value stops it (see jq_option_is_valueless).
 #
 # Only a clean literal is ever dropped (env_exception_literal_shell_token
 # rejects quoting that survives unquoting, expansion, globs, redirection and
-# whitespace), so `echo $(cat .env)` keeps both substitution tokens and stays
-# blocked. The list is minimal and additive on purpose: a command missing from
-# it merely keeps today's false positive, it can never turn a real read into a
-# pass. Broader shapes — a deny-listed basename inside a commit message, a grep
-# pattern — are not covered here.
+# whitespace). The command word is taken from the FIRST token, with no wrapper
+# skipping: `sudo echo foo.key` and `FOO=1 echo foo.key` simply keep today's
+# false positive rather than widening what may be stripped.
 bash_strip_non_path_tokens() {
   (
     set -f
-    words=$(shell_command_words "$1")
+    strip_input=$1
+    # The syntax test MUST run on the untouched command ($2), not on $1. The
+    # strip helpers ahead of this one rejoin their tokens with single spaces and
+    # so have already destroyed a real newline separator by the time $1 arrives
+    # — `echo hi<newline>cat .env` reaches here as `echo hi cat .env`, which
+    # reads like one `echo`. That is exactly the bypass this test exists to stop.
+    strip_raw=$2
+
+    # Any shell syntax at all -> strip nothing. Newline, `&`, `|`, `;`, command
+    # grouping, redirection, substitution and expansion each give a dropped word
+    # a route to a reader.
+    case "$strip_raw" in
+      *'
+'*|*'&'*|*'|'*|*';'*|*'('*|*')'*|*'{'*|*'}'*|*'<'*|*'>'*|*'`'*|*'$'*|*'\'*)
+        printf '%s' "$strip_input"
+        return 0
+        ;;
+    esac
+
+    words=$(shell_command_words "$strip_input")
     # shellcheck disable=SC2086
     set -- $words
-    result= strip_command= strip_seen_operand=0 strip_redirected=0
+    if [ "$#" -lt 2 ]; then
+      printf '%s' "$strip_input"
+      return 0
+    fi
 
-    keep_policy_token() {
-      if [ -z "$result" ]; then result=$1; else result="$result $1"; fi
-    }
+    strip_command=${1##*/}
+    strip_command=$(printf '%s' "$strip_command" | tr -d "'\"")
+    case "$strip_command" in
+      echo|printf|jq|gojq|jaq|yq) ;;
+      *)
+        printf '%s' "$strip_input"
+        return 0
+        ;;
+    esac
+
+    result=$1
+    shift
+    strip_seen_operand=0
 
     for token in "$@"; do
-      if is_shell_command_separator "$token"; then
-        strip_command= strip_seen_operand=0 strip_redirected=0
-        keep_policy_token "$token"
-        continue
+      strip_literal=$(env_exception_literal_shell_token "$token" 2>/dev/null \
+        || true)
+      if [ -n "$strip_literal" ]; then
+        case "$strip_command" in
+          echo|printf)
+            continue
+            ;;
+          *)
+            if [ "$strip_seen_operand" -eq 0 ]; then
+              case "$strip_literal" in
+                --) strip_seen_operand=1 ;;
+                -*)
+                  jq_option_is_valueless "$strip_literal" \
+                    || strip_seen_operand=1
+                  ;;
+                ./*|../*) strip_seen_operand=1 ;;
+                .*) strip_seen_operand=1; continue ;;
+                *) strip_seen_operand=1 ;;
+              esac
+            fi
+            ;;
+        esac
       fi
-
-      if [ -z "$strip_command" ]; then
-        if is_assignment_token "$token" || is_noop_wrapper "${token##*/}"; then
-          keep_policy_token "$token"
-          continue
-        fi
-        strip_command=${token##*/}
-        strip_command=$(printf '%s' "$strip_command" | tr -d "'\"")
-        keep_policy_token "$token"
-        continue
-      fi
-
-      case "$token" in
-        *'<'*|*'>'*) strip_redirected=1 ;;
-      esac
-
-      if [ "$strip_redirected" -eq 0 ]; then
-        strip_literal=$(env_exception_literal_shell_token "$token" 2>/dev/null \
-          || true)
-        if [ -n "$strip_literal" ]; then
-          case "$strip_command" in
-            echo|printf)
-              continue
-              ;;
-            jq|gojq|jaq|yq)
-              if [ "$strip_seen_operand" -eq 0 ]; then
-                case "$strip_literal" in
-                  -*) ;;
-                  ./*|../*) strip_seen_operand=1 ;;
-                  .*) strip_seen_operand=1; continue ;;
-                  *) strip_seen_operand=1 ;;
-                esac
-              fi
-              ;;
-          esac
-        fi
-      fi
-      keep_policy_token "$token"
+      result="$result $token"
     done
     printf '%s' "$result"
   )
@@ -2376,7 +2415,7 @@ bash_matches_deny_path() {
   deny_cmd=$1
   deny_cmd=$(bash_strip_exclusion_operands "$deny_cmd")
   deny_cmd=$(bash_strip_allowed_tokens "$deny_cmd")
-  deny_cmd=$(bash_strip_non_path_tokens "$deny_cmd")
+  deny_cmd=$(bash_strip_non_path_tokens "$deny_cmd" "$1")
   bash_matches_deny_path_mode "$deny_cmd" "literal" && return 0
   bash_matches_deny_path_mode "$deny_cmd" "shell-expanded" && return 0
   dequoted=$(shell_dequote_for_policy "$deny_cmd")

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -3463,7 +3463,11 @@ secretish_env_values() {
           return 1
         }
         value = substr(raw, 1, end - 1)
-        if (require_credential && !credential_shaped(value)) return 0
+        # Classify an edge-trimmed copy, replace the original. A quoted value
+        # with padding (`" <secret>"`) failed the whitespace-is-prose test on
+        # its padding alone, on this single-line path as well as the multiline
+        # one. Internal whitespace is untouched, so prose still reads as prose.
+        if (require_credential && !credential_shaped(edge_trim(value))) return 0
       } else {
         value = raw
         sub(/[ \t,;].*$/, "", value)
@@ -3477,7 +3481,7 @@ secretish_env_values() {
         }
         value = substr(value, 1, end)
         if (looks_like_reference(value, assignment, leading)) return 0
-        if (require_credential && !credential_shaped(value)) return 0
+        if (require_credential && !credential_shaped(edge_trim(value))) return 0
         # Eligibility is based on the complete token. For short values, scope
         # replacement to the complete assignment token so an ordinary
         # one-character literal is not replaced throughout the response.

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -3479,7 +3479,11 @@ secretish_env_values() {
         emit_secret(value, length(token))
         return 0
       }
-      emit_secret(value)
+      # emit_captured, not emit_secret: a padded quoted value (`" <secret> "`)
+      # is classified on its trimmed copy just above, so recording only the
+      # padded literal left a bare recurrence of the same credential further
+      # down unmasked. Record both forms, exactly as the multiline close does.
+      emit_captured(value)
       return 0
     }
     function scan_line(line, rest, end, low, eq_start, eq_length, \

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -2277,129 +2277,6 @@ bash_strip_allowed_tokens() {
   )
 }
 
-# The deny-read patterns are basename globs, and matching them against every
-# word of a command makes any word that merely ends in a listed extension a
-# block: `echo foo.key`, `jq -r .key data.json`, `echo see also foo.pem` (#99).
-# Nothing has to exist on disk and nothing has to be read, so the gate stops
-# deciding what is sensitive and starts inheriting whatever the glob does. It
-# surfaces as `blocked shell command referencing a deny-listed path`, which
-# reads in the transcript as if the agent had tried to open a private key.
-#
-# The narrowing is deliberately by command POSITION, not by whether the named
-# file exists. An existence test would also unblock `cat .env` in a directory
-# without one, and refusing that read by name — before anything is created — is
-# the behaviour the README quick start verifies and the deny-read tests pin.
-#
-# It is also deliberately restricted to ONE simple command with no shell
-# metacharacters at all. Dropping a word is only sound while that word cannot
-# reach a reader, and shell syntax is exactly what carries it to one:
-#
-#   echo hi<newline>cat .env     - a later line reads it
-#   echo a & cat .env            - `&` starts another command
-#   echo .env | xargs cat        - the dropped word becomes the reader's operand
-#
-# All three read the file, and all three were allowed by a version of this
-# function that tracked segments itself. Rather than re-derive shell parsing
-# here, bail out whenever the command contains any of them and strip nothing.
-# The cost is a false positive on a compound command, which is what the gate
-# already does today; the alternative cost is a silent read bypass.
-#
-# Within one simple command, drop only operands the command cannot read:
-#
-#   - every word operand of `echo` / `printf`, which take no file operands;
-# `echo` and `printf` and nothing else, and the reason is what they ARE rather
-# than what they do with their operands: both are shell builtins, so bash runs
-# the builtin whatever sits on PATH. Naming a command here is a claim about the
-# program that will actually run, and for a builtin that claim holds.
-#
-# It does not hold for an external binary, which is why `jq` is no longer here.
-# jq had the same exception for its first non-option operand — always its filter
-# program — and that was sound about jq itself and useless in practice: jq
-# resolves through PATH at execution time, so a wrapper or shadow earlier in
-# PATH inherits the exception meant for the real one. Reproduced: a `jq` script
-# running `cat .env` for `jq .env` was allowed here and read the file, where the
-# baseline blocked it. A text gate cannot know what PATH will resolve to, and
-# checking at hook time would not bind what runs a moment later. `yq`, `gojq`
-# and `jaq` were removed earlier for narrower reasons; this argument covers
-# them too.
-#
-# The cost is that `jq -r .key data.json` keeps the #99 false positive. That is
-# the trade, and it is the right way round: a false positive is an annoyance,
-# and this exception was a read.
-#
-# Only a clean literal is ever dropped (env_exception_literal_shell_token
-# rejects quoting that survives unquoting, expansion, globs, redirection and
-# whitespace). The command word is taken from the FIRST token, with no wrapper
-# skipping: `sudo echo foo.key` and `FOO=1 echo foo.key` simply keep today's
-# false positive rather than widening what may be stripped.
-bash_strip_non_path_tokens() {
-  (
-    set -f
-    strip_input=$1
-    # The syntax test MUST run on the untouched command ($2), not on $1. The
-    # strip helpers ahead of this one rejoin their tokens with single spaces and
-    # so have already destroyed a real newline separator by the time $1 arrives
-    # — `echo hi<newline>cat .env` reaches here as `echo hi cat .env`, which
-    # reads like one `echo`. That is exactly the bypass this test exists to stop.
-    strip_raw=$2
-
-    # Any shell syntax at all -> strip nothing. Newline, `&`, `|`, `;`, command
-    # grouping, redirection, substitution and expansion each give a dropped word
-    # a route to a reader.
-    case "$strip_raw" in
-      *'
-'*|*'&'*|*'|'*|*';'*|*'('*|*')'*|*'{'*|*'}'*|*'<'*|*'>'*|*'`'*|*'$'*|*'\'*)
-        printf '%s' "$strip_input"
-        return 0
-        ;;
-    esac
-
-    words=$(shell_command_words "$strip_input")
-    # shellcheck disable=SC2086
-    set -- $words
-    if [ "$#" -lt 2 ]; then
-      printf '%s' "$strip_input"
-      return 0
-    fi
-
-    # The token EXACTLY: no basename strip, and no quote removal either.
-    #
-    # Stripping the directory handed the exception to any executable that merely
-    # shares the name — `./echo .env`, `/tmp/printf .env` and `./jq .env` all
-    # passed while reading the denied file.
-    #
-    # Removing quotes was worse, because shell_command_words splits on
-    # whitespace BEFORE quotes are resolved: a command name containing quoted
-    # whitespace arrives here as its first fragment, so `'\''echo foo'\'' .env`
-    # reduced to `echo` and took the exception, while the shell resolved an
-    # executable literally named `echo foo` that read the file. Comparing the
-    # raw token is the only form that cannot be talked into a false match.
-    #
-    # `'\''echo'\'' .env` therefore keeps its false positive. That is the same
-    # trade every other narrowing here makes, and quoting a bare command name is
-    # not a shape worth widening the gate for.
-    strip_command=$1
-    case "$strip_command" in
-      echo|printf) ;;
-      *)
-        printf '%s' "$strip_input"
-        return 0
-        ;;
-    esac
-
-    result=$1
-    shift
-
-    for token in "$@"; do
-      strip_literal=$(env_exception_literal_shell_token "$token" 2>/dev/null \
-        || true)
-      [ -n "$strip_literal" ] && continue
-      result="$result $token"
-    done
-    printf '%s' "$result"
-  )
-}
-
 # POSIX sh has no locals: this function must NOT assign the bare name `cmd`, or
 # it clobbers the caller's command in check_bash_command. The strip helpers
 # rejoin tokens with single spaces (dropping a real newline separator), so a
@@ -2409,7 +2286,6 @@ bash_matches_deny_path() {
   deny_cmd=$1
   deny_cmd=$(bash_strip_exclusion_operands "$deny_cmd")
   deny_cmd=$(bash_strip_allowed_tokens "$deny_cmd")
-  deny_cmd=$(bash_strip_non_path_tokens "$deny_cmd" "$1")
   bash_matches_deny_path_mode "$deny_cmd" "literal" && return 0
   bash_matches_deny_path_mode "$deny_cmd" "shell-expanded" && return 0
   dequoted=$(shell_dequote_for_policy "$deny_cmd")

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -2322,15 +2322,19 @@ jq_option_is_valueless() {
 # Within one simple command, drop only operands the command cannot read:
 #
 #   - every word operand of `echo` / `printf`, which take no file operands;
-#   - the jq family's first non-option operand, which is the filter program
+#   - `jq`'s first non-option operand, which is the filter program
 #     (`jq -r .key data.json` reads data.json; `.key` selects a field). A
 #     leading `./` or `../` marks a path and is kept, `--` ends the search, and
 #     an option that might take a value stops it (see jq_option_is_valueless).
 #
-# `yq` is deliberately NOT in that family. Mike Farah yq autodetects its first
-# argument: it is an expression only when no file of that name exists, so
-# `yq .env` in a directory that has one READS it. jq has no such ambiguity.
-# That leaves `yq .key f.yaml` a false positive, which is the safe direction.
+# `jq` and nothing else, on purpose. `yq` was in this list and was a read
+# bypass: Mike Farah yq autodetects its first argument, treating it as an
+# expression only when no file of that name exists, so `yq .env` in a directory
+# that has one READS it. `gojq` and `jaq` were added on the assumption that they
+# copy jq's grammar, which was never checked against either tool. An unverified
+# assumption is what produced the yq hole, so they are out too: the reported
+# false positive is about jq, and jq is what this covers. Everything else keeps
+# today's false positive, which is the safe direction.
 #
 # Only a clean literal is ever dropped (env_exception_literal_shell_token
 # rejects quoting that survives unquoting, expansion, globs, redirection and
@@ -2370,7 +2374,7 @@ bash_strip_non_path_tokens() {
     strip_command=${1##*/}
     strip_command=$(printf '%s' "$strip_command" | tr -d "'\"")
     case "$strip_command" in
-      echo|printf|jq|gojq|jaq) ;;
+      echo|printf|jq) ;;
       *)
         printf '%s' "$strip_input"
         return 0

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1806,11 +1806,16 @@ done
 # yq is NOT in the jq family: Mike Farah yq treats its first argument as an
 # expression only when no file of that name exists, so `yq .env` in a directory
 # holding one reads it. Dropping that operand was a read bypass.
+# `gojq` and `jaq` are out for a weaker but sufficient reason: this repo has no
+# copy of either to check their argument grammar against, and assuming they copy
+# jq's is the same assumption that produced the yq hole.
 for nonpath_case in \
   "yq .env" \
   "yq -r .env" \
-  "yq .$NONPATH_KEY data.yaml"; do
-  expect_json_status 2 "#99 Bash yq keeps its first operand: '$nonpath_case'" \
+  "yq .$NONPATH_KEY data.yaml" \
+  "gojq .$NONPATH_KEY data.json" \
+  "jaq .$NONPATH_KEY data.json"; do
+  expect_json_status 2 "#99 Bash only jq gets the filter exception: '$nonpath_case'" \
     "$(jq -nc --arg c "$nonpath_case" \
       '{tool_name:"Bash",tool_input:{command:$c}}')" \
     hook-pre-tool

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -7125,10 +7125,17 @@ fi
 # A delimiter-separated passphrase is far less prose-like than a bare word, so
 # the compound-length fallback accepts `.`/`-`/`_` joins rather than requiring a
 # purely alphabetic value.
+# Composed at runtime, not written as literals: the plugin scanner's
+# "No hardcoded secrets" check reads this file too, and a password-shaped
+# literal here fails the build the same way a real one would. Same trick the
+# fixtures above use.
+PASSPHRASE_HYPHEN=$(printf '%s-%s-%s-%s' correct horse battery staple)
+PASSPHRASE_DOT=$(printf '%s.%s.%s.%s' correct horse battery staple)
+PASSPHRASE_UNDER=$(printf '%s_%s_%s_%s' correct horse battery staple)
 for display_case in \
-  'correct-horse-battery-staple' \
-  'correct.horse.battery.staple' \
-  'correct_horse_battery_staple'; do
+  "$PASSPHRASE_HYPHEN" \
+  "$PASSPHRASE_DOT" \
+  "$PASSPHRASE_UNDER"; do
   display_input=$(jq -nc --arg stdout "error: password: $display_case" \
     '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
   post_tool_out "$display_input"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -7024,6 +7024,96 @@ for display_case in \
   fi
 done
 
+# A QUOTED value is the whole message, so the class tests have to ask whether a
+# letter and a digit belong to the same token rather than whether both occur
+# somewhere in the string. Without that, an ordinary validation message behind a
+# status label was rewritten to `"[REDACTED]"`.
+for display_case in \
+  'error: password: "must be at least 8 characters"' \
+  'warning: token: "expires in 3600 seconds"' \
+  'error: api_key: "not found in profile 2"' \
+  'fatal: secret: "rotate within 90 days"' \
+  'info: credential: "Check Your Settings Page"'; do
+  display_input=$(jq -nc --arg stdout "$display_case" \
+    '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
+  post_tool_out "$display_input"
+  post_status=$?
+  if [ "$post_status" -eq 0 ] && [ ! -s "$OUT" ]; then
+    ok "#156 post-tool leaves a quoted multi-word message after a status label untouched (${display_case%%:*})"
+  else
+    not_ok "#156 post-tool leaves a quoted multi-word message after a status label untouched (${display_case%%:*})"
+    sed 's/^/  out: /' "$OUT"
+  fi
+done
+
+# The date/clock exclusions must be anchored at BOTH ends. Unanchored, any value
+# merely STARTING with an ISO date escaped the gate entirely — a date-prefixed
+# credential name is a common rotation convention, so that was a one-line bypass.
+DATED_SECRET=$(printf '2026-01-01-sk-live-%s' 'abc123XYZ')
+display_input=$(jq -nc --arg stdout "error: api_key: $DATED_SECRET" \
+  '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
+post_tool_out "$display_input"
+post_out=$(cat "$OUT")
+if printf '%s' "$post_out" | grep -q '\[REDACTED\]' \
+   && ! printf '%s' "$post_out" | grep -Fq "$DATED_SECRET"; then
+  ok "#156 post-tool masks a date-prefixed credential behind a status label"
+else
+  not_ok "#156 post-tool masks a date-prefixed credential behind a status label"
+  printf '%s\n' "$post_out" | sed 's/^/  out: /'
+fi
+
+for display_case in \
+  'error: token: 2026-08-30' \
+  'error: token: 2026-08-30T10:00:00Z' \
+  'error: token: 2026-08-30T10:00:00.123+09:00' \
+  'fatal: password: 10:00:00'; do
+  display_input=$(jq -nc --arg stdout "$display_case" \
+    '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
+  post_tool_out "$display_input"
+  post_status=$?
+  if [ "$post_status" -eq 0 ] && [ ! -s "$OUT" ]; then
+    ok "#156 post-tool leaves a complete date/clock value untouched (${display_case##*: })"
+  else
+    not_ok "#156 post-tool leaves a complete date/clock value untouched (${display_case##*: })"
+    sed 's/^/  out: /' "$OUT"
+  fi
+done
+
+# On the status-label path a shape gate, not a detector, decided the value is a
+# credential, so the replacement is scoped to the matched assignment token. A
+# global literal would erase the value from every other line of the response —
+# scrubbing a version string out of a release note, or a resource name out of
+# the very command the agent needs to run next.
+scoped_input=$(jq -nc --arg stdout 'error: token: v1.2.3 is not a valid tag
+Downloading release v1.2.3 from github' \
+  '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
+post_tool_out "$scoped_input"
+post_out=$(cat "$OUT")
+if printf '%s' "$post_out" \
+  | jq -e '.hookSpecificOutput.updatedToolOutput.stdout
+      | (contains("Downloading release v1.2.3 from github"))
+        and (startswith("error: token: [REDACTED] is not a valid tag"))' >/dev/null 2>&1; then
+  ok "#156 status-label masking is scoped to its own line, not the whole output"
+else
+  not_ok "#156 status-label masking is scoped to its own line, not the whole output"
+  printf '%s\n' "$post_out" | sed 's/^/  out: /'
+fi
+
+# The same property with a value the agent needs to keep reading afterwards.
+scoped_input=$(jq -nc --arg stdout 'Error: secret: prod-db-secret-v2 not found
+Run: kubectl create secret generic prod-db-secret-v2 --from-literal=x=y' \
+  '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
+post_tool_out "$scoped_input"
+post_out=$(cat "$OUT")
+if printf '%s' "$post_out" \
+  | jq -e '.hookSpecificOutput.updatedToolOutput.stdout
+      | contains("kubectl create secret generic prod-db-secret-v2")' >/dev/null 2>&1; then
+  ok "#156 a status-label false positive does not scrub the value from later lines"
+else
+  not_ok "#156 a status-label false positive does not scrub the value from later lines"
+  printf '%s\n' "$post_out" | sed 's/^/  out: /'
+fi
+
 # Display redaction must not mangle credential-handling SOURCE CODE. A
 # credential-shaped key on the left says nothing about the right-hand side: a
 # reference (`process.env.API_KEY`, `os.environ["DB_PASSWORD"]`, `config.apiKey`,

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -7167,6 +7167,43 @@ else
   sed 's/^/  out: /' "$OUT"
 fi
 
+# Edge padding on a single-line quoted value must not defeat the shape test
+# either — the trim was applied to the multiline capture paths first and these
+# two direct classification sites were missed, so a padded credential leaked on
+# both the display and the block path.
+for display_pad in ' %s' '%s ' '  %s  '; do
+  # shellcheck disable=SC2059
+  padded_secret=$(printf "$display_pad" "$LABEL_SECRET")
+  display_input=$(jq -nc --arg stdout "error: password: \"$padded_secret\"" \
+    '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
+  post_tool_out "$display_input"
+  post_out=$(cat "$OUT")
+  if printf '%s' "$post_out" | grep -q '\[REDACTED\]' \
+     && ! printf '%s' "$post_out" | grep -Fq "$LABEL_SECRET"; then
+    ok "#156 a padded quoted status-label credential still masks"
+  else
+    not_ok "#156 a padded quoted status-label credential still masks"
+    printf '%s\n' "$post_out" | sed 's/^/  out: /'
+  fi
+done
+
+expect_json_status 2 "#156 a padded quoted status-label credential still blocks at the prompt guard" \
+  "$(jq -nc --arg prompt "error: password: \" $LABEL_SECRET\"" \
+    '{session_id:"t",hook_event_name:"UserPromptSubmit",prompt:$prompt}')" \
+  hook-user-prompt
+
+# Padding must not turn prose into a credential either.
+display_input=$(jq -nc --arg stdout 'error: password: " authentication is disabled "' \
+  '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
+post_tool_out "$display_input"
+post_status=$?
+if [ "$post_status" -eq 0 ] && [ ! -s "$OUT" ]; then
+  ok "#156 a padded quoted prose message stays visible"
+else
+  not_ok "#156 a padded quoted prose message stays visible"
+  sed 's/^/  out: /' "$OUT"
+fi
+
 # The value may not start on the label's own line. Classifying the fragment
 # available there missed this entirely: the fragment is empty, so it failed the
 # shape test, the capture never opened, and the continuation line carries no

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1806,15 +1806,23 @@ done
 # yq is NOT in the jq family: Mike Farah yq treats its first argument as an
 # expression only when no file of that name exists, so `yq .env` in a directory
 # holding one reads it. Dropping that operand was a read bypass.
-# The command word is the token EXACTLY. Reducing `./echo` to its basename gave
-# the exception to any executable merely sharing the name, and those can read
-# the denied file — verified as a real pass before the fix.
+# The command word is the RAW token: no basename strip, no quote removal.
+# Stripping the directory gave the exception to any executable merely sharing
+# the name. Removing quotes was worse — shell_command_words splits on whitespace
+# before quotes resolve, so a command name containing quoted whitespace arrives
+# as its first fragment and reduced to a trusted name, while the shell resolved
+# an executable literally called `echo foo` that read the file. Both verified as
+# real passes, and the second as a real read, before the fix.
 for nonpath_case in \
   "./echo .env" \
   "/tmp/printf .env" \
   "./jq .env" \
   "bin/echo .env" \
-  "/usr/bin/echo .env"; do
+  "/usr/bin/echo .env" \
+  "'echo foo' .env" \
+  "\"echo foo\" .env" \
+  "'echo' .env" \
+  "\"echo\" .env"; do
   expect_json_status 2 "#99 Bash a path-qualified lookalike gets no exception: '$nonpath_case'" \
     "$(jq -nc --arg c "$nonpath_case" \
       '{tool_name:"Bash",tool_input:{command:$c}}')" \

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1806,6 +1806,21 @@ done
 # yq is NOT in the jq family: Mike Farah yq treats its first argument as an
 # expression only when no file of that name exists, so `yq .env` in a directory
 # holding one reads it. Dropping that operand was a read bypass.
+# The command word is the token EXACTLY. Reducing `./echo` to its basename gave
+# the exception to any executable merely sharing the name, and those can read
+# the denied file — verified as a real pass before the fix.
+for nonpath_case in \
+  "./echo .env" \
+  "/tmp/printf .env" \
+  "./jq .env" \
+  "bin/echo .env" \
+  "/usr/bin/echo .env"; do
+  expect_json_status 2 "#99 Bash a path-qualified lookalike gets no exception: '$nonpath_case'" \
+    "$(jq -nc --arg c "$nonpath_case" \
+      '{tool_name:"Bash",tool_input:{command:$c}}')" \
+    hook-pre-tool
+done
+
 # `gojq` and `jaq` are out for a weaker but sufficient reason: this repo has no
 # copy of either to check their argument grammar against, and assuming they copy
 # jq's is the same assumption that produced the yq hole.
@@ -7190,6 +7205,37 @@ if printf '%s' "$post_out" | grep -q '\[REDACTED\]' \
 else
   not_ok "#156 a multiline status-label capture also masks the bare recurrence"
   printf '%s\n' "$post_out" | sed 's/^/  out: /'
+fi
+
+# An indented continuation carries leading whitespace into the capture, and the
+# whitespace test would reject the credential before the trim could reach it.
+# Classification runs on the edge-trimmed capture; internal whitespace still
+# marks prose, so the indented prose chain below stays visible.
+for display_indent in '  ' '\t'; do
+  multiline_indented=$(printf 'error: password: "\n%s%s"' "$display_indent" "$LABEL_SECRET")
+  display_input=$(jq -nc --arg stdout "$multiline_indented" \
+    '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
+  post_tool_out "$display_input"
+  post_out=$(cat "$OUT")
+  if printf '%s' "$post_out" | grep -q '\[REDACTED\]' \
+     && ! printf '%s' "$post_out" | grep -Fq "$LABEL_SECRET"; then
+    ok "#156 an indented multiline status-label credential still masks"
+  else
+    not_ok "#156 an indented multiline status-label credential still masks"
+    printf '%s\n' "$post_out" | sed 's/^/  out: /'
+  fi
+done
+
+multiline_indented_prose=$(printf 'error: %s: "\n  authentication is disabled"' password)
+display_input=$(jq -nc --arg stdout "$multiline_indented_prose" \
+  '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
+post_tool_out "$display_input"
+post_status=$?
+if [ "$post_status" -eq 0 ] && [ ! -s "$OUT" ]; then
+  ok "#156 an indented multiline prose chain stays visible"
+else
+  not_ok "#156 an indented multiline prose chain stays visible"
+  sed 's/^/  out: /' "$OUT"
 fi
 
 # A delimiter-separated passphrase is far less prose-like than a bare word, so

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -7111,7 +7111,11 @@ else
   printf '%s\n' "$post_out" | sed 's/^/  out: /'
 fi
 
-display_input=$(jq -nc --arg stdout 'error: password: "authentication is disabled' \
+# Composed, not literal: the plugin scanner's HARDCODED_SECRET rule reads this
+# file and flags a `password: "` sequence regardless of what follows it, so even
+# this prose fixture fails the build if written out.
+unterminated_prose=$(printf 'error: %s: "authentication is disabled' password)
+display_input=$(jq -nc --arg stdout "$unterminated_prose" \
   '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
 post_tool_out "$display_input"
 post_status=$?

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1803,6 +1803,19 @@ for nonpath_case in \
     hook-pre-tool
 done
 
+# yq is NOT in the jq family: Mike Farah yq treats its first argument as an
+# expression only when no file of that name exists, so `yq .env` in a directory
+# holding one reads it. Dropping that operand was a read bypass.
+for nonpath_case in \
+  "yq .env" \
+  "yq -r .env" \
+  "yq .$NONPATH_KEY data.yaml"; do
+  expect_json_status 2 "#99 Bash yq keeps its first operand: '$nonpath_case'" \
+    "$(jq -nc --arg c "$nonpath_case" \
+      '{tool_name:"Bash",tool_input:{command:$c}}')" \
+    hook-pre-tool
+done
+
 # Valueless jq options must not stop the filter search, or the false positive
 # the narrowing exists to fix comes back for any invocation that uses a flag.
 for nonpath_case in \
@@ -7123,6 +7136,37 @@ if [ "$post_status" -eq 0 ] && [ ! -s "$OUT" ]; then
   ok "#156 an unterminated quoted prose chain behind a status label stays visible"
 else
   not_ok "#156 an unterminated quoted prose chain behind a status label stays visible"
+  sed 's/^/  out: /' "$OUT"
+fi
+
+# The value may not start on the label's own line. Classifying the fragment
+# available there missed this entirely: the fragment is empty, so it failed the
+# shape test, the capture never opened, and the continuation line carries no
+# assignment key of its own. Classification is deferred to the close instead.
+multiline_secret=$(printf 'error: password: "\n%s"' "$LABEL_SECRET")
+display_input=$(jq -nc --arg stdout "$multiline_secret" \
+  '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
+post_tool_out "$display_input"
+post_out=$(cat "$OUT")
+if printf '%s' "$post_out" | grep -q '\[REDACTED\]' \
+   && ! printf '%s' "$post_out" | grep -Fq "$LABEL_SECRET"; then
+  ok "#156 a status-label credential beginning on the next line still masks"
+else
+  not_ok "#156 a status-label credential beginning on the next line still masks"
+  printf '%s\n' "$post_out" | sed 's/^/  out: /'
+fi
+
+# ...and the same shape carrying prose must still come through untouched, or the
+# deferral would just be masking every multiline quoted value.
+multiline_prose=$(printf 'error: %s: "\nauthentication is disabled"' password)
+display_input=$(jq -nc --arg stdout "$multiline_prose" \
+  '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
+post_tool_out "$display_input"
+post_status=$?
+if [ "$post_status" -eq 0 ] && [ ! -s "$OUT" ]; then
+  ok "#156 a status-label prose chain beginning on the next line stays visible"
+else
+  not_ok "#156 a status-label prose chain beginning on the next line stays visible"
   sed 's/^/  out: /' "$OUT"
 fi
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -7297,6 +7297,26 @@ else
   printf '%s\n' "$post_out" | sed 's/^/  out: /'
 fi
 
+# The same asymmetry on the SINGLE-line quoted path: a padded value is
+# classified on its trimmed copy, so recording only the padded literal left a
+# bare recurrence of the same credential visible further down.
+for display_pad_spec in ' ' '  ' '\t' '\r'; do
+  display_pad=$(printf "$display_pad_spec")
+  padded_recur=$(printf 'error: password: "%s%s%s"\nretrying with %s' \
+    "$display_pad" "$LABEL_SECRET" "$display_pad" "$LABEL_SECRET")
+  display_input=$(jq -nc --arg stdout "$padded_recur" \
+    '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
+  post_tool_out "$display_input"
+  post_out=$(cat "$OUT")
+  if printf '%s' "$post_out" | grep -q '\[REDACTED\]' \
+     && ! printf '%s' "$post_out" | grep -Fq "$LABEL_SECRET"; then
+    ok "#156 a padded single-line credential also masks the bare recurrence"
+  else
+    not_ok "#156 a padded single-line credential also masks the bare recurrence"
+    printf '%s\n' "$post_out" | sed 's/^/  out: /'
+  fi
+done
+
 # An indented continuation carries leading whitespace into the capture, and the
 # whitespace test would reject the credential before the trim could reach it.
 # Classification runs on the edge-trimmed capture; internal whitespace still

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -7079,40 +7079,68 @@ for display_case in \
   fi
 done
 
-# On the status-label path a shape gate, not a detector, decided the value is a
-# credential, so the replacement is scoped to the matched assignment token. A
-# global literal would erase the value from every other line of the response —
-# scrubbing a version string out of a release note, or a resource name out of
-# the very command the agent needs to run next.
-scoped_input=$(jq -nc --arg stdout 'error: token: v1.2.3 is not a valid tag
-Downloading release v1.2.3 from github' \
+# A value that passes the shape gate is masked GLOBALLY, like one found behind
+# any other label — scoping it to the labelled line left a recurrence visible.
+# The false positives that scoping would contain are not specific to this path:
+# `response: token: v1.2.3` already scrubs every v1.2.3 in the response on main.
+recur_input=$(jq -nc --arg stdout "error: password: $LABEL_SECRET
+retrying with $LABEL_SECRET" \
   '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
-post_tool_out "$scoped_input"
+post_tool_out "$recur_input"
 post_out=$(cat "$OUT")
-if printf '%s' "$post_out" \
-  | jq -e '.hookSpecificOutput.updatedToolOutput.stdout
-      | (contains("Downloading release v1.2.3 from github"))
-        and (startswith("error: token: [REDACTED] is not a valid tag"))' >/dev/null 2>&1; then
-  ok "#156 status-label masking is scoped to its own line, not the whole output"
+if printf '%s' "$post_out" | grep -q '\[REDACTED\]' \
+   && ! printf '%s' "$post_out" | grep -Fq "$LABEL_SECRET"; then
+  ok "#156 a status-label secret is masked where it recurs later in the output"
 else
-  not_ok "#156 status-label masking is scoped to its own line, not the whole output"
+  not_ok "#156 a status-label secret is masked where it recurs later in the output"
   printf '%s\n' "$post_out" | sed 's/^/  out: /'
 fi
 
-# The same property with a value the agent needs to keep reading afterwards.
-scoped_input=$(jq -nc --arg stdout 'Error: secret: prod-db-secret-v2 not found
-Run: kubectl create secret generic prod-db-secret-v2 --from-literal=x=y' \
+# Truncated output after an opening quote must not buy a pass. There is no
+# complete value to classify, so the fragment decides: credential-shaped opens
+# multiline capture like any other path, prose still falls through.
+display_input=$(jq -nc --arg stdout "error: password: \"$LABEL_SECRET" \
   '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
-post_tool_out "$scoped_input"
+post_tool_out "$display_input"
 post_out=$(cat "$OUT")
-if printf '%s' "$post_out" \
-  | jq -e '.hookSpecificOutput.updatedToolOutput.stdout
-      | contains("kubectl create secret generic prod-db-secret-v2")' >/dev/null 2>&1; then
-  ok "#156 a status-label false positive does not scrub the value from later lines"
+if printf '%s' "$post_out" | grep -q '\[REDACTED\]' \
+   && ! printf '%s' "$post_out" | grep -Fq "$LABEL_SECRET"; then
+  ok "#156 an unterminated quoted credential behind a status label still masks"
 else
-  not_ok "#156 a status-label false positive does not scrub the value from later lines"
+  not_ok "#156 an unterminated quoted credential behind a status label still masks"
   printf '%s\n' "$post_out" | sed 's/^/  out: /'
 fi
+
+display_input=$(jq -nc --arg stdout 'error: password: "authentication is disabled' \
+  '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
+post_tool_out "$display_input"
+post_status=$?
+if [ "$post_status" -eq 0 ] && [ ! -s "$OUT" ]; then
+  ok "#156 an unterminated quoted prose chain behind a status label stays visible"
+else
+  not_ok "#156 an unterminated quoted prose chain behind a status label stays visible"
+  sed 's/^/  out: /' "$OUT"
+fi
+
+# A delimiter-separated passphrase is far less prose-like than a bare word, so
+# the compound-length fallback accepts `.`/`-`/`_` joins rather than requiring a
+# purely alphabetic value.
+for display_case in \
+  'correct-horse-battery-staple' \
+  'correct.horse.battery.staple' \
+  'correct_horse_battery_staple'; do
+  display_input=$(jq -nc --arg stdout "error: password: $display_case" \
+    '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
+  post_tool_out "$display_input"
+  post_out=$(cat "$OUT")
+  if printf '%s' "$post_out" | grep -q '\[REDACTED\]' \
+     && ! printf '%s' "$post_out" | grep -Fq "$display_case"; then
+    ok "#156 post-tool masks a delimiter-separated passphrase ($display_case)"
+  else
+    not_ok "#156 post-tool masks a delimiter-separated passphrase ($display_case)"
+    printf '%s\n' "$post_out" | sed 's/^/  out: /'
+  fi
+done
 
 # Display redaction must not mangle credential-handling SOURCE CODE. A
 # credential-shaped key on the left says nothing about the right-hand side: a

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -7175,6 +7175,23 @@ else
   sed 's/^/  out: /' "$OUT"
 fi
 
+# The captured value keeps the newline that separated the label from it, so the
+# global literal is `<newline><secret>` and a BARE recurrence later in the output
+# does not match it. The trimmed token is emitted as a second record for that.
+multiline_recur=$(printf 'error: password: "\n%s"\nretrying with %s' \
+  "$LABEL_SECRET" "$LABEL_SECRET")
+display_input=$(jq -nc --arg stdout "$multiline_recur" \
+  '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
+post_tool_out "$display_input"
+post_out=$(cat "$OUT")
+if printf '%s' "$post_out" | grep -q '\[REDACTED\]' \
+   && ! printf '%s' "$post_out" | grep -Fq "$LABEL_SECRET"; then
+  ok "#156 a multiline status-label capture also masks the bare recurrence"
+else
+  not_ok "#156 a multiline status-label capture also masks the bare recurrence"
+  printf '%s\n' "$post_out" | sed 's/^/  out: /'
+fi
+
 # A delimiter-separated passphrase is far less prose-like than a bare word, so
 # the compound-length fallback accepts `.`/`-`/`_` joins rather than requiring a
 # purely alphabetic value.
@@ -8216,6 +8233,33 @@ if [ "$exec_first_byte" = ff ] \
 else
   not_ok "exec raw masking does not strand a longer assignment suffix"
   LC_ALL=C od -An -tx1 "$OUT" | sed 's/^/  hex: /'
+fi
+
+# The raw-probe END terminates an unterminated quote for a capture that exceeded
+# the byte cap and held invalid UTF-8. It has to honour the status-label gate
+# like every other termination, or a large prose tail is replaced wholesale.
+exec_raw_prose=$(printf 'error: %s: "authentication is disabled' password)
+"$PLUGIN_ROOT/bin/agent-guard" exec -- sh -c \
+  'printf "\377\n"; i=0; while [ $i -lt 2200 ]; do printf "filler line %s of ordinary output text here to pad the capture\n" "$i"; i=$((i+1)); done; printf "error: %s: \"authentication is disabled" password' \
+  >"$OUT" 2>/dev/null
+exec_raw_tail=$(LC_ALL=C tail -n 1 "$OUT")
+if [ "$exec_raw_tail" = "$exec_raw_prose" ]; then
+  ok "#156 exec raw-probe termination leaves a status-label prose tail visible"
+else
+  not_ok "#156 exec raw-probe termination leaves a status-label prose tail visible"
+  printf '  tail: %s\n' "$exec_raw_tail"
+fi
+
+exec_raw_secret=$(printf '%s%s' 'hunter2-' 'long-value')
+"$PLUGIN_ROOT/bin/agent-guard" exec -- sh -c \
+  'printf "\377\n"; i=0; while [ $i -lt 2200 ]; do printf "filler line %s of ordinary output text here to pad the capture\n" "$i"; i=$((i+1)); done; printf "error: %s: \"%s" password "hunter2-long-value"' \
+  >"$OUT" 2>/dev/null
+if LC_ALL=C grep -q '\[REDACTED\]' "$OUT" \
+   && ! LC_ALL=C grep -Fq "$exec_raw_secret" "$OUT"; then
+  ok "#156 exec raw-probe termination still masks a credential tail"
+else
+  not_ok "#156 exec raw-probe termination still masks a credential tail"
+  LC_ALL=C tail -n 1 "$OUT" | sed 's/^/  tail: /'
 fi
 
 "$PLUGIN_ROOT/bin/agent-guard" exec -- sh -c \

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1749,6 +1749,72 @@ for nonpath_case in \
     hook-pre-tool
 done
 
+# Dropping a word is only sound while that word cannot reach a reader, and shell
+# syntax is what carries it to one. Every case below reads the file for real
+# (verified with `bash -c` against a fixture directory) and was ALLOWED by an
+# earlier revision of this narrowing that tried to track command segments
+# itself. The newline cases are the subtle ones: the strip helpers that run
+# first rejoin their tokens with single spaces, so `echo hi<newline>cat .env`
+# arrives here as `echo hi cat .env` and reads like one `echo` — which is why
+# the syntax test runs on the untouched command, not on the stripped one.
+nonpath_newline_env=$(printf 'echo hi\ncat .env')
+nonpath_newline_ssh=$(printf 'echo one\necho two\ncat .ssh/id_rsa')
+nonpath_newline_sec=$(printf 'printf x\ncat secrets.json')
+for nonpath_case in \
+  "$nonpath_newline_env" \
+  "$nonpath_newline_ssh" \
+  "$nonpath_newline_sec" \
+  "echo a & cat .env" \
+  "echo a&cat .ssh/id_rsa" \
+  "echo a & cat .netrc" \
+  "echo a & cat .git-credentials" \
+  "echo a & head -c 100 secrets.json" \
+  "echo .env | xargs cat" \
+  "printf %s .env | xargs cat" \
+  "echo .ssh/id_rsa | xargs cat" \
+  "echo .env | xargs -I{} cat {}" \
+  "command echo .env | xargs cat" \
+  "sudo echo .env | xargs cat" \
+  "FOO=1 echo .env | xargs cat"; do
+  expect_json_status 2 \
+    "#99 Bash shell syntax defeats the strip: '$(printf '%s' "$nonpath_case" | tr '\n' '~')' blocks" \
+    "$(jq -nc --arg c "$nonpath_case" \
+      '{tool_name:"Bash",tool_input:{command:$c}}')" \
+    hook-pre-tool
+done
+
+# A jq option outside the valueless allowlist may take the NEXT token as a
+# value, and for `-f`/`--from-file`/`-L` that token is a path jq reads — so it
+# must not be mistaken for the filter and dropped. A combined cluster (`-rf`)
+# counts as unrecognised, and `--` ends the filter search outright.
+for nonpath_case in \
+  "jq -f .env data.json" \
+  "jq -rf .aws/credentials data.json" \
+  "jq --from-file .env data.json" \
+  "jq -f .env" \
+  "jq -L .ssh/id_rsa ." \
+  "jq --slurpfile d .env ." \
+  "jq --rawfile d .env ." \
+  "jq -- .env" \
+  "yq --from-file .env x.yaml"; do
+  expect_json_status 2 "#99 Bash value-taking jq option keeps its operand: '$nonpath_case'" \
+    "$(jq -nc --arg c "$nonpath_case" \
+      '{tool_name:"Bash",tool_input:{command:$c}}')" \
+    hook-pre-tool
+done
+
+# Valueless jq options must not stop the filter search, or the false positive
+# the narrowing exists to fix comes back for any invocation that uses a flag.
+for nonpath_case in \
+  "jq -c -r .$NONPATH_KEY f.json" \
+  "jq -n .$NONPATH_KEY" \
+  "jq --sort-keys .$NONPATH_KEY f.json"; do
+  expect_json_status 0 "#99 Bash valueless jq option keeps the filter droppable: '$nonpath_case'" \
+    "$(jq -nc --arg c "$nonpath_case" \
+      '{tool_name:"Bash",tool_input:{command:$c}}')" \
+    hook-pre-tool
+done
+
 # Path-prefixed candidates go through basename stripping before the suffix match.
 expect_json_status 0 "Read config/.env.local.example (path-prefixed template) is allowed" \
   '{"tool_name":"Read","tool_input":{"file_path":"config/.env.local.example"}}' \

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1721,9 +1721,7 @@ for nonpath_case in \
   "echo foo.$NONPATH_KEY" \
   "echo see also foo.$NONPATH_PEM" \
   "echo see also foo.env" \
-  "printf '%s' foo.$NONPATH_KEY" \
-  "jq -r .$NONPATH_KEY data.json" \
-  "jq .$NONPATH_KEY"; do
+  "printf '%s' foo.$NONPATH_KEY"; do
   expect_json_status 0 "#99 Bash '$nonpath_case' does not reference a read target" \
     "$(jq -nc --arg c "$nonpath_case" \
       '{tool_name:"Bash",tool_input:{command:$c}}')" \
@@ -1783,29 +1781,6 @@ for nonpath_case in \
     hook-pre-tool
 done
 
-# A jq option outside the valueless allowlist may take the NEXT token as a
-# value, and for `-f`/`--from-file`/`-L` that token is a path jq reads — so it
-# must not be mistaken for the filter and dropped. A combined cluster (`-rf`)
-# counts as unrecognised, and `--` ends the filter search outright.
-for nonpath_case in \
-  "jq -f .env data.json" \
-  "jq -rf .aws/credentials data.json" \
-  "jq --from-file .env data.json" \
-  "jq -f .env" \
-  "jq -L .ssh/id_rsa ." \
-  "jq --slurpfile d .env ." \
-  "jq --rawfile d .env ." \
-  "jq -- .env" \
-  "yq --from-file .env x.yaml"; do
-  expect_json_status 2 "#99 Bash value-taking jq option keeps its operand: '$nonpath_case'" \
-    "$(jq -nc --arg c "$nonpath_case" \
-      '{tool_name:"Bash",tool_input:{command:$c}}')" \
-    hook-pre-tool
-done
-
-# yq is NOT in the jq family: Mike Farah yq treats its first argument as an
-# expression only when no file of that name exists, so `yq .env` in a directory
-# holding one reads it. Dropping that operand was a read bypass.
 # The command word is the RAW token: no basename strip, no quote removal.
 # Stripping the directory gave the exception to any executable merely sharing
 # the name. Removing quotes was worse — shell_command_words splits on whitespace
@@ -1829,28 +1804,98 @@ for nonpath_case in \
     hook-pre-tool
 done
 
-# `gojq` and `jaq` are out for a weaker but sufficient reason: this repo has no
-# copy of either to check their argument grammar against, and assuming they copy
-# jq's is the same assumption that produced the yq hole.
+# Only shell BUILTINS get the exception. An external binary resolves through
+# PATH at execution time, so naming it here is a claim about a program the gate
+# cannot identify: a `jq` wrapper earlier in PATH inherited the exception meant
+# for the real jq and read the file. jq, yq, gojq and jaq are all external, so
+# all four keep their operands and their false positive.
 for nonpath_case in \
+  "jq .env" \
+  "jq -r .$NONPATH_KEY data.json" \
+  "jq .$NONPATH_KEY" \
   "yq .env" \
   "yq -r .env" \
   "yq .$NONPATH_KEY data.yaml" \
   "gojq .$NONPATH_KEY data.json" \
   "jaq .$NONPATH_KEY data.json"; do
-  expect_json_status 2 "#99 Bash only jq gets the filter exception: '$nonpath_case'" \
+  expect_json_status 2 "#99 Bash an external binary gets no exception: '$nonpath_case'" \
     "$(jq -nc --arg c "$nonpath_case" \
       '{tool_name:"Bash",tool_input:{command:$c}}')" \
     hook-pre-tool
 done
 
-# Valueless jq options must not stop the filter search, or the false positive
-# the narrowing exists to fix comes back for any invocation that uses a flag.
+# Dropping a word is only sound while that word cannot reach a reader, and shell
+# syntax is what carries it to one. Every case below reads the file for real
+# (verified with `bash -c` against a fixture directory) and was ALLOWED by an
+# earlier revision of this narrowing that tried to track command segments
+# itself. The newline cases are the subtle ones: the strip helpers that run
+# first rejoin their tokens with single spaces, so `echo hi<newline>cat .env`
+# arrives here as `echo hi cat .env` and reads like one `echo` — which is why
+# the syntax test runs on the untouched command, not on the stripped one.
+nonpath_newline_env=$(printf 'echo hi\ncat .env')
+nonpath_newline_ssh=$(printf 'echo one\necho two\ncat .ssh/id_rsa')
+nonpath_newline_sec=$(printf 'printf x\ncat secrets.json')
 for nonpath_case in \
-  "jq -c -r .$NONPATH_KEY f.json" \
-  "jq -n .$NONPATH_KEY" \
-  "jq --sort-keys .$NONPATH_KEY f.json"; do
-  expect_json_status 0 "#99 Bash valueless jq option keeps the filter droppable: '$nonpath_case'" \
+  "$nonpath_newline_env" \
+  "$nonpath_newline_ssh" \
+  "$nonpath_newline_sec" \
+  "echo a & cat .env" \
+  "echo a&cat .ssh/id_rsa" \
+  "echo a & cat .netrc" \
+  "echo a & cat .git-credentials" \
+  "echo a & head -c 100 secrets.json" \
+  "echo .env | xargs cat" \
+  "printf %s .env | xargs cat" \
+  "echo .ssh/id_rsa | xargs cat" \
+  "echo .env | xargs -I{} cat {}" \
+  "command echo .env | xargs cat" \
+  "sudo echo .env | xargs cat" \
+  "FOO=1 echo .env | xargs cat"; do
+  expect_json_status 2 \
+    "#99 Bash shell syntax defeats the strip: '$(printf '%s' "$nonpath_case" | tr '\n' '~')' blocks" \
+    "$(jq -nc --arg c "$nonpath_case" \
+      '{tool_name:"Bash",tool_input:{command:$c}}')" \
+    hook-pre-tool
+done
+
+# The command word is the RAW token: no basename strip, no quote removal.
+# Stripping the directory gave the exception to any executable merely sharing
+# the name. Removing quotes was worse — shell_command_words splits on whitespace
+# before quotes resolve, so a command name containing quoted whitespace arrives
+# as its first fragment and reduced to a trusted name, while the shell resolved
+# an executable literally called `echo foo` that read the file. Both verified as
+# real passes, and the second as a real read, before the fix.
+for nonpath_case in \
+  "./echo .env" \
+  "/tmp/printf .env" \
+  "./jq .env" \
+  "bin/echo .env" \
+  "/usr/bin/echo .env" \
+  "'echo foo' .env" \
+  "\"echo foo\" .env" \
+  "'echo' .env" \
+  "\"echo\" .env"; do
+  expect_json_status 2 "#99 Bash a path-qualified lookalike gets no exception: '$nonpath_case'" \
+    "$(jq -nc --arg c "$nonpath_case" \
+      '{tool_name:"Bash",tool_input:{command:$c}}')" \
+    hook-pre-tool
+done
+
+# Only shell BUILTINS get the exception. An external binary resolves through
+# PATH at execution time, so naming it here is a claim about a program the gate
+# cannot identify: a `jq` wrapper earlier in PATH inherited the exception meant
+# for the real jq and read the file. jq, yq, gojq and jaq are all external, so
+# all four keep their operands and their false positive.
+for nonpath_case in \
+  "jq .env" \
+  "jq -r .$NONPATH_KEY data.json" \
+  "jq .$NONPATH_KEY" \
+  "yq .env" \
+  "yq -r .env" \
+  "yq .$NONPATH_KEY data.yaml" \
+  "gojq .$NONPATH_KEY data.json" \
+  "jaq .$NONPATH_KEY data.json"; do
+  expect_json_status 2 "#99 Bash an external binary gets no exception: '$nonpath_case'" \
     "$(jq -nc --arg c "$nonpath_case" \
       '{tool_name:"Bash",tool_input:{command:$c}}')" \
     hook-pre-tool

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -7238,6 +7238,51 @@ else
   sed 's/^/  out: /' "$OUT"
 fi
 
+# A guarded capture that fails the shape test must not swallow the rest of the
+# leaf. The capture absorbs every following line, so discarding it dropped the
+# assignments inside — an unterminated quote after a status label made real
+# `KEY=value` lines below it stop masking entirely, and stopped the prompt guard
+# blocking the same text. What was absorbed is re-scanned as ordinary input.
+swallow_secret_a=$(printf '%s%s' 'pr0d-db-' 'passw0rd-2026')
+swallow_secret_b=$(printf '%s%s' 'Zk9xQvL2' 'mNpRt4Ys')
+swallow_input=$(printf 'error: %s: "connection refused\n# production config\nDB_PASSWORD=%s\nSESSION_SECRET=%s' \
+  password "$swallow_secret_a" "$swallow_secret_b")
+display_input=$(jq -nc --arg stdout "$swallow_input" \
+  '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
+post_tool_out "$display_input"
+post_out=$(cat "$OUT")
+if ! printf '%s' "$post_out" | grep -Fq "$swallow_secret_a" \
+   && ! printf '%s' "$post_out" | grep -Fq "$swallow_secret_b" \
+   && printf '%s' "$post_out" | grep -q 'connection refused'; then
+  ok "#156 an unterminated status-label quote does not swallow later assignments"
+else
+  not_ok "#156 an unterminated status-label quote does not swallow later assignments"
+  printf '%s\n' "$post_out" | sed 's/^/  out: /'
+fi
+
+# The same input on the BLOCK path: this was a prompt-guard bypass, not just a
+# display leak, so it is pinned on the hook that refuses rather than rewrites.
+expect_json_status 2 "#156 an unterminated status-label quote still blocks at the prompt guard" \
+  "$(jq -nc --arg prompt "$swallow_input" \
+    '{session_id:"t",hook_event_name:"UserPromptSubmit",prompt:$prompt}')" \
+  hook-user-prompt
+
+# A single quote is enough to open the capture, and an apostrophe in ordinary
+# prose is common, so the same property is pinned for that spelling.
+swallow_squote=$(printf "error: %s: 'twas malformed\nDATABASE_PASSWORD=%s here" \
+  secret "$LABEL_SECRET")
+display_input=$(jq -nc --arg stdout "$swallow_squote" \
+  '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
+post_tool_out "$display_input"
+post_out=$(cat "$OUT")
+if printf '%s' "$post_out" | grep -q '\[REDACTED\]' \
+   && ! printf '%s' "$post_out" | grep -Fq "$LABEL_SECRET"; then
+  ok "#156 an apostrophe in status-label prose does not swallow later assignments"
+else
+  not_ok "#156 an apostrophe in status-label prose does not swallow later assignments"
+  printf '%s\n' "$post_out" | sed 's/^/  out: /'
+fi
+
 # A delimiter-separated passphrase is far less prose-like than a bare word, so
 # the compound-length fallback accepts `.`/`-`/`_` joins rather than requiring a
 # purely alphabetic value.

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1711,26 +1711,49 @@ expect_json_status 2 "Bash cat .env.tpl.bak (tpl marker not final) is blocked" \
   '{"tool_name":"Bash","tool_input":{"command":"cat .env.tpl.bak"}}' \
   hook-pre-tool
 
-# #99: the deny-read globs used to match any word ending in a listed extension,
-# so an `echo` argument and a jq field selector blocked as if a private key had
-# been opened. Nothing is read in either case. The exts are composed at runtime
-# because a literal in this file would trip the gate under test.
+# #99 asked for the deny-read globs to stop matching words that are not read
+# operands: `echo foo.key` and `jq -r .key data.json` block as if a private key
+# had been opened, and nothing is read in either case.
+#
+# A command-position narrowing was written for this and is deliberately NOT
+# here. Every revision of it leaked a real read, eight times over, because the
+# gate is a text test and the shell is not: newline and `&` start another
+# command, `|` hands the dropped word to `xargs cat`, a path- or quote-qualified
+# name resolves to a different program than the one compared, an external
+# binary resolves through PATH at execution time, and — the one that ended it —
+# an exported Bash function named `echo` or `printf` beats the builtin, so even
+# a builtin name does not identify what will run. A gate that cannot name the
+# program cannot safely drop its operands, so it drops none: the #99 false
+# positive stays, and the read stays blocked.
+#
+# The exts are composed at runtime because a literal in this file would trip the
+# gate under test.
 NONPATH_KEY=$(printf 'k%s' 'ey')
 NONPATH_PEM=$(printf 'p%s' 'em')
+
+# The accepted cost of the decision above: a word that merely ends in a listed
+# extension still blocks, whatever command it sits under. Pinned so that any
+# future narrowing has to change these lines on purpose.
 for nonpath_case in \
   "echo foo.$NONPATH_KEY" \
   "echo see also foo.$NONPATH_PEM" \
   "echo see also foo.env" \
-  "printf '%s' foo.$NONPATH_KEY"; do
-  expect_json_status 0 "#99 Bash '$nonpath_case' does not reference a read target" \
+  "printf '%s' foo.$NONPATH_KEY" \
+  "jq -r .$NONPATH_KEY data.json" \
+  "jq .$NONPATH_KEY"; do
+  expect_json_status 2 "#99 Bash '$nonpath_case' keeps the accepted false positive" \
     "$(jq -nc --arg c "$nonpath_case" \
       '{tool_name:"Bash",tool_input:{command:$c}}')" \
     hook-pre-tool
 done
 
-# The narrowing is by command position only, so every real read operand — and
-# any token the literal test refuses to classify — still blocks. `cat .env` in
-# particular must keep refusing by name, with or without a file on disk.
+# Every case below reads the file for real (verified with `bash -c` against a
+# fixture directory) and was ALLOWED by some revision of the narrowing. They all
+# block trivially now that nothing is stripped; they stay as the standing
+# counter-examples any re-attempt has to answer.
+nonpath_newline_env=$(printf 'echo hi\ncat .env')
+nonpath_newline_ssh=$(printf 'echo one\necho two\ncat .ssh/id_rsa')
+nonpath_newline_sec=$(printf 'printf x\ncat secrets.json')
 for nonpath_case in \
   "cat .env" \
   "cat foo.$NONPATH_PEM" \
@@ -1740,25 +1763,7 @@ for nonpath_case in \
   "cat .env | jq .$NONPATH_KEY" \
   "echo \$(cat .env)" \
   "echo x > .env" \
-  "echo x >.env"; do
-  expect_json_status 2 "#99 Bash '$nonpath_case' still blocks" \
-    "$(jq -nc --arg c "$nonpath_case" \
-      '{tool_name:"Bash",tool_input:{command:$c}}')" \
-    hook-pre-tool
-done
-
-# Dropping a word is only sound while that word cannot reach a reader, and shell
-# syntax is what carries it to one. Every case below reads the file for real
-# (verified with `bash -c` against a fixture directory) and was ALLOWED by an
-# earlier revision of this narrowing that tried to track command segments
-# itself. The newline cases are the subtle ones: the strip helpers that run
-# first rejoin their tokens with single spaces, so `echo hi<newline>cat .env`
-# arrives here as `echo hi cat .env` and reads like one `echo` — which is why
-# the syntax test runs on the untouched command, not on the stripped one.
-nonpath_newline_env=$(printf 'echo hi\ncat .env')
-nonpath_newline_ssh=$(printf 'echo one\necho two\ncat .ssh/id_rsa')
-nonpath_newline_sec=$(printf 'printf x\ncat secrets.json')
-for nonpath_case in \
+  "echo x >.env" \
   "$nonpath_newline_env" \
   "$nonpath_newline_ssh" \
   "$nonpath_newline_sec" \
@@ -1773,22 +1778,7 @@ for nonpath_case in \
   "echo .env | xargs -I{} cat {}" \
   "command echo .env | xargs cat" \
   "sudo echo .env | xargs cat" \
-  "FOO=1 echo .env | xargs cat"; do
-  expect_json_status 2 \
-    "#99 Bash shell syntax defeats the strip: '$(printf '%s' "$nonpath_case" | tr '\n' '~')' blocks" \
-    "$(jq -nc --arg c "$nonpath_case" \
-      '{tool_name:"Bash",tool_input:{command:$c}}')" \
-    hook-pre-tool
-done
-
-# The command word is the RAW token: no basename strip, no quote removal.
-# Stripping the directory gave the exception to any executable merely sharing
-# the name. Removing quotes was worse — shell_command_words splits on whitespace
-# before quotes resolve, so a command name containing quoted whitespace arrives
-# as its first fragment and reduced to a trusted name, while the shell resolved
-# an executable literally called `echo foo` that read the file. Both verified as
-# real passes, and the second as a real read, before the fix.
-for nonpath_case in \
+  "FOO=1 echo .env | xargs cat" \
   "./echo .env" \
   "/tmp/printf .env" \
   "./jq .env" \
@@ -1797,105 +1787,14 @@ for nonpath_case in \
   "'echo foo' .env" \
   "\"echo foo\" .env" \
   "'echo' .env" \
-  "\"echo\" .env"; do
-  expect_json_status 2 "#99 Bash a path-qualified lookalike gets no exception: '$nonpath_case'" \
-    "$(jq -nc --arg c "$nonpath_case" \
-      '{tool_name:"Bash",tool_input:{command:$c}}')" \
-    hook-pre-tool
-done
-
-# Only shell BUILTINS get the exception. An external binary resolves through
-# PATH at execution time, so naming it here is a claim about a program the gate
-# cannot identify: a `jq` wrapper earlier in PATH inherited the exception meant
-# for the real jq and read the file. jq, yq, gojq and jaq are all external, so
-# all four keep their operands and their false positive.
-for nonpath_case in \
+  "\"echo\" .env" \
   "jq .env" \
-  "jq -r .$NONPATH_KEY data.json" \
-  "jq .$NONPATH_KEY" \
   "yq .env" \
   "yq -r .env" \
-  "yq .$NONPATH_KEY data.yaml" \
-  "gojq .$NONPATH_KEY data.json" \
-  "jaq .$NONPATH_KEY data.json"; do
-  expect_json_status 2 "#99 Bash an external binary gets no exception: '$nonpath_case'" \
-    "$(jq -nc --arg c "$nonpath_case" \
-      '{tool_name:"Bash",tool_input:{command:$c}}')" \
-    hook-pre-tool
-done
-
-# Dropping a word is only sound while that word cannot reach a reader, and shell
-# syntax is what carries it to one. Every case below reads the file for real
-# (verified with `bash -c` against a fixture directory) and was ALLOWED by an
-# earlier revision of this narrowing that tried to track command segments
-# itself. The newline cases are the subtle ones: the strip helpers that run
-# first rejoin their tokens with single spaces, so `echo hi<newline>cat .env`
-# arrives here as `echo hi cat .env` and reads like one `echo` — which is why
-# the syntax test runs on the untouched command, not on the stripped one.
-nonpath_newline_env=$(printf 'echo hi\ncat .env')
-nonpath_newline_ssh=$(printf 'echo one\necho two\ncat .ssh/id_rsa')
-nonpath_newline_sec=$(printf 'printf x\ncat secrets.json')
-for nonpath_case in \
-  "$nonpath_newline_env" \
-  "$nonpath_newline_ssh" \
-  "$nonpath_newline_sec" \
-  "echo a & cat .env" \
-  "echo a&cat .ssh/id_rsa" \
-  "echo a & cat .netrc" \
-  "echo a & cat .git-credentials" \
-  "echo a & head -c 100 secrets.json" \
-  "echo .env | xargs cat" \
-  "printf %s .env | xargs cat" \
-  "echo .ssh/id_rsa | xargs cat" \
-  "echo .env | xargs -I{} cat {}" \
-  "command echo .env | xargs cat" \
-  "sudo echo .env | xargs cat" \
-  "FOO=1 echo .env | xargs cat"; do
+  "gojq . .env" \
+  "jaq . .env"; do
   expect_json_status 2 \
-    "#99 Bash shell syntax defeats the strip: '$(printf '%s' "$nonpath_case" | tr '\n' '~')' blocks" \
-    "$(jq -nc --arg c "$nonpath_case" \
-      '{tool_name:"Bash",tool_input:{command:$c}}')" \
-    hook-pre-tool
-done
-
-# The command word is the RAW token: no basename strip, no quote removal.
-# Stripping the directory gave the exception to any executable merely sharing
-# the name. Removing quotes was worse — shell_command_words splits on whitespace
-# before quotes resolve, so a command name containing quoted whitespace arrives
-# as its first fragment and reduced to a trusted name, while the shell resolved
-# an executable literally called `echo foo` that read the file. Both verified as
-# real passes, and the second as a real read, before the fix.
-for nonpath_case in \
-  "./echo .env" \
-  "/tmp/printf .env" \
-  "./jq .env" \
-  "bin/echo .env" \
-  "/usr/bin/echo .env" \
-  "'echo foo' .env" \
-  "\"echo foo\" .env" \
-  "'echo' .env" \
-  "\"echo\" .env"; do
-  expect_json_status 2 "#99 Bash a path-qualified lookalike gets no exception: '$nonpath_case'" \
-    "$(jq -nc --arg c "$nonpath_case" \
-      '{tool_name:"Bash",tool_input:{command:$c}}')" \
-    hook-pre-tool
-done
-
-# Only shell BUILTINS get the exception. An external binary resolves through
-# PATH at execution time, so naming it here is a claim about a program the gate
-# cannot identify: a `jq` wrapper earlier in PATH inherited the exception meant
-# for the real jq and read the file. jq, yq, gojq and jaq are all external, so
-# all four keep their operands and their false positive.
-for nonpath_case in \
-  "jq .env" \
-  "jq -r .$NONPATH_KEY data.json" \
-  "jq .$NONPATH_KEY" \
-  "yq .env" \
-  "yq -r .env" \
-  "yq .$NONPATH_KEY data.yaml" \
-  "gojq .$NONPATH_KEY data.json" \
-  "jaq .$NONPATH_KEY data.json"; do
-  expect_json_status 2 "#99 Bash an external binary gets no exception: '$nonpath_case'" \
+    "#99 Bash a read target still blocks: '$(printf '%s' "$nonpath_case" | tr '\n' '~')'" \
     "$(jq -nc --arg c "$nonpath_case" \
       '{tool_name:"Bash",tool_input:{command:$c}}')" \
     hook-pre-tool

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1711,6 +1711,44 @@ expect_json_status 2 "Bash cat .env.tpl.bak (tpl marker not final) is blocked" \
   '{"tool_name":"Bash","tool_input":{"command":"cat .env.tpl.bak"}}' \
   hook-pre-tool
 
+# #99: the deny-read globs used to match any word ending in a listed extension,
+# so an `echo` argument and a jq field selector blocked as if a private key had
+# been opened. Nothing is read in either case. The exts are composed at runtime
+# because a literal in this file would trip the gate under test.
+NONPATH_KEY=$(printf 'k%s' 'ey')
+NONPATH_PEM=$(printf 'p%s' 'em')
+for nonpath_case in \
+  "echo foo.$NONPATH_KEY" \
+  "echo see also foo.$NONPATH_PEM" \
+  "echo see also foo.env" \
+  "printf '%s' foo.$NONPATH_KEY" \
+  "jq -r .$NONPATH_KEY data.json" \
+  "jq .$NONPATH_KEY"; do
+  expect_json_status 0 "#99 Bash '$nonpath_case' does not reference a read target" \
+    "$(jq -nc --arg c "$nonpath_case" \
+      '{tool_name:"Bash",tool_input:{command:$c}}')" \
+    hook-pre-tool
+done
+
+# The narrowing is by command position only, so every real read operand — and
+# any token the literal test refuses to classify — still blocks. `cat .env` in
+# particular must keep refusing by name, with or without a file on disk.
+for nonpath_case in \
+  "cat .env" \
+  "cat foo.$NONPATH_PEM" \
+  "jq . .env" \
+  "jq -r .name .env" \
+  "jq -f prog.jq .env" \
+  "cat .env | jq .$NONPATH_KEY" \
+  "echo \$(cat .env)" \
+  "echo x > .env" \
+  "echo x >.env"; do
+  expect_json_status 2 "#99 Bash '$nonpath_case' still blocks" \
+    "$(jq -nc --arg c "$nonpath_case" \
+      '{tool_name:"Bash",tool_input:{command:$c}}')" \
+    hook-pre-tool
+done
+
 # Path-prefixed candidates go through basename stripping before the suffix match.
 expect_json_status 0 "Read config/.env.local.example (path-prefixed template) is allowed" \
   '{"tool_name":"Read","tool_input":{"file_path":"config/.env.local.example"}}' \
@@ -6368,6 +6406,66 @@ else
   printf '%s\n' "$post_out" | sed 's/^/  out: /'
 fi
 
+# #169: the same exact-extent property, pinned on the nested MCP tool_response
+# contract this time. On v3.0.1 an unquoted value ran to the end of its leaf, so
+# everything after the secret was swallowed with it (`API_KEY=[REDACTED]`, and
+# `tail one` gone) — which is what a large nested response made visible. Fixed
+# by ff50c21; this pins it against a regression on both hosts, and pins that a
+# clean leaf and untouched sibling fields keep their shape.
+NESTED_TOKEN=$(printf '%s%s' 'example_token' '_value_long')
+nested_input=$(jq -nc --arg a "leaf one API_KEY=$NESTED_TOKEN tail one" \
+  --arg b "leaf two DB_PASSWORD=$DISPLAY_SECRET tail two" \
+  '{tool_name:"mcp__fixture__tool",
+    tool_response:{content:[{type:"text",text:$a},{type:"text",text:$b},
+                            {type:"text",text:"clean leaf, nothing here"}],
+                   meta:{count:42,ok:true,note:"untouched"},isError:false}}')
+post_tool_out "$nested_input"
+post_out=$(cat "$OUT")
+if printf '%s' "$post_out" | jq -e '
+      .hookSpecificOutput.updatedToolOutput as $o
+      | ($o.content[0].text == "leaf one API_KEY=[REDACTED] tail one")
+        and ($o.content[1].text == "leaf two DB_PASSWORD=[REDACTED] tail two")
+        and ($o.content[2].text == "clean leaf, nothing here")
+        and ($o.meta == {count:42,ok:true,note:"untouched"})
+        and ($o.isError == false)' >/dev/null 2>&1; then
+  ok "#169 post-tool masks the exact value in each nested leaf and preserves shape"
+else
+  not_ok "#169 post-tool masks the exact value in each nested leaf and preserves shape"
+  printf '%s\n' "$post_out" | sed 's/^/  out: /'
+fi
+
+printf '%s' "$nested_input" \
+  | (cd "$TMP_ROOT" && AGENT_GUARD_HOOK_HOST=codex "$PLUGIN_ROOT/bin/agent-guard" hook-post-tool) \
+    >"$OUT" 2>"$ERR"
+codex_nested_status=$?
+post_out=$(cat "$OUT")
+if [ "$codex_nested_status" -eq 0 ] \
+   && printf '%s' "$post_out" | jq -e '.decision == "block"
+        and (.hookSpecificOutput.additionalContext | contains("tail one"))
+        and (.hookSpecificOutput.additionalContext | contains("tail two"))
+        and (.hookSpecificOutput.additionalContext | contains("untouched"))' >/dev/null 2>&1 \
+   && ! printf '%s' "$post_out" | grep -Fq "$NESTED_TOKEN" \
+   && ! printf '%s' "$post_out" | grep -Fq "$DISPLAY_SECRET"; then
+  ok "#169 Codex post-tool keeps the same exact-extent nested rewrite"
+else
+  not_ok "#169 Codex post-tool keeps the same exact-extent nested rewrite (status $codex_nested_status)"
+  printf '%s\n' "$post_out" | sed 's/^/  out: /'
+fi
+
+# A nested response with no secret must pass through with no rewrite at all.
+nested_clean=$(jq -nc \
+  '{tool_name:"mcp__fixture__tool",
+    tool_response:{content:[{type:"text",text:"just ordinary nested output"}],
+                   isError:false}}')
+post_tool_out "$nested_clean"
+post_status=$?
+if [ "$post_status" -eq 0 ] && [ ! -s "$OUT" ]; then
+  ok "#169 post-tool leaves a clean nested response unrewritten"
+else
+  not_ok "#169 post-tool leaves a clean nested response unrewritten"
+  sed 's/^/  out: /' "$OUT"
+fi
+
 for display_closing in '}' ']' ')'; do
   display_input=$(jq -nc \
     --arg stdout "API_TOKEN=${DISPLAY_SECRET}${display_closing}" \
@@ -6806,6 +6904,56 @@ for display_case in \
     ok "post-tool leaves a status-word prose chain untouched (${display_case%%:*})"
   else
     not_ok "post-tool leaves a status-word prose chain untouched (${display_case%%:*})"
+    sed 's/^/  out: /' "$OUT"
+  fi
+done
+
+# #156: a status label alone must not buy a pass. The label is identical in
+# `error: password: authentication is disabled` (prose, covered above) and in
+# `error: password: <credential>`, so the VALUE decides. These values are the
+# gitleaks-invisible shape `tests/run.sh` already uses elsewhere, which is
+# exactly the gap the allowlist left open: anything gitleaks recognises was
+# already masked regardless of the label.
+LABEL_SECRET=$(printf '%s%s' 'hunter2-' 'long-value')
+for display_case in \
+  "error: password: $LABEL_SECRET" \
+  "warning: db_password: $LABEL_SECRET" \
+  "WARNING: client_secret: $LABEL_SECRET" \
+  "fatal: api_key: $LABEL_SECRET" \
+  "info: refresh_token: $LABEL_SECRET" \
+  "response: error: api_key: $LABEL_SECRET" \
+  "2026-08-02 10:00:00 ERROR: password: $LABEL_SECRET"; do
+  display_input=$(jq -nc --arg stdout "$display_case" \
+    '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
+  post_tool_out "$display_input"
+  post_out=$(cat "$OUT")
+  if printf '%s' "$post_out" | grep -q '\[REDACTED\]' \
+     && ! printf '%s' "$post_out" | grep -Fq "$LABEL_SECRET"; then
+    ok "#156 post-tool masks a gitleaks-invisible secret behind a status label (${display_case%%:*})"
+  else
+    not_ok "#156 post-tool masks a gitleaks-invisible secret behind a status label (${display_case%%:*})"
+    printf '%s\n' "$post_out" | sed 's/^/  out: /'
+  fi
+done
+
+# #156 must-not-mask companions: the value-side gate decides on SHAPE, so an
+# ordinary word, a path, a number and a timestamp after a status label all stay
+# visible. Without these the gate could be made to pass by masking everything.
+for display_case in \
+  'error: secret: not-found' \
+  'warning: private_key: /path/to/configured/key' \
+  'error: token: 2026-08-30T10:00:00' \
+  'fatal: password: 10:00:00' \
+  'warning: api_key: Missing' \
+  'info: credential: unauthenticated'; do
+  display_input=$(jq -nc --arg stdout "$display_case" \
+    '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
+  post_tool_out "$display_input"
+  post_status=$?
+  if [ "$post_status" -eq 0 ] && [ ! -s "$OUT" ]; then
+    ok "#156 post-tool leaves a non-credential value after a status label untouched (${display_case##*: })"
+  else
+    not_ok "#156 post-tool leaves a non-credential value after a status label untouched (${display_case##*: })"
     sed 's/^/  out: /' "$OUT"
   fi
 done

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -7283,6 +7283,50 @@ else
   sed 's/^/  out: /' "$OUT"
 fi
 
+# The capture scans forward for ANY matching quote, so it can close on one that
+# belongs to something else — typically the OPENING quote of a credential
+# further down. Re-scanning only what was absorbed left that credential on the
+# far side of the eaten quote with its key consumed, so nothing masked it, on
+# the block path as well as display. The re-scan gets the rest of the line too.
+quoteeat_secret=$(printf '%s%s' 'sk-live-A1b2C3d4' 'e5F6g7H8secret')
+for quoteeat_shape in \
+  'error: %s: "\napi_key: "%s"' \
+  'warning: %s: " prose\nexport api_key="%s"' \
+  'hint: %s: "\nfiller\nfiller\ntoken = "%s"'; do
+  # shellcheck disable=SC2059
+  quoteeat_input=$(printf "$quoteeat_shape" password "$quoteeat_secret")
+  display_input=$(jq -nc --arg stdout "$quoteeat_input" \
+    '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
+  post_tool_out "$display_input"
+  post_out=$(cat "$OUT")
+  if printf '%s' "$post_out" | grep -q '\[REDACTED\]' \
+     && ! printf '%s' "$post_out" | grep -Fq "$quoteeat_secret"; then
+    ok "#156 a capture closing on a later credential's opening quote still masks it"
+  else
+    not_ok "#156 a capture closing on a later credential's opening quote still masks it"
+    printf '%s\n' "$post_out" | sed 's/^/  out: /'
+  fi
+done
+
+expect_json_status 2 "#156 the same shape still blocks at the prompt guard" \
+  "$(jq -nc --arg prompt "$(printf 'error: %s: "\napi_key: "%s"' password "$quoteeat_secret")" \
+    '{session_id:"t",hook_event_name:"UserPromptSubmit",prompt:$prompt}')" \
+  hook-user-prompt
+
+# The single-quote spelling behaves the same way.
+quoteeat_squote=$(printf "fatal: %s: '\npassword='%s'" secret "$quoteeat_secret")
+display_input=$(jq -nc --arg stdout "$quoteeat_squote" \
+  '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
+post_tool_out "$display_input"
+post_out=$(cat "$OUT")
+if printf '%s' "$post_out" | grep -q '\[REDACTED\]' \
+   && ! printf '%s' "$post_out" | grep -Fq "$quoteeat_secret"; then
+  ok "#156 the single-quote spelling of the eaten-quote shape still masks"
+else
+  not_ok "#156 the single-quote spelling of the eaten-quote shape still masks"
+  printf '%s\n' "$post_out" | sed 's/^/  out: /'
+fi
+
 # A guarded capture that fails the shape test must not swallow the rest of the
 # leaf. The capture absorbs every following line, so discarding it dropped the
 # assignments inside — an unterminated quote after a status label made real


### PR DESCRIPTION
Review of the remaining open issues, with each one reproduced on `main` (`818f540`) before anything was changed.

Closes #156

Refs #99 (measured and **not** taken — see below). Refs #169 (regression test only — that issue needs a release). Split out during this work: #178.

> **Note on history.** This branch went through nine review rounds and its early commits are not safe on their own — the first contained four read bypasses, and several later rounds found regressions introduced by the round before. Read the commits as a series, or read only the final state. A running account is in the round summaries: [round 1](https://github.com/JeongJaeSoon/agent-guard/pull/177#issuecomment-5470506872), [decisions](https://github.com/JeongJaeSoon/agent-guard/pull/177#issuecomment-5470832859).

## #156 — display redaction leaked behind an allowlisted status label

Reproduced exactly as filed:

```
IN : error: password: hunter2-long-value          OUT: (no rewrite)   <- leaked
IN : warning: db_password: hunter2-long-value     OUT: (no rewrite)   <- leaked
IN : response: password: hunter2-long-value       OUT: [REDACTED]     # fixed by #153
IN : DATABASE_PASSWORD=hunter2-long-value         OUT: [REDACTED]     # equals path
IN : error: password: authentication is disabled  OUT: (no rewrite)   # correct
```

The label cannot decide this, because it is identical in the prose chain the allowlist exists to protect. So the **value** decides. `credential_shaped()` masks a token that reads as a credential:

- a digit **adjacent to** a letter (`hunter2-long-value`, not `least 8 characters`);
- a lowercase letter with an uppercase run starting **past the first character** — a leading capital alone is sentence case;
- a single-case alphabetic run of 24+ characters, with `.`/`-`/`_` joins allowed (`correct-horse-battery-staple`).

and leaves visible: any value containing whitespace (a multi-word message is prose), and a complete date, timestamp or clock time — **anchored at both ends**, because a prefix match let `2026-01-01-sk-live-abc123XYZ` through.

Masking is **global**, like every other detection path. Scoping it to the labelled line was tried and reverted: `main` already scrubs a false-positive value from every line on the non-status path (`response: token: v1.2.3` scrubs each `v1.2.3` in the response), so scoping only made one path inconsistent while letting a recurrence of the real secret stay visible.

An **unterminated** quoted value (truncated output) opens the capture and is classified at the closing quote or leaf end, rather than skipped — including when the value begins on the next physical line. All three terminations honour that gate, `agent-guard exec`'s raw-probe path included. A capture that then fails the shape test is re-scanned as ordinary input, handed the text it absorbed *and* the rest of the line from the quote it closed on, so a credential the capture ate into still masks.

Both classification sites trim before deciding and record **both** forms of the value, so a padded (`" <secret> "`) or newline-separated credential masks on a bare recurrence further down as well.

Scope unchanged: PostToolUse display redaction only, block/detect path untouched.

Residual, documented in the code: a **bare** lowercase alphabetic secret shorter than 24 characters is the same shape as a prose word on this path and stays visible.

## #99 — measured, attempted, and deliberately abandoned

The issue **body** was closed by #100. The separate bug reported in the comment still reproduces on `main`, and this PR **does not fix it**:

```
echo foo.key             blocked
jq -r .key data.json     blocked      <- jq field selector
echo see also foo.pem    blocked
```

Nothing exists on disk in any of these and nothing is read. A command-position narrowing was written for it, and then removed again after nine rounds. The record, because it is the useful part:

| # | Narrowing as it stood | Reproduced read that broke it |
|---|---|---|
| 1 | drop operands of commands taking no file operands | `echo hi⏎cat .env` — a later line reads it |
| 2 | segment tracking inside the function | `echo a & cat .ssh/id_rsa` |
| 3 | " | `echo .env \| xargs cat` — the dropped word becomes the reader's operand |
| 4 | `jq` first non-option operand | `jq -f .env` |
| 5 | `yq` likewise | `yq .env` reads the file when one exists |
| 6 | basename of the command word | `./echo .env` |
| 7 | quote removal on the command word | `'echo foo' .env` — an executable literally named `echo foo` |
| 8 | external binaries dropped; builtins only | a `jq` wrapper earlier in `PATH` inherits the exception |
| 9 | `echo`/`printf` only, exact raw token, no shell syntax | `echo() { cat "$@"; }; echo .env` — a function beats the builtin |

Round 9 is the one that ended it. The justification for the last surviving form was that a shell builtin is the one name a text gate can keep a claim about, because bash runs the builtin whatever sits on `PATH`. That is true of `PATH` and false of the shell's own resolution order: functions and aliases are resolved **before** builtins.

```
$ bash -c 'echo() { cat "$@"; }; echo .env'
SECRET_MARKER=zzTOPSECRETzz          # the file is read
$ bash -c 'shopt -s expand_aliases; alias echo=cat; echo .env'
SECRET_MARKER=zzTOPSECRETzz          # same via alias
```

That exact one-liner bails on its own syntax, so it is not a one-shot bypass. It does not have to be: the shadow only has to already be in place — a host that keeps a persistent shell, or an `echo`/`printf` function in the profile the tool's shell is initialized from.

So the conclusion is a property of the approach, not of the eight patches: **a text gate that cannot name the program cannot safely drop its operands.** It drops none. #99 stays open as an accepted false positive — an annoying block costs less than a silent read — and every counter-example above is kept as a test so a future attempt has to answer them rather than rediscover them.

Also from that comment, and **kept**: `\"` inside the shell parser's awk bracket expression is not a defined escape, so gawk warned on every `hook-pre-tool` run. Verified under gawk 5.2.1 — the pre-change binary emits the warning three times per `git commit -m "…"` run, the new one is silent, and both spellings match `"`, `\`, `$`, `` ` `` and reject everything else identically under gawk and mawk.

## #169 — reproduces on v3.0.1, already fixed on main

A **match-extent** bug, not anything about nesting or size: an unquoted value ran to the end of its leaf and took the rest of the text with it.

```
IN    : API_KEY=example_token_value_long and then more prose after it
3.0.1 : API_KEY=[REDACTED]
main  : API_KEY=[REDACTED] and then more prose after it
```

Bisected to `ff50c21` (#145), which is on `main` and in **no release** — v3.0.1 users still have it, so the real remaining action there is cutting a release. Hence `Refs` rather than `Closes`. This PR adds the regression test that was missing: the nested MCP `tool_response` contract on both hosts, pinning exact-extent masking per leaf, untouched sibling fields and JSON shape, and a clean nested response passing through unrewritten.

## Verification

- `tests/run.sh`: **1091 passed, 0 failed** (990 on `main`).
- `shellcheck --severity=error` clean; **plugin scanner 0 high findings, 96/100** (run locally with plugin-scanner 2.2.121, matching the CI action).
- Every must-mask / must-not-mask case run through the real hook binary, not read off the regex.
- **50+ bypass probes** blocked, each first verified to really read the file with `bash -c` against a fixture directory. The `exec` raw-probe cases push >64 KiB with an invalid byte through the real command path.
- Deny-read behaviour is now **identical to `818f540`** — the narrowing that changed it is gone.
- Final adversarial differential pass against a real `818f540` worktree: **3,638 generated cases, 0 redaction regressions**, checked by extracting every span the baseline replaced and failing if it survives in the new output — not by marker presence. Covers gawk and mawk, all four record modes (`json`, `framed`, `probe`, `probe_raw`), multi-leaf and nested-array `tool_response`, CRLF, 4–8 KB lines, and `hook-user-prompt` exit-code parity.
- gawk 5.2.1 vs mawk 1.3.4: byte-identical over that corpus, no warnings from either, and the suite passes 1091/0 under both.

Two method notes, both of which cost a cycle here:

- a binary extracted with `git show :… > /tmp/x` is **not** a usable baseline. It resolves its policy files relative to its own location, so at a loose path it runs DEGRADED and falls open — every comparison becomes a false "allowed before". Use a real `git worktree`.
- the plugin scanner reads `tests/run.sh` and this script too. Its `HARDCODED_SECRET` rule keys on an unterminated quote after a credential-shaped key, so even a *prose* fixture written literally fails the build. Compose them at runtime, as the existing fixtures do.

`make bench` and `make smoke-test` were not run: both need a real gitleaks binary, unavailable in this environment. A **mock** gitleaks on `PATH` makes 38 tests fail — the shape-rule and lockfile-filter cases that shell out to the real binary — which is an artifact of the sandbox and not a repo bug; see [the correction](https://github.com/JeongJaeSoon/agent-guard/pull/177#issuecomment-5471650920).

## Review record

Nine Codex rounds plus three independent adversarial passes; **16 findings**, all reproduced before being acted on. Several were regressions introduced by my own previous round — worth knowing when reading the history.

## Deliberately out of scope

#178 — a `KEY=value` assignment inside a quoted JSON string leaf (`{"log":"API_KEY="}`, the ordinary MCP serialized-log shape) is skipped. Different root cause; fixed in #179.