### PR TITLE
fix(redaction): mask quoted line-start assignments

### DIFF
--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -3105,10 +3105,20 @@ secretish_env_values() {
       }
       return 1
     }
-    function emit_mapping(literal, replacement) {
+    # scan_line deliberately re-scans inside a quoted value after emit_secret
+    # records that wider literal. A short inner assignment can then produce a
+    # contextual mapping whose value span is the SAME occurrence already
+    # covered by the outer secret. Applying it first strands the inner key
+    # prefix. Suppress only that scanner occurrence; an identical short value
+    # elsewhere still needs its own contextual mapping and must remain emitted.
+    function emit_mapping(literal, replacement, value_start, value_length) {
       if (record_mode == "probe" || record_mode == "probe_raw") {
         if (!probe_found) print "x"
         probe_found = 1
+      } else if (rescan_cover_end > 0 \
+                 && value_start >= rescan_cover_start \
+                 && value_start + value_length - 1 <= rescan_cover_end) {
+        return
       } else if (record_mode == "framed") {
         emit_framed(literal, "L")
         emit_framed(replacement, "R")
@@ -3298,6 +3308,8 @@ secretish_env_values() {
     function emit_value(source, start, assignment, require_credential, \
                         raw, leading, quote, end, \
                         value, token, trailing, ch) {
+      next_rescan_cover_start = 0
+      next_rescan_cover_end = 0
       raw = substr(source, start)
       match(raw, /^[ \t]*/)
       leading = substr(raw, 1, RLENGTH)
@@ -3366,14 +3378,11 @@ secretish_env_values() {
           # interior quote still marks a reference and the accessor forms in
           # the #169 assertions stay preserved.
           #
-          # Not when the ASSIGNMENT ITSELF begins with a quote. That marks the
-          # line-start rescan of a value an OUTER quoted assignment already
-          # claimed: scan_line advances past the matched key only, so the inner
-          # text is examined a second time and matches via the `^` alternative.
-          # The outer match has already emitted the whole quoted value as the
-          # secret; stripping here produced a second, narrower mapping that beat
-          # it and left the inner key prefix on display.
-          if (strip_quote == 0 && assignment !~ /^["'\''`]/ \
+          # A line-start quoted assignment needs the same strip. The re-scan of
+          # an outer quoted value can then rediscover a narrower short token;
+          # emit_mapping suppresses that record only when an already-emitted
+          # secret literal covers its exact value span (#180).
+          if (strip_quote == 0 \
               && (ch == "\"" || ch == "'\''" || ch == "`")) {
             strip_quote = 1
             end--
@@ -3401,7 +3410,9 @@ secretish_env_values() {
         if (length(value) < 4 && length(token) >= 4) {
           trailing = substr(token, end + 1)
           emit_mapping(assignment leading token,
-                       assignment leading "[REDACTED]" trailing)
+                       assignment leading "[REDACTED]" trailing,
+                       start + length(leading),
+                       length(value))
           return 0
         }
         emit_secret(value, length(token))
@@ -3412,13 +3423,21 @@ secretish_env_values() {
       # padded literal left a bare recurrence of the same credential further
       # down unmasked. Record both forms, exactly as the multiline close does.
       emit_captured(value)
+      # Coordinates are relative to this scan_line source. Once scan_line
+      # advances past the assignment delimiter it translates them to the new
+      # `rest`, allowing only mappings from this exact emitted value occurrence
+      # to be suppressed. Mixed quotes elsewhere in the span stay scannable.
+      next_rescan_cover_start = start + length(leading) + 1
+      next_rescan_cover_end = start + length(leading) + length(value)
       return 0
     }
     function scan_line(line, rest, end, low, eq_start, eq_length, \
                        colon_start, colon_length, start, matched_length, \
                        chose_colon, skip, status_guard, first, expansion, \
-                       closed_value, key_opener) {
+                       closed_value, key_opener, advance) {
       rest = line
+      rescan_cover_start = 0
+      rescan_cover_end = 0
       if (open_quote != "") {
         end = quoted_end(rest, open_quote)
         if (end == 0) {
@@ -3519,10 +3538,24 @@ secretish_env_values() {
         # Emit exactly the quoted value or the next unquoted token. Continuing
         # after the delimiter finds multiple assignments on one log line while
         # leaving adjacent status text untouched.
+        next_rescan_cover_start = 0
+        next_rescan_cover_end = 0
         if (!skip &&
             emit_value(rest, start + matched_length,
                        substr(rest, start, matched_length), status_guard)) break
-        rest = substr(rest, start + matched_length)
+        advance = start + matched_length - 1
+        if (next_rescan_cover_end > 0) {
+          rescan_cover_start = next_rescan_cover_start - advance
+          rescan_cover_end = next_rescan_cover_end - advance
+        } else if (rescan_cover_end > 0) {
+          rescan_cover_start -= advance
+          rescan_cover_end -= advance
+          if (rescan_cover_end < 1) {
+            rescan_cover_start = 0
+            rescan_cover_end = 0
+          }
+        }
+        rest = substr(rest, advance + 1)
       }
     }
     function scan_leaf(value, newline, line) {

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -7485,7 +7485,8 @@ done
 # rediscover a short inner assignment after the wider value was already
 # recorded. The narrower contextual mapping must not beat that wider literal
 # and strand the inner key prefix on display.
-quoted_duplicate='PASSWORD=abc) API_TOKEN="PASSWORD=abc)" status=ok'
+quoted_duplicate=$(printf '%s%s' 'PASSWORD=abc) API_TOKEN="' \
+  'PASSWORD=abc)" status=ok')
 display_input=$(jq -nc --arg stdout "$quoted_duplicate" \
   '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
 post_tool_out "$display_input"
@@ -7500,7 +7501,8 @@ fi
 # Coverage is span-specific, not a substring shortcut. A separate short value
 # must still get its own contextual mapping even when its text occurs inside a
 # previously emitted longer credential.
-quoted_distinct_short='API_TOKEN="abc-long-value" PASSWORD=abc)'
+quoted_distinct_short=$(printf '%s%s' 'API_TOKEN="' \
+  'abc-long-value" PASSWORD=abc)')
 display_input=$(jq -nc --arg stdout "$quoted_distinct_short" \
   '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
 post_tool_out "$display_input"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -7514,11 +7514,15 @@ fi
 
 # The mixed-quote shapes that invalidated the earlier position/span attempts
 # still depend on the inner re-scan. Keep representative credential-shaped
-# values pinned so closing the line-start leak cannot reopen those leaks.
-mixed_quote_secret='Ab3xQ9zPlm4Kd7'
+# values pinned so closing the line-start leak cannot reopen those leaks. Build
+# the fixture at runtime so repository-wide secret scanners do not mistake the
+# inert test value for a committed credential.
+mixed_quote_secret=$(printf '%s%s' 'Ab3xQ9zP' 'Lm4Kd7')
+mixed_quote_case_a="error: api_key\`: \"ab; end password=$mixed_quote_secret\"}]"
+mixed_quote_case_b="x \"API_KEY'=\`none'' API_KEY=\`$mixed_quote_secret]"
 for display_case in \
-  'error: api_key`: "ab; end password=Ab3xQ9zPlm4Kd7"}]' \
-  'x "API_KEY'"'"'=`none'"'"''"'"' API_KEY=`Ab3xQ9zPlm4Kd7]'; do
+  "$mixed_quote_case_a" \
+  "$mixed_quote_case_b"; do
   display_input=$(jq -nc --arg stdout "$display_case" \
     '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
   post_tool_out "$display_input"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -7460,11 +7460,89 @@ for display_case in \
   fi
 done
 
+# #180: when the assignment itself begins a line inside quotes, the trailing
+# quote belongs to the enclosing string rather than to the credential. The old
+# duplicate-mapping guard kept that quote attached and the heuristic treated
+# the value as a source-code reference, leaking it in full.
+quoted_assignment_multiline=$(printf 'line0\n"API_KEY=%s"' "$JSONLEAF_SECRET")
+for display_case in \
+  "\"API_KEY=$JSONLEAF_SECRET\"" \
+  "$quoted_assignment_multiline"; do
+  display_input=$(jq -nc --arg stdout "$display_case" \
+    '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
+  post_tool_out "$display_input"
+  post_out=$(cat "$OUT")
+  if printf '%s' "$post_out" | grep -q '\[REDACTED\]' \
+     && ! printf '%s' "$post_out" | grep -Fq "$JSONLEAF_SECRET"; then
+    ok "#180 post-tool masks a quoted assignment that begins a line"
+  else
+    not_ok "#180 post-tool masks a quoted assignment that begins a line"
+    printf '%s\n' "$post_out" | sed 's/^/  out: /'
+  fi
+done
+
+# Re-scanning inside an outer quoted value is still load-bearing, but it can
+# rediscover a short inner assignment after the wider value was already
+# recorded. The narrower contextual mapping must not beat that wider literal
+# and strand the inner key prefix on display.
+quoted_duplicate='PASSWORD=abc) API_TOKEN="PASSWORD=abc)" status=ok'
+display_input=$(jq -nc --arg stdout "$quoted_duplicate" \
+  '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
+post_tool_out "$display_input"
+post_out=$(jq -r '.hookSpecificOutput.updatedToolOutput.stdout // empty' "$OUT" 2>/dev/null)
+if [ "$post_out" = 'PASSWORD=[REDACTED]) API_TOKEN="[REDACTED]" status=ok' ]; then
+  ok "#180 a duplicate inner mapping does not strand its key prefix"
+else
+  not_ok "#180 a duplicate inner mapping does not strand its key prefix"
+  printf '%s\n' "$post_out" | sed 's/^/  out: /'
+fi
+
+# Coverage is span-specific, not a substring shortcut. A separate short value
+# must still get its own contextual mapping even when its text occurs inside a
+# previously emitted longer credential.
+quoted_distinct_short='API_TOKEN="abc-long-value" PASSWORD=abc)'
+display_input=$(jq -nc --arg stdout "$quoted_distinct_short" \
+  '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
+post_tool_out "$display_input"
+post_out=$(jq -r '.hookSpecificOutput.updatedToolOutput.stdout // empty' "$OUT" 2>/dev/null)
+if [ "$post_out" = 'API_TOKEN="[REDACTED]" PASSWORD=[REDACTED])' ]; then
+  ok "#180 a separate short credential is not suppressed by substring overlap"
+else
+  not_ok "#180 a separate short credential is not suppressed by substring overlap"
+  printf '%s\n' "$post_out" | sed 's/^/  out: /'
+fi
+
+# The mixed-quote shapes that invalidated the earlier position/span attempts
+# still depend on the inner re-scan. Keep representative credential-shaped
+# values pinned so closing the line-start leak cannot reopen those leaks.
+mixed_quote_secret='Ab3xQ9zPlm4Kd7'
+for display_case in \
+  'error: api_key`: "ab; end password=Ab3xQ9zPlm4Kd7"}]' \
+  'x "API_KEY'"'"'=`none'"'"''"'"' API_KEY=`Ab3xQ9zPlm4Kd7]'; do
+  display_input=$(jq -nc --arg stdout "$display_case" \
+    '{tool_name:"Bash",tool_input:{command:"x"},tool_response:{stdout:$stdout,stderr:"",interrupted:false,isImage:false}}')
+  post_tool_out "$display_input"
+  post_out=$(cat "$OUT")
+  if printf '%s' "$post_out" | grep -q '\[REDACTED\]' \
+     && ! printf '%s' "$post_out" | grep -Fq "$mixed_quote_secret"; then
+    ok "#180 mixed quotes keep nested credential masking"
+  else
+    not_ok "#180 mixed quotes keep nested credential masking"
+    printf '%s\n' "$post_out" | sed 's/^/  out: /'
+  fi
+done
+
 # The same shape on the BLOCK path, since a serialized log is exactly what an
 # agent pastes back into a prompt.
 jsonleaf_prompt="{\"log\":\"DB_PASSWORD=$JSONLEAF_SECRET\"}"
 expect_json_status 2 "#178 an assignment inside a quoted JSON string leaf still blocks at the prompt guard" \
   "$(jq -nc --arg prompt "$jsonleaf_prompt" \
+    '{session_id:"t",hook_event_name:"UserPromptSubmit",prompt:$prompt}')" \
+  hook-user-prompt
+
+quoted_assignment_prompt="\"API_KEY=$JSONLEAF_SECRET\""
+expect_json_status 2 "#180 a quoted line-start assignment blocks at the prompt guard" \
+  "$(jq -nc --arg prompt "$quoted_assignment_prompt" \
     '{session_id:"t",hook_event_name:"UserPromptSubmit",prompt:$prompt}')" \
   hook-user-prompt
 


### PR DESCRIPTION
## Summary

- strip an enclosing trailing quote for assignments that begin a line, closing the display-redaction and prompt-guard leak
- track the exact quoted value occurrence already emitted while scan_line re-scans its contents
- suppress only a narrower contextual mapping inside that same occurrence, preserving independent identical short values and nested mixed-quote credentials
- add regression coverage for the issue acceptance cases and both previously failed design directions

Closes #180

## Verification

- make test: 1206 passed, 0 failed
- make smoke-test: passed
- deterministic 4,000-case differential against main: 0 baseline-masked regressions, 0 candidate leaks, 0 stable-shape differences, 800 newly masked issue cases
- git diff --check: passed