### PR TITLE
fix: address post-merge hook regressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@
 
 ## Unreleased
 
+- fix(hooks): treat malformed `UserPromptSubmit` JSON as an infrastructure
+  failure instead of collapsing a failed `jq` extraction into an empty prompt.
+  The opt-in closed policy now blocks; the default open policy emits one
+  host-shaped degradation notice.
+- fix(shell): when SessionStart still receives a fish `$SHELL`, require both
+  `.bashrc` and `.zshrc` managed blocks to remain loadable. The host snapshot may
+  choose either shell, so one surviving rc can no longer silence the warning
+  while the other snapshot path is unprotected.
+- fix(redaction): limit the `:` equals-assignment delimiter to the quoted string
+  leaf it was added for. Serialized output such as
+  `{"log":"API_KEY=<value>"}` still masks, while valid compact source such as
+  the JavaScript labelled statement `label:API_KEY=config.apiKey;` is preserved
+  on display and accepted by the prompt guard.
 - fix(redaction): accept a carriage return as an assignment delimiter. A `\r`
   before the key hid the assignment completely, on display and at the prompt
   guard, so a secret printed after a progress meter, a spinner, or on

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -3417,7 +3417,7 @@ secretish_env_values() {
     function scan_line(line, rest, end, low, eq_start, eq_length, \
                        colon_start, colon_length, start, matched_length, \
                        chose_colon, skip, status_guard, first, expansion, \
-                       closed_value) {
+                       closed_value, key_opener) {
       rest = line
       if (open_quote != "") {
         end = quoted_end(rest, open_quote)
@@ -3479,8 +3479,20 @@ secretish_env_values() {
         # whose innermost label is a status word: the value decides there too.
         skip = 0
         status_guard = 0
+        first = substr(rest, start, 1)
+        # `:` joined the equals delimiter class only for a serialized string
+        # leaf (`{"log":"API_KEY=<secret>"}`), where it is immediately followed
+        # by the quote that opens the leaf. Without requiring that quote, valid
+        # compact source such as the JavaScript labelled statement
+        # `label:API_KEY=config.apiKey;` becomes newly reachable and the shared
+        # prompt guard blocks it. Preserve the pre-widening behavior for an
+        # unquoted key after a colon while keeping the quoted JSON form.
+        if (!chose_colon && first == ":") {
+          key_opener = substr(rest, start + 1, 1)
+          if (key_opener != "\"" && key_opener != "'\''" && key_opener != "`")
+            skip = 1
+        }
         if (chose_colon && start > 1) {
-          first = substr(rest, start, 1)
           # `\r` belongs with space and tab here, or the guard misses the shape
           # the delimiter widening just made reachable: with a carriage return
           # between the label and the key (`error:\rpassword: <prose>`) the
@@ -4328,7 +4340,16 @@ hook_user_prompt() {
   fi
   need_cmd jq
   [ -n "$input" ] || return 0
-  prompt=$(json_value '.prompt // empty' "$input")
+  # A jq failure is an infrastructure failure, not an empty benign prompt.
+  # Check the substitution in the parent shell so the closed policy can block;
+  # the default open policy emits one host-shaped notice and returns.
+  if ! prompt=$(json_value '.prompt // empty' "$input" 2>/dev/null); then
+    begin_infrastructure_failure "$input" \
+      "$PROGRAM: the prompt hook input could not be parsed;"
+    notice=$INFRA_FAILURE_NOTICE
+    emit_prompt_response "$notice" ''
+    return 0
+  fi
   [ -n "$prompt" ] || return 0
 
   # The PII input gate is governed by AGENT_GUARD_PII_HOOK_MODE alone and stays
@@ -4418,9 +4439,9 @@ hook_user_prompt() {
 # duplicates host-independent warnings in additionalContext so the model can act
 # on them; both hosts receive a user-facing systemMessage.
 
-# Classify `setup-shell`'s managed block in the rc file Claude Code's shell
-# snapshot reads: 0 = the block is there AND can still load, 2 = the block is
-# there but the binary it resolves is gone, 1 = no usable block at all.
+# Classify `setup-shell`'s managed block in one rc file: 0 = the block is there
+# AND can still load, 2 = the block is there but the binary it resolves is gone,
+# 1 = no usable block at all.
 #
 # The marker only reaches this hook when the shell that LAUNCHED the agent
 # evaluated that rc — which never happens for a fish (or any non-POSIX) login
@@ -4434,16 +4455,8 @@ hook_user_prompt() {
 # resolution order against the paths it baked in: the stable/self path, then the
 # newest versioned binary under the plugin cache base, then `agent-guard` on
 # $PATH. All stat-level; nothing is executed and no subshell is forked.
-# The hook's $SHELL describes the snapshot shell whose rc matters here.
-# setup-shell also consults the account login shell; if either reading says fish,
-# it installs both POSIX rc files because the eventual snapshot choice is not
-# visible while the setup skill is running.
-shell_init_block_state() {
-  [ -n "${HOME:-}" ] || return 1
-  case "${SHELL:-}" in
-    */bash) rc_probe=$HOME/.bashrc ;;
-    *) rc_probe=$HOME/.zshrc ;;
-  esac
+shell_init_rc_block_state() {
+  rc_probe=$1
   # Both delimiters must be present, or the block is not a block (setup-shell
   # itself refuses to rewrite an unbalanced one).
   block=$(awk -v b="$SHELL_INIT_BLOCK_BEGIN" -v e="$SHELL_INIT_BLOCK_END" \
@@ -4471,6 +4484,33 @@ shell_init_block_state() {
   fi
   command -v agent-guard >/dev/null 2>&1 && return 0
   return 2
+}
+
+# Choose the rc whose snapshot matters. setup-shell also consults the account
+# login shell; if either reading says fish, it installs both POSIX rc files
+# because the eventual bash/zsh snapshot choice is not visible while setup is
+# running. The hook can likewise still receive a fish $SHELL. In that case one
+# healthy rc cannot prove the unknown snapshot is protected, so require both.
+# State 3 means exactly that partial fish coverage: rerunning setup-shell must
+# restore both files before SessionStart can stay quiet.
+shell_init_block_state() {
+  [ -n "${HOME:-}" ] || return 1
+  case "${SHELL:-}" in
+    */bash) shell_init_rc_block_state "$HOME/.bashrc" ;;
+    */fish)
+      shell_init_rc_block_state "$HOME/.bashrc"
+      bash_rc_state=$?
+      shell_init_rc_block_state "$HOME/.zshrc"
+      zsh_rc_state=$?
+      [ "$bash_rc_state" -eq 0 ] && [ "$zsh_rc_state" -eq 0 ] && return 0
+      [ "$bash_rc_state" -eq 1 ] && [ "$zsh_rc_state" -eq 1 ] && return 1
+      if [ "$bash_rc_state" -eq 0 ] || [ "$zsh_rc_state" -eq 0 ]; then
+        return 3
+      fi
+      return 2
+      ;;
+    *) shell_init_rc_block_state "$HOME/.zshrc" ;;
+  esac
 }
 
 hook_session_start() {
@@ -4510,6 +4550,7 @@ hook_session_start() {
     case $? in
       0) wrapping_setup= ;;
       2) wrapping_setup='agent-guard command wrapping is set up in your shell rc but can no longer load: the agent-guard binary that block resolves is gone (plugin cache updated, uninstalled, or the block was edited). Command output is NOT masked. Reinstall or update agent-guard, rerun /agent-guard:setup-shell (or agent-guard setup-shell for a standalone install), then restart the shell and Claude Code.' ;;
+      3) wrapping_setup='agent-guard command wrapping for a fish shell does not cover both .bashrc and .zshrc, so the host snapshot may be unprotected. Command output is NOT masked unless the snapshot chose the surviving rc. Rerun /agent-guard:setup-shell (or agent-guard setup-shell for a standalone install), then restart the shell and Claude Code.' ;;
       *) wrapping_setup='agent-guard command wrapping is not loaded. Run /agent-guard:setup-shell (or agent-guard setup-shell for a standalone install), then restart the shell and Claude Code. Use setup-shell --no-command-wrapping for a persistent opt-out.' ;;
     esac
     if [ -n "$wrapping_setup" ]; then

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1127,6 +1127,40 @@ for pg_h in claude codex; do
     prompt_guard_case "$pg_h" nonsense '' '{"prompt":"hello"}'
 done
 
+# A malformed host payload is an infrastructure failure, not a benign empty
+# prompt. In particular, the opt-in closed policy must not collapse a jq parse
+# error inside command substitution into prompt="" and return success.
+malformed_prompt_json=$(printf '{"prompt":"pasted DB_PASSWORD=%s"' "$prompt_guard_fake_value")
+printf '%s' "$malformed_prompt_json" \
+  | AGENT_GUARD_HOOK_HOST=claude AGENT_GUARD_INFRA_FAILURE_MODE=closed \
+    AGENT_GUARD_WARNING_DIR="$TESTTMP/prompt-malformed-closed" \
+    "$PLUGIN_ROOT/bin/agent-guard" hook-user-prompt >"$OUT" 2>"$ERR"
+malformed_prompt_status=$?
+if [ "$malformed_prompt_status" -eq 2 ] && [ ! -s "$OUT" ] \
+   && grep -q 'prompt hook input could not be parsed' "$ERR"; then
+  ok "prompt guard closed policy blocks a malformed host payload"
+else
+  not_ok "prompt guard closed policy blocks malformed input (status $malformed_prompt_status)"
+  sed 's/^/  stdout: /' "$OUT"; sed 's/^/  stderr: /' "$ERR"
+fi
+
+# The default open policy may continue, but it must emit one valid host-shaped
+# notice instead of treating the parse failure as a clean prompt.
+printf '%s' "$malformed_prompt_json" \
+  | AGENT_GUARD_HOOK_HOST=codex AGENT_GUARD_INFRA_FAILURE_MODE=open \
+    AGENT_GUARD_WARNING_DIR="$TESTTMP/prompt-malformed-open" \
+    "$PLUGIN_ROOT/bin/agent-guard" hook-user-prompt >"$OUT" 2>"$ERR"
+malformed_prompt_status=$?
+if [ "$malformed_prompt_status" -eq 0 ] \
+   && [ "$(jq -s 'length' <"$OUT" 2>/dev/null)" = 1 ] \
+   && jq -e '.hookSpecificOutput.additionalContext
+             | contains("prompt hook input could not be parsed")' "$OUT" >/dev/null 2>&1; then
+  ok "prompt guard open policy reports a malformed host payload once"
+else
+  not_ok "prompt guard open policy reports malformed input (status $malformed_prompt_status)"
+  sed 's/^/  stdout: /' "$OUT"; sed 's/^/  stderr: /' "$ERR"
+fi
+
 # warn emits the host-appropriate notice shape: Claude renders systemMessage;
 # Codex documents hookSpecificOutput.additionalContext as its context channel.
 prompt_guard_case claude warn '' '{"prompt":"my key is AGENT_GUARD_TEST_SECRET"}' >"$OUT" 2>"$ERR"
@@ -7434,6 +7468,27 @@ expect_json_status 2 "#178 an assignment inside a quoted JSON string leaf still 
     '{session_id:"t",hook_event_name:"UserPromptSubmit",prompt:$prompt}')" \
   hook-user-prompt
 
+# The colon delimiter added for a serialized string leaf must require the quote
+# that opens that leaf. Otherwise valid compact source such as a JavaScript
+# labelled statement becomes newly reachable and its reference is mistaken for
+# a credential literal. The quoted JSON controls above must remain masked.
+label_reference='label:API_KEY=config.apiKey;'
+display_input=$(jq -nc --arg stdout "$label_reference" \
+  '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
+post_tool_out "$display_input"
+label_reference_status=$?
+if [ "$label_reference_status" -eq 0 ] && [ ! -s "$OUT" ]; then
+  ok "#178 colon widening preserves a compact JavaScript labelled reference"
+else
+  not_ok "#178 colon widening preserves labelled source (status $label_reference_status)"
+  sed 's/^/  out: /' "$OUT"
+fi
+
+expect_json_status 0 "#178 prompt guard allows a compact JavaScript labelled reference" \
+  "$(jq -nc --arg prompt "$label_reference" \
+    '{session_id:"t",hook_event_name:"UserPromptSubmit",prompt:$prompt}')" \
+  hook-user-prompt
+
 # The trailing-quote strip must NOT fire on the line-start rescan of a value an
 # outer quoted assignment already claimed, or it emits a second, narrower
 # mapping that beats the outer one and strands the key prefix on display.
@@ -9558,6 +9613,32 @@ for ss_snapshot_shell in /bin/bash /bin/zsh; do
     ok "SessionStart is quiet for ${ss_snapshot_shell##*/} snapshot after fish-login setup (#139)"
   else
     not_ok "SessionStart ${ss_snapshot_shell##*/} snapshot after fish-login setup (got: $vd_out)"
+  fi
+done
+
+# If the hook still sees the fish login shell, it cannot know whether the host
+# snapshot chose bash or zsh. One surviving rc must therefore not validate the
+# other missing half: that would make SessionStart stay silent while the actual
+# snapshot may be unwrapped. setup-shell writes both, so partial coverage means
+# rerunning setup is required.
+vd_out=$(run_session_start "" "$ss_home_login_fish" /usr/bin/fish 2>"$ERR")
+if [ $? -eq 0 ] && [ -z "$vd_out" ]; then
+  ok "SessionStart is quiet when fish snapshot coverage includes both rc files"
+else
+  not_ok "SessionStart fish snapshot with complete rc coverage (got: $vd_out)"
+fi
+
+for ss_missing_rc in .bashrc .zshrc; do
+  mv "$ss_home_login_fish/$ss_missing_rc" "$ss_home_login_fish/$ss_missing_rc.removed"
+  vd_out=$(run_session_start "" "$ss_home_login_fish" /usr/bin/fish 2>"$ERR")
+  vd_status=$?
+  mv "$ss_home_login_fish/$ss_missing_rc.removed" "$ss_home_login_fish/$ss_missing_rc"
+  if [ "$vd_status" -eq 0 ] \
+     && printf '%s' "$vd_out" \
+       | jq -e '.systemMessage | contains("does not cover both .bashrc and .zshrc")' >/dev/null 2>&1; then
+    ok "SessionStart warns when fish snapshot coverage is missing $ss_missing_rc"
+  else
+    not_ok "SessionStart fish partial rc coverage for $ss_missing_rc (status $vd_status, got: $vd_out)"
   fi
 done
 


### PR DESCRIPTION
## Summary

- Treat malformed `UserPromptSubmit` JSON as an infrastructure failure so the opt-in closed policy blocks instead of silently accepting an empty prompt; the default open policy emits one host-shaped notice.
- When SessionStart still sees a fish `$SHELL`, require both `.bashrc` and `.zshrc` managed blocks to remain loadable because the eventual bash/zsh host snapshot is unknown.
- Restrict the `:` equals-assignment widening to quoted serialized leaves, preserving valid compact source such as `label:API_KEY=config.apiKey;` while retaining masking for JSON log strings.

## Regression coverage

- malformed prompt payloads under open and closed infrastructure policies
- complete and partial fish rc coverage
- PostToolUse and prompt-guard handling of JavaScript labelled references, with quoted JSON masking retained as the control

## Verification

- `sh tests/run.sh` — 1199 passed, 0 failed
- `make smoke-test`
- `make submission-check`
- `sh scripts/render-hook-manifests.sh --check`
- `sh -n plugins/agent-guard/bin/agent-guard`
- `sh -n tests/run.sh`
- `git diff --check`

Local `shellcheck` was unavailable on the host; the repository's pinned CI lint job remains the authoritative shellcheck run.
