### PR TITLE
fix(redaction): accept a carriage return as an assignment delimiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,11 @@
   previous release commit over 2,518 carriage-return shapes: 357 real leaks
   closed, 6 false-positive prose masks removed, and every other newly masked
   case byte-identical to what that commit already produced with a space in the
-  same position.
+  same position. The status guard in `scan_line` tests the delimiter character
+  directly and had to agree: with the carriage return between the label and the
+  key (`error:\rpassword: <prose>`) the colon assignment matches at the CR, and
+  while that check accepted only space and tab the label went unrecognised and
+  the prose was masked.
 - fix(redaction): mask a `KEY=value` assignment inside a quoted string leaf
   (#178). The ordinary shape of a tool that returns a serialized log —
   `{"log":"starting with API_KEY=<value>"}` — reached the model in full on the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@
 
 ## Unreleased
 
+- fix(redaction): accept a carriage return as an assignment delimiter. A `\r`
+  before the key hid the assignment completely, on display and at the prompt
+  guard, so a secret printed after a progress meter, a spinner, or on
+  classic-Mac line endings reached the model in full and was not blocked when
+  pasted back:
+
+  ```
+    0 12.3M    0 16384    0     0  50000      0\rAPI_KEY=<secret>   ->  no rewrite
+  ```
+
+  `\r` is a delimiter for the same reason it is edge whitespace on the value
+  side: it separates fields on screen and belongs to neither. It joins the
+  leading class of both assignment forms and of the status-label test, so the
+  prose chain the status allowlist protects (`error: password: authentication
+  is disabled`) is now recognised after a carriage return too — previously the
+  label went unseen there and the prose was masked. Measured against the
+  previous release commit over 2,518 carriage-return shapes: 357 real leaks
+  closed, 6 false-positive prose masks removed, and every other newly masked
+  case byte-identical to what that commit already produced with a space in the
+  same position.
 - fix(redaction): mask a `KEY=value` assignment inside a quoted string leaf
   (#178). The ordinary shape of a tool that returns a serialized log —
   `{"log":"starting with API_KEY=<value>"}` — reached the model in full on the

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -3034,14 +3034,21 @@ secretish_env_values() {
       # class and makes the whole regex invalid. The value gate
       # below stops treating a whole call expression as a single literal, so a
       # nested assignment has to be reachable on its own to stay masked.
-      equals_assignment = "(^|[ \t,:{;([])[\"'\''`]?" key "[\"'\''`]?[ \t]*="
+      #
+      # `\r` is a delimiter for the same reason it is edge whitespace on the
+      # value side: a carriage return separates fields on screen but is not
+      # part of either. Without it a CR before the key hid the assignment
+      # completely — a curl or pip progress meter, a spinner, or classic-Mac
+      # line endings all put one there, and `<meter>\rAPI_KEY=<secret>` leaked
+      # in full and did not block at the prompt guard.
+      equals_assignment = "(^|[ \t\r,:{;([])[\"'\''`]?" key "[\"'\''`]?[ \t]*="
       # A colon is ambiguous in prose. Accept it at the start of a YAML field,
       # after a JSON/map/argument delimiter, or after plain whitespace (log lines
       # such as `10:00:00 password: hunter2`); the loop below rejects the
       # whitespace form only when the preceding token is a known status word,
       # which marks a prose chain like `error: password: authentication is
       # disabled`.
-      colon_assignment = "(^[ \t]*|[,{([][ \t]*|[ \t]+)[\"'\''`]?" key "[\"'\''`]?[ \t]*:"
+      colon_assignment = "(^[ \t\r]*|[,{([][ \t\r]*|[ \t\r]+)[\"'\''`]?" key "[\"'\''`]?[ \t]*:"
       # Skipping after ANY colon-terminated token also let real structured log
       # lines through unmasked (`response: api_key: <secret>`), so only these
       # status words justify the skip. Deliberately short: an unlisted label
@@ -3051,7 +3058,7 @@ secretish_env_values() {
       # `response.error:` / `response/error:` are structured labels and must
       # not suppress masking. Matched against the lowercased line, so `Error:` /
       # `ERROR:` are covered too, including after a timestamp/log prefix.
-      status_label = "(^|[ \t])(error|warning|info|note|debug|fatal|hint)[ \t]*:$"
+      status_label = "(^|[ \t\r])(error|warning|info|note|debug|fatal|hint)[ \t]*:$"
       boundary = sprintf("%c", 30)
       escape = sprintf("%c", 31)
     }

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -3481,7 +3481,13 @@ secretish_env_values() {
         status_guard = 0
         if (chose_colon && start > 1) {
           first = substr(rest, start, 1)
-          if ((first == " " || first == "\t") &&
+          # `\r` belongs with space and tab here, or the guard misses the shape
+          # the delimiter widening just made reachable: with a carriage return
+          # between the label and the key (`error:\rpassword: <prose>`) the
+          # colon assignment now matches AT the CR, this test saw a character
+          # that was not space or tab, the status label went unrecognised, and
+          # the prose chain the allowlist exists to protect was masked.
+          if ((first == " " || first == "\t" || first == "\r") &&
               match(substr(low, 1, start - 1), status_label))
             status_guard = 1
           # `${NAME:-default}` / `${NAME:?message}` / `${NAME:=x}` / `${NAME:+x}`

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -7536,6 +7536,38 @@ expect_json_status 2 "#178 an assignment after a carriage return still blocks at
     '{session_id:"t",hook_event_name:"UserPromptSubmit",prompt:$prompt}')" \
   hook-user-prompt
 
+# The status guard in scan_line tests the delimiter character imperatively, and
+# it has to agree with the regexes: with a carriage return BETWEEN the label and
+# the key (`error:\rpassword: <prose>`) the colon assignment now matches at the
+# CR, and while that check accepted only space and tab the label went
+# unrecognised and the prose chain was masked. Every status word, both ways
+# round: prose stays visible, a credential-shaped value still masks.
+CRGUARD_SECRET=$(printf '%s%s' 'hunter2-' 'long-value')
+for crguard_label in error warning info note debug fatal hint; do
+  display_input=$(jq -nc --arg stdout "$(printf '%s:\rpassword: authentication is disabled' "$crguard_label")" \
+    '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
+  post_tool_out "$display_input"
+  post_status=$?
+  if [ "$post_status" -eq 0 ] && [ ! -s "$OUT" ]; then
+    ok "#156 a status-label prose chain split by a carriage return stays visible"
+  else
+    not_ok "#156 a status-label prose chain split by a carriage return stays visible"
+    sed 's/^/  out: /' "$OUT"
+  fi
+
+  display_input=$(jq -nc --arg stdout "$(printf '%s:\rpassword: %s' "$crguard_label" "$CRGUARD_SECRET")" \
+    '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
+  post_tool_out "$display_input"
+  post_out=$(cat "$OUT")
+  if printf '%s' "$post_out" | grep -q '\[REDACTED\]' \
+     && ! printf '%s' "$post_out" | grep -Fq "$CRGUARD_SECRET"; then
+    ok "#156 a credential behind a carriage-return-split status label still masks"
+  else
+    not_ok "#156 a credential behind a carriage-return-split status label still masks"
+    printf '%s\n' "$post_out" | sed 's/^/  out: /'
+  fi
+done
+
 # The status-label value gate still decides after a carriage return: the prose
 # chain the allowlist exists to protect stays visible.
 display_input=$(jq -nc --arg stdout "$(printf 'x\rerror: password: authentication is disabled')" \

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -7505,6 +7505,50 @@ for jsonleaf_cr_spec in \
   fi
 done
 
+# `\r` is a leading DELIMITER for the same reason it is edge whitespace on the
+# value side. Without it a carriage return before the key hid the assignment
+# entirely, on display and at the prompt guard — and a CR before a field is
+# what curl and pip progress meters, spinners and classic-Mac line endings all
+# produce, so `<meter>\rAPI_KEY=<secret>` leaked in full.
+JSONLEAF_CRKEY_SECRET=$(printf '%s%s' 'hunter2-' 'long-value')
+crkey_meter=$(printf '  0 12.3M    0 16384    0     0  50000      0\rAPI_KEY=%s\r\n' \
+  "$JSONLEAF_CRKEY_SECRET")
+for crkey_case in \
+  "$(printf 'x\rAPI_KEY=%s' "$JSONLEAF_CRKEY_SECRET")" \
+  "$(printf 'x\rpassword: %s' "$JSONLEAF_CRKEY_SECRET")" \
+  "$(printf 'x\rerror: password: %s' "$JSONLEAF_CRKEY_SECRET")" \
+  "$crkey_meter"; do
+  display_input=$(jq -nc --arg stdout "$crkey_case" \
+    '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
+  post_tool_out "$display_input"
+  post_out=$(cat "$OUT")
+  if printf '%s' "$post_out" | grep -q '\[REDACTED\]' \
+     && ! printf '%s' "$post_out" | grep -Fq "$JSONLEAF_CRKEY_SECRET"; then
+    ok "#178 an assignment after a carriage return still masks"
+  else
+    not_ok "#178 an assignment after a carriage return still masks"
+    printf '%s\n' "$post_out" | sed 's/^/  out: /'
+  fi
+done
+
+expect_json_status 2 "#178 an assignment after a carriage return still blocks at the prompt guard" \
+  "$(jq -nc --arg prompt "$crkey_meter" \
+    '{session_id:"t",hook_event_name:"UserPromptSubmit",prompt:$prompt}')" \
+  hook-user-prompt
+
+# The status-label value gate still decides after a carriage return: the prose
+# chain the allowlist exists to protect stays visible.
+display_input=$(jq -nc --arg stdout "$(printf 'x\rerror: password: authentication is disabled')" \
+  '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
+post_tool_out "$display_input"
+post_status=$?
+if [ "$post_status" -eq 0 ] && [ ! -s "$OUT" ]; then
+  ok "#156 a status-label prose chain after a carriage return stays visible"
+else
+  not_ok "#156 a status-label prose chain after a carriage return stays visible"
+  sed 's/^/  out: /' "$OUT"
+fi
+
 # The carriage return is edge whitespace, not part of the value: it must stay
 # in the rewritten text, or the extent guarantee #169 pins is broken.
 display_input=$(jq -nc --arg stdout "$(printf '{"log":"API_KEY=%s"}\r' "$JSONLEAF_CR_SECRET")" \


### PR DESCRIPTION
Follow-up to #179, found by adversarial re-verification of the CRLF fix that PR added.

## The leak

#179 made `\r` edge whitespace on the **value** side. It was never accepted before the **key**, so a carriage return in front of an assignment hid it completely — on display and at the prompt guard:

```
IN     :   0 12.3M    0 16384    0     0  50000      0\rAPI_KEY=hunter2-long-value\r\n
main   : no rewrite, prompt guard exit 0     <- secret reaches the model, and is not blocked
this PR: …0\rAPI_KEY=[REDACTED]\r\n,  prompt guard exit 2
```

The same line with a **space** where the `\r` is has always masked and blocked. So this was not a policy decision anywhere — the CR position was simply never reachable.

It is not an exotic shape either. A carriage return before a field is what curl and pip progress meters, spinners, and classic-Mac line endings all produce, and those are ordinary in the tool output an agent reads back.

## The change

`\r` joins the leading class of `equals_assignment` and `colon_assignment`, and of `status_label`.

That third one matters on its own and is easy to miss. Without it the status word goes unseen after a carriage return, so the prose chain the allowlist exists to protect loses its protection and gets a word masked out of it:

```
IN     : <spinner>\rerror: password: authentication is disabled
main   : <spinner>\rerror: password: [REDACTED] is disabled     <- false positive
this PR: no rewrite
```

`\r` is a delimiter for the same reason #179 made it edge whitespace: it separates fields on screen and belongs to neither the key nor the value.

## Verification

Measured against `274bc6e` (the #179 merge) over a corpus of **2,518 carriage-return shapes** — progress meters, spinners, CR in every position relative to the key and `=`, prose values, source-code values, and 1,500 random strings drawn from an alphabet including `\r`:

| | |
|---|---|
| real leaks closed (secret visible on `main`, masked here) | **357** |
| secrets still visible after this change | **0** |
| false-positive prose masks removed | **6** |
| other newly masked cases | 448 — **each verified byte-identical to what `274bc6e` already produces with a space in the same position** |

That last row is the one to check rather than take on trust. Every case in it is the pre-existing behaviour of the space position now reaching the CR position, not a new behaviour class:

```
main, space form : x API_KEY=authentication is disabled  ->  x API_KEY=[REDACTED] is disabled
main, space form : x API_KEY: required                   ->  x API_KEY: [REDACTED]
```

Both are what `main` does today; this PR makes `x\rAPI_KEY=…` do the same. Whether that masking is right is a separate question about the value gate on the non-status path — it is unchanged here, and narrowing it would be its own change.

Also:

- Structured and fuzz corpora (**5,252 cases**) against `274bc6e`: **0 differences**. Neither contains a carriage return, so they confirm nothing else moved.
- `tests/run.sh`: **1121 passed, 0 failed**, identical under mawk 1.3.4 and gawk 5.2.1.
- `shellcheck --severity=error` clean; plugin scanner **0 high, 96/100**.
- New assertions cover: the meter shape on display and at the prompt guard, `\r` before an `=` key, before a `:` key, before a status label, and the status-label prose chain staying visible after a `\r`.

Block/detect path unchanged apart from the prompt guard, which shares this heuristic and is the half that was letting the secret through unblocked.

## Not in scope

The adversarial pass also re-flagged the `agent-guard exec` raw-probe branch replacing an entire >64 KiB non-UTF-8 output when anything matches. That is the all-or-nothing design at that site, predates all of this, and is unchanged here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BK9rt1R3SSaeXjEGgtF2Au)_