### PR TITLE
fix(redaction): mask a KEY=value assignment inside a quoted string leaf (#178)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@
 
 ## Unreleased
 
+- fix(redaction): mask a `KEY=value` assignment inside a quoted string leaf
+  (#178). The ordinary shape of a tool that returns a serialized log —
+  `{"log":"starting with API_KEY=<value>"}` — reached the model in full on the
+  heuristic path. Two causes, both needed. The enclosing string's own closing
+  quote rode along on the value token, and `looks_like_reference()` tests for an
+  embedded quote without position, so a terminator at the very end marked the
+  token a nested reference and skipped it; a single trailing quote is now
+  stripped the way trailing `}`/`]`/`)` already were, and only when the
+  assignment does not itself begin with a quote, so the line-start re-scan of a
+  value an outer quoted assignment already claimed cannot emit a narrower
+  mapping that beats it. And `:` was not accepted as the delimiter before a
+  quoted key, so the JSON form never matched at all — it joins the class away
+  from `[`, since `[:` opens a POSIX character class and invalidates the whole
+  regex. Credential-handling source code is unchanged: `os.environ["DB_PASSWORD"]`
+  and `ENV.fetch("SESSION_KEY")` keep interior quotes and stay references.
+  Display redaction and the prompt guard; the block/detect path is unchanged.
 - fix(redaction): close the status-label display-redaction leak (#156). The
   seven-word status allowlist (`error`, `warning`, `info`, `note`, `debug`,
   `fatal`, `hint`) let a secret that gitleaks does not recognise reach the model

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
   regex. Credential-handling source code is unchanged: `os.environ["DB_PASSWORD"]`
   and `ENV.fetch("SESSION_KEY")` keep interior quotes and stay references.
   Display redaction and the prompt guard; the block/detect path is unchanged.
+  The strip stops at the redaction sentinel: `password=[REDACTED]"` would
+  otherwise lose the `]` that belongs to the marker, so `[REDACTED` was
+  re-emitted as a secret and a stray `]` appended — compounding on every pass
+  and making the prompt guard block text Agent Guard had itself redacted.
 - fix(redaction): close the status-label display-redaction leak (#156). The
   seven-word status allowlist (`error`, `warning`, `info`, `note`, `debug`,
   `fatal`, `hint`) let a secret that gitleaks does not recognise reach the model

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@
   otherwise lose the `]` that belongs to the marker, so `[REDACTED` was
   re-emitted as a secret and a stray `]` appended — compounding on every pass
   and making the prompt guard block text Agent Guard had itself redacted.
+  A trailing carriage return is skipped as edge whitespace, so CRLF output —
+  Windows tools, PowerShell, Docker and CI logs — masks the same shape it
+  does on LF; the carriage return itself is preserved.
 - fix(redaction): close the status-label display-redaction leak (#156). The
   seven-word status allowlist (`error`, `warning`, `info`, `note`, `debug`,
   `fatal`, `hint`) let a secret that gitleaks does not recognise reach the model

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -3342,6 +3342,13 @@ secretish_env_values() {
           # text agent-guard itself redacted.
           if (already_redacted(substr(value, 1, end))) return 0
           ch = substr(value, end, 1)
+          # `\r` is edge whitespace, not value: scan_leaf splits on `\n` and
+          # keeps the preceding carriage return, so on CRLF output the token is
+          # `…"}\r` and this loop stopped on the CR before it could reach the
+          # quote or the closers — leaving the exact shape #178 is about
+          # unmasked on Windows, PowerShell, Docker and CI logs. Stripping it
+          # keeps the replacement extent at the value: the CR stays in the text.
+          if (ch == "\r") { end--; continue }
           if (ch == "}" || ch == "]" || ch == ")") { end--; continue }
           # One trailing quote closes the string the assignment SITS INSIDE; it
           # is not part of the value. A tool returning a serialized log leaf

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -3331,6 +3331,16 @@ secretish_env_values() {
         end = length(value)
         strip_quote = 0
         while (end > 0) {
+          # Re-test after every strip, because the strip can walk INTO the
+          # redaction sentinel. `password=[REDACTED]"}` loses `}` and then the
+          # quote, and the next closer taken is the `]` that belongs to the
+          # marker itself. The pre-loop test passed (the tail held a quote),
+          # and after that
+          # `[REDACTED` no longer matches, so the fragment is re-emitted as a
+          # secret and a stray `]` appended. That compounds on every pass
+          # (`[REDACTED]]`, `[REDACTED]]]`) and makes the prompt guard BLOCK
+          # text agent-guard itself redacted.
+          if (already_redacted(substr(value, 1, end))) return 0
           ch = substr(value, end, 1)
           if (ch == "}" || ch == "]" || ch == ")") { end--; continue }
           # One trailing quote closes the string the assignment SITS INSIDE; it

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -3026,10 +3026,15 @@ secretish_env_values() {
       qualifier = "([_-](id|ids|value|val|hash|b64|base64|hex|enc|encrypted|encoded|raw|str|string|pem|cert|json|prod|production|dev|development|staging|stage|test|local|old|new|current|primary|secondary|backup|main|default|[0-9]+))*"
       key = "[a-z0-9_.-]*(" core "|[_-](pat|pwd))" qualifier
       # `(` and `[` open an argument or subscript list, so an assignment can
-      # begin immediately after one (`wrap(secret_key=<secret>)`). The value gate
+      # begin immediately after one (`wrap(secret_key=<secret>)`). `:` is here
+      # for the serialized-log leaf a tool returns as JSON: in a
+      # `{"log":"KEY=<value>"}` shape the only thing between the structure and
+      # the key is `:`, so without it the whole class went unmatched (#178).
+      # It must sit away from `[` in the class — `[:` opens a POSIX character
+      # class and makes the whole regex invalid. The value gate
       # below stops treating a whole call expression as a single literal, so a
       # nested assignment has to be reachable on its own to stay masked.
-      equals_assignment = "(^|[ \t,{;([])[\"'\''`]?" key "[\"'\''`]?[ \t]*="
+      equals_assignment = "(^|[ \t,:{;([])[\"'\''`]?" key "[\"'\''`]?[ \t]*="
       # A colon is ambiguous in prose. Accept it at the start of a YAML field,
       # after a JSON/map/argument delimiter, or after plain whitespace (log lines
       # such as `10:00:00 password: hunter2`); the loop below rejects the
@@ -3324,10 +3329,33 @@ secretish_env_values() {
         if (already_redacted(value)) return 0
         token = value
         end = length(value)
+        strip_quote = 0
         while (end > 0) {
           ch = substr(value, end, 1)
-          if (ch != "}" && ch != "]" && ch != ")") break
-          end--
+          if (ch == "}" || ch == "]" || ch == ")") { end--; continue }
+          # One trailing quote closes the string the assignment SITS INSIDE; it
+          # is not part of the value. A tool returning a serialized log leaf
+          # puts the JSON string terminator right after the credential, and
+          # leaving it attached made the token carry a quote, which
+          # looks_like_reference() reads as a nested string — so the whole class
+          # went unmasked (#178). Exactly one, only at the very end, so an
+          # interior quote still marks a reference and the accessor forms in
+          # the #169 assertions stay preserved.
+          #
+          # Not when the ASSIGNMENT ITSELF begins with a quote. That marks the
+          # line-start rescan of a value an OUTER quoted assignment already
+          # claimed: scan_line advances past the matched key only, so the inner
+          # text is examined a second time and matches via the `^` alternative.
+          # The outer match has already emitted the whole quoted value as the
+          # secret; stripping here produced a second, narrower mapping that beat
+          # it and left the inner key prefix on display.
+          if (strip_quote == 0 && assignment !~ /^["'\''`]/ \
+              && (ch == "\"" || ch == "'\''" || ch == "`")) {
+            strip_quote = 1
+            end--
+            continue
+          }
+          break
         }
         value = substr(value, 1, end)
         if (looks_like_reference(value, assignment, leading)) return 0

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -7415,6 +7415,35 @@ else
   printf '%s\n' "$post_out" | sed 's/^/  out: /'
 fi
 
+# The trailing-quote strip must not walk INTO the redaction sentinel. With a
+# quote after it (`password=[REDACTED]"}` — exactly the leaf shape #178 adds)
+# the loop took `}`, then the quote, then the `]` that belongs to the marker,
+# so already_redacted() stopped matching, `[REDACTED` was re-emitted as a
+# secret and a stray `]` appended. It compounded on every pass and made the
+# prompt guard BLOCK text agent-guard itself had redacted. The pre-existing
+# idempotence assertion only covers the bare form, so it did not catch this.
+for jsonleaf_sentinel in \
+  '{"log":"password=[REDACTED]"}' \
+  '{"a":{"b":"tok=[REDACTED]"}}' \
+  '{"log":"api_key=[REDACTED]"} see also [REDACTED] and [REDACTEDX]' \
+  'prefix "DB_PASSWORD=[REDACTED]" suffix'; do
+  display_input=$(jq -nc --arg stdout "$jsonleaf_sentinel" \
+    '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
+  post_tool_out "$display_input"
+  post_status=$?
+  if [ "$post_status" -eq 0 ] && [ ! -s "$OUT" ]; then
+    ok "#178 a redaction sentinel inside a quoted leaf stays idempotent"
+  else
+    not_ok "#178 a redaction sentinel inside a quoted leaf stays idempotent"
+    sed 's/^/  out: /' "$OUT"
+  fi
+done
+
+expect_json_status 0 "#178 the prompt guard does not block its own sentinel in a quoted leaf" \
+  "$(jq -nc --arg prompt '{"log":"password=[REDACTED]"}' \
+    '{session_id:"t",hook_event_name:"UserPromptSubmit",prompt:$prompt}')" \
+  hook-user-prompt
+
 # Display redaction must not mangle credential-handling SOURCE CODE. A
 # credential-shaped key on the left says nothing about the right-hand side: a
 # reference (`process.env.API_KEY`, `os.environ["DB_PASSWORD"]`, `config.apiKey`,

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -7444,6 +7444,45 @@ expect_json_status 0 "#178 the prompt guard does not block its own sentinel in a
     '{session_id:"t",hook_event_name:"UserPromptSubmit",prompt:$prompt}')" \
   hook-user-prompt
 
+# CRLF output (Windows tools, PowerShell, Docker and CI logs) kept a carriage
+# return glued to the value token, and the strip loop stopped on it before it
+# could reach the quote or the closers — leaving the exact shape #178 is about
+# unmasked. `\r` is edge whitespace here, as it already is in edge_trim(); the
+# replacement extent stays the value, so the CR survives in the output.
+JSONLEAF_CR_SECRET=$(printf '%s%s' 'hunter2-' 'long-value')
+for jsonleaf_cr_spec in \
+  '{"log":"API_KEY=%s"}\r' \
+  'API_KEY=%s\r' \
+  'a\r\n{"log":"API_KEY=%s"}\r\nb'; do
+  # shellcheck disable=SC2059
+  jsonleaf_cr=$(printf "$jsonleaf_cr_spec" "$JSONLEAF_CR_SECRET")
+  display_input=$(jq -nc --arg stdout "$jsonleaf_cr" \
+    '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
+  post_tool_out "$display_input"
+  post_out=$(cat "$OUT")
+  if printf '%s' "$post_out" | grep -q '\[REDACTED\]' \
+     && ! printf '%s' "$post_out" | grep -Fq "$JSONLEAF_CR_SECRET"; then
+    ok "#178 a CRLF quoted leaf still masks"
+  else
+    not_ok "#178 a CRLF quoted leaf still masks"
+    printf '%s\n' "$post_out" | sed 's/^/  out: /'
+  fi
+done
+
+# The carriage return is edge whitespace, not part of the value: it must stay
+# in the rewritten text, or the extent guarantee #169 pins is broken.
+display_input=$(jq -nc --arg stdout "$(printf '{"log":"API_KEY=%s"}\r' "$JSONLEAF_CR_SECRET")" \
+  '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
+post_tool_out "$display_input"
+if cat "$OUT" \
+  | jq -e '.hookSpecificOutput.updatedToolOutput.stdout
+      == "{\"log\":\"API_KEY=[REDACTED]\"}\r"' >/dev/null 2>&1; then
+  ok "#178 the carriage return survives the CRLF rewrite"
+else
+  not_ok "#178 the carriage return survives the CRLF rewrite"
+  sed 's/^/  out: /' "$OUT"
+fi
+
 # Display redaction must not mangle credential-handling SOURCE CODE. A
 # credential-shaped key on the left says nothing about the right-hand side: a
 # reference (`process.env.API_KEY`, `os.environ["DB_PASSWORD"]`, `config.apiKey`,

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -7363,6 +7363,58 @@ for display_case in \
   fi
 done
 
+# #178: a KEY=value assignment INSIDE a quoted JSON string leaf — the ordinary
+# shape of a tool that returns a serialized log — was skipped entirely. Two
+# causes, both needed: the string's own closing quote rode along on the value
+# token and looks_like_reference() read it as a nested string, and `:` was not
+# accepted as the delimiter before a quoted key, so the JSON form never matched
+# at all. gitleaks-detectable content was masked in the same shape throughout,
+# which is what pins this to the heuristic path.
+JSONLEAF_SECRET=$(printf '%s%s' 'hunter2-' 'long-value')
+for display_case in \
+  "{\"log\":\"DB_PASSWORD=$JSONLEAF_SECRET\"}" \
+  "{\"level\":\"info\",\"log\":\"starting with API_KEY=$JSONLEAF_SECRET\",\"ok\":true}" \
+  "prefix \"DB_PASSWORD=$JSONLEAF_SECRET\" suffix" \
+  "{\"a\":{\"b\":\"API_KEY=$JSONLEAF_SECRET\"}}" \
+  "{\"log\":\"DB_PASSWORD=$JSONLEAF_SECRET,x\"}"; do
+  display_input=$(jq -nc --arg stdout "$display_case" \
+    '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
+  post_tool_out "$display_input"
+  post_out=$(cat "$OUT")
+  if printf '%s' "$post_out" | grep -q '\[REDACTED\]' \
+     && ! printf '%s' "$post_out" | grep -Fq "$JSONLEAF_SECRET"; then
+    ok "#178 post-tool masks an assignment inside a quoted JSON string leaf"
+  else
+    not_ok "#178 post-tool masks an assignment inside a quoted JSON string leaf"
+    printf '%s\n' "$post_out" | sed 's/^/  out: /'
+  fi
+done
+
+# The same shape on the BLOCK path, since a serialized log is exactly what an
+# agent pastes back into a prompt.
+jsonleaf_prompt="{\"log\":\"DB_PASSWORD=$JSONLEAF_SECRET\"}"
+expect_json_status 2 "#178 an assignment inside a quoted JSON string leaf still blocks at the prompt guard" \
+  "$(jq -nc --arg prompt "$jsonleaf_prompt" \
+    '{session_id:"t",hook_event_name:"UserPromptSubmit",prompt:$prompt}')" \
+  hook-user-prompt
+
+# The trailing-quote strip must NOT fire on the line-start rescan of a value an
+# outer quoted assignment already claimed, or it emits a second, narrower
+# mapping that beats the outer one and strands the key prefix on display.
+JSONLEAF_SHARED=$(printf '%s%s' 'PASSWORD=' 'abc)')
+display_input=$(jq -nc --arg stdout "$JSONLEAF_SHARED API_TOKEN=\"$JSONLEAF_SHARED\" status=ok" \
+  '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
+post_tool_out "$display_input"
+post_out=$(cat "$OUT")
+if printf '%s' "$post_out" \
+  | jq -e '.hookSpecificOutput.updatedToolOutput.stdout
+      | contains("API_TOKEN=\"[REDACTED]\"")' >/dev/null 2>&1; then
+  ok "#178 the outer quoted assignment still wins over its own rescan"
+else
+  not_ok "#178 the outer quoted assignment still wins over its own rescan"
+  printf '%s\n' "$post_out" | sed 's/^/  out: /'
+fi
+
 # Display redaction must not mangle credential-handling SOURCE CODE. A
 # credential-shaped key on the left says nothing about the right-hand side: a
 # reference (`process.env.API_KEY`, `os.environ["DB_PASSWORD"]`, `config.apiKey`,

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -6668,6 +6668,42 @@ else
   printf '%s\n' "$post_out" | sed 's/^/  out: /'
 fi
 
+# Idempotence as a PROPERTY, not a handful of literals. The assertion above
+# pins one bare sentinel with nothing after it, and that is exactly why the
+# quoted-leaf corruption got through: `password=[REDACTED]"}` walked the strip
+# into the marker, so the second pass re-masked a fragment and appended a `]`,
+# and it compounded on every further pass. Feed each redacted output straight
+# back in: a second pass must produce no rewrite at all.
+DISPLAY_IDEM_SECRET=$(printf '%s%s' 'hunter2-' 'long-value')
+for display_idem_case in \
+  "{\"log\":\"API_KEY=$DISPLAY_IDEM_SECRET\"}" \
+  "{\"level\":\"info\",\"log\":\"start API_KEY=$DISPLAY_IDEM_SECRET\",\"ok\":true}" \
+  "prefix \"DB_PASSWORD=$DISPLAY_IDEM_SECRET\" suffix" \
+  "{\"a\":{\"b\":\"API_KEY=$DISPLAY_IDEM_SECRET\"}}" \
+  "{\"log\":\"DB_PASSWORD=$DISPLAY_IDEM_SECRET,x\"}" \
+  "API_KEY=$DISPLAY_IDEM_SECRET" \
+  "error: password: $DISPLAY_IDEM_SECRET" \
+  "$(printf '{"log":"API_KEY=%s"}\r' "$DISPLAY_IDEM_SECRET")"; do
+  display_input=$(jq -nc --arg stdout "$display_idem_case" \
+    '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
+  post_tool_out "$display_input"
+  display_idem_first=$(jq -r '.hookSpecificOutput.updatedToolOutput.stdout // empty' <"$OUT" 2>/dev/null)
+  if [ -z "$display_idem_first" ]; then
+    not_ok "#178 idempotence precondition: first pass masks '$display_idem_case'"
+    continue
+  fi
+  display_input=$(jq -nc --arg stdout "$display_idem_first" \
+    '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
+  post_tool_out "$display_input"
+  if [ ! -s "$OUT" ]; then
+    ok "#178 a redacted output is unchanged when fed back through post-tool"
+  else
+    not_ok "#178 a redacted output is unchanged when fed back through post-tool"
+    printf '  in : %s\n' "$display_idem_first"
+    sed 's/^/  out: /' "$OUT"
+  fi
+done
+
 display_input=$(jq -nc \
   --arg stdout 'PASSWORD=[REDACTED]]evil-suffix' \
   '{tool_name:"Bash",tool_input:{command:"x"},tool_response:


### PR DESCRIPTION
Closes #178

Split out of #177 as promised there. Reproduced on `main` before and after that merge — #177 does not touch this path.

## The gap

The ordinary shape of a tool that returns a serialized log reached the model in full, on the heuristic path:

```
IN : {"level":"info","log":"starting with API_KEY=hunter2-long-value","ok":true}
OUT: (no rewrite)
```

`hunter2-long-value` is the value the suite already uses to stand for "a secret gitleaks misses", so this is the heuristic specifically — anything gitleaks recognises was masked in the same shape throughout, which is what pins it.

## Two causes, both required

I expected one. Fixing only the quote left the JSON form still unmasked, which is what turned up the second.

**1. The enclosing string's closing quote rode along on the value token.** The unquoted branch cuts at `[ \t,;]` and strips trailing `}`, `]`, `)`, so the token was `hunter2-long-value"`. `looks_like_reference()` then tests for an embedded quote with an *unpositioned* `index()`:

```awk
|| index(value, "\"") || index(value, "'") || index(value, "`"))
  return 1
```

A quote anywhere — including as the final character — marks the token a nested reference and skips it.

Fixed the way the issue suggests, and the way the opener tests are already positioned: strip exactly one trailing quote, only at the very end, so an interior quote still marks a reference.

With one guard the issue does not mention. The strip must **not** fire when the assignment itself begins with a quote. That marks the line-start re-scan of a value an outer quoted assignment already claimed: `scan_line` advances past the matched key only, so the inner text is examined a second time and matches via the `^` alternative. The outer match has already emitted the whole quoted value; stripping again produced a second, narrower mapping that beat it and stranded the inner key prefix on display:

```
IN  : PASSWORD=abc) API_TOKEN="PASSWORD=abc)" status=ok
BAD : PASSWORD=abc) API_TOKEN="PASSWORD=[REDACTED])" status=ok   <- key prefix visible
NOW : PASSWORD=abc) API_TOKEN="[REDACTED]" status=ok
```

That case is pinned as a test. The guard has a cost, tracked separately in #180: a leaf line that *begins* with a quoted assignment still leaks. That shape leaks on `main` too, so it is residual rather than a regression, and getting both properties needs a different change from this one.

**2. `:` was not a delimiter before a quoted key.** `equals_assignment` required `(^|[ \t,{;([])` before the optional opening quote. In a `{"log":"KEY=<value>"}` shape the only thing between the structure and the key is `:`, so the entire class went unmatched regardless of the quote fix.

It must sit **away from `[`** in the bracket expression — `[:` opens a POSIX character class and invalidates the whole regex, which silently disables *all* masking rather than failing loudly. Confirmed the hard way in review: `[ \t,{;([:]` is fatal in both awks (`mawk: bad class`, `gawk: Unmatched [, [^, [:`), while `[ \t,:{;([]` is clean under `gawk --lint` and `--posix`.

## Two defects found in adversarial review, both fixed

Written up in full [here](https://github.com/JeongJaeSoon/agent-guard/pull/179#issuecomment-5471887931). Both were in the strip loop, and both would have shipped without the review.

**`f2ae9f8` — the strip walked into the redaction sentinel.** With a quote after it, `password=[REDACTED]"}` lost `}`, then the quote, then the `]` belonging to the marker. `already_redacted()` ran only *before* the loop, so `[REDACTED` was re-emitted as a secret and a `]` appended — compounding on every pass, damaging every `[REDACTED` in the response, taking the prompt guard from exit 0 to **exit 2** on text Agent Guard had itself redacted, and annihilating a >64 KiB non-UTF-8 `exec` stream that contained nothing else. Now re-tested after every strip.

**`985f4f1` — one carriage return defeated the whole fix.** `{"log":"API_KEY=<secret>"}\r\n` did not mask at all, while the LF form did: the loop stopped on the CR before reaching the quote. That is Windows tools, PowerShell, Docker and CI logs. `\r` is edge whitespace here, as it already is in `edge_trim()`; the extent still stops at the value, so the carriage return survives in the output.

## Verification

Acceptance criteria from the issue, run through the real hook binary:

| | |
|---|---|
| `{"log":"API_KEY=…"}` | masked |
| `{"level":"info","log":"starting with API_KEY=…","ok":true}` | masked, siblings and JSON shape preserved |
| `prefix "DB_PASSWORD=…" suffix` | masked |
| `{"a":{"b":"API_KEY=…"}}` | masked |
| `{"log":"DB_PASSWORD=…,x"}` | masked, `,x` preserved |
| the same with CRLF line endings | masked, the CR preserved |
| nested MCP `content[].text`, both host contracts | masked |
| clean nested response | no rewrite |
| a leaf already carrying `[REDACTED]` | no rewrite, idempotent |
| the same shape at the prompt guard | rc 2 for a secret, rc 0 for a sentinel |

Must-not-mask, the #169 source-code preservation assertions, all still pass unchanged:

```
process.env.API_KEY          preserved
os.environ["DB_PASSWORD"]    preserved
config.apiKey                preserved
ENV.fetch("SESSION_KEY")     preserved
${API_KEY:?required}         preserved
```

- Differential against a real `94af279` worktree: **5,252 cases (1,252 structured + 4,000 fuzz), 0 regressions**, checked by extracting every span the baseline replaced and failing if it survives verbatim — not by marker presence. `hook-user-prompt` exit codes compared across the corpus: no case where base blocks and head allows.
- `tests/run.sh`: **1107 passed, 0 failed**, identical under mawk 1.3.4 and gawk 5.2.1.
- `shellcheck --severity=error` clean; plugin scanner **0 high, 96/100** (plugin-scanner 2.2.121, matching the CI action).
- Replacement extent is exactly the value: the enclosing quote, the carriage return and the rest of the leaf are preserved, per the #169 regression test merged in #177.
- Block/detect path unchanged. This is display redaction plus the prompt guard, which shares the same heuristic.

## Considered and dismissed, with measurements

Two review findings turned out to be pre-existing behaviour that this PR extends consistently rather than new bugs — the reasoning and numbers are in the review comment. In short: global masking of an ordinary word (`api_key=production` scrubbing every `production`) is what `main` already does for the unquoted form, and total replacement of a large non-UTF-8 `exec` output is the raw probe path being all-or-nothing by design. Making the JSON shape quieter than the bare one would be the inconsistency.

## Non-goals honoured

The gitleaks path is untouched, and the reference heuristic is not removed — only positioned.