### PR TITLE
fix(update): standalone 자기참조 symlink 방지

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,7 @@ jobs:
             install.sh \
             bootstrap.sh \
             githooks/pre-commit \
+            tests/bootstrap-update.sh \
             tests/run.sh \
             bench/run.sh \
             scripts/build-release-tarball.sh \

--- a/README.md
+++ b/README.md
@@ -237,13 +237,29 @@ Override install defaults with `AGENT_GUARD_VERSION`, `AGENT_GUARD_HOME`, `AGENT
 delegates to the same checksum-verified `bootstrap.sh` used for first install.
 Plugin installations must be updated by Claude Code or Codex; after a plugin
 update, rerun `agent-guard setup-shell` if the shell integration reports drift.
-The current standalone updater has a known symlink failure ([#194](https://github.com/JeongJaeSoon/agent-guard/issues/194));
-do not use it to repair an already broken installation. Preserve the existing
-installation. Test the checksum-verified bootstrap in a disposable account
-with separate `AGENT_GUARD_HOME` and `AGENT_GUARD_BIN_DIR`, then run `version`,
-`check`, and `smoke-test` there before repairing the active installation.
-The bootstrap also refreshes shell startup files; changing only its two install
-directories does not isolate that side effect.
+Standalone v3.1.1 introduced `update` with a symlink failure
+([#194](https://github.com/JeongJaeSoon/agent-guard/issues/194)). Do not use that
+version's `update` command to repair an already broken installation. A fixed
+updater preserves the public bin directory used to invoke it, validates the
+downloaded payload before extraction, and does not create a link when the
+public bin directory is the payload's own physical directory. This reduces the
+failure surface but does not make the whole installation transaction atomic.
+
+If `version` or `doctor` now fails with `Too many levels of symbolic links`,
+preserve the installation and inspect `$AGENT_GUARD_HOME/bin/agent-guard`
+(default: `$HOME/.agent-guard/bin/agent-guard`). If, and only if, that payload
+path is a symlink, move just the symlink to a backup name; do not delete the
+install directory or the public bin entry. Then rerun `bootstrap.sh` from a
+release whose notes say #194 is fixed, using the same `AGENT_GUARD_HOME` and
+`AGENT_GUARD_BIN_DIR` as the original install. Keep the backup until the public
+path passes `version`, `check`, and `smoke-test`. If the payload path is a
+regular file or directory, stop instead of moving it and report the layout in
+[#194](https://github.com/JeongJaeSoon/agent-guard/issues/194).
+
+Test recovery first with a separate temporary home, install directory, and
+public bin directory. The bootstrap also refreshes shell startup files, so
+changing only `AGENT_GUARD_HOME` and `AGENT_GUARD_BIN_DIR` does not isolate that
+side effect.
 
 Homebrew requires formulas to live in a tap. Install the published formula with:
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -74,17 +74,41 @@ main() {
   ( cd "$tmp" && shasum -a 256 -c "$archive.sha256" ) >&2 \
     || die "checksum verification failed for $archive"
 
+  # Validate the downloaded payload before touching a working installation.
+  stage="$tmp/payload"
+  mkdir "$stage"
+  tar -xzf "$tmp/$archive" -C "$stage" || die "archive extraction failed"
+  [ -f "$stage/bin/agent-guard" ] && [ ! -L "$stage/bin/agent-guard" ] \
+    && [ -x "$stage/bin/agent-guard" ] || die "expected regular executable not found in archive"
+  [ -f "$stage/install.sh" ] && [ ! -L "$stage/install.sh" ] \
+    && [ -x "$stage/install.sh" ] || die "expected regular installer not found in archive"
+  sh -n "$stage/bin/agent-guard" && sh -n "$stage/install.sh" \
+    || die "archive contains invalid shell scripts"
+  for policy in gitleaks.toml deny-read-paths.txt deny-bash-patterns.txt; do
+    [ -f "$stage/config/$policy" ] && [ ! -L "$stage/config/$policy" ] \
+      && [ -r "$stage/config/$policy" ] || die "archive has no regular policy file: $policy"
+  done
+
   info "$prog: extracting to $HOME_DIR"
-  mkdir -p "$HOME_DIR"
-  tar -xzf "$tmp/$archive" -C "$HOME_DIR"
-
-  bin_path="$HOME_DIR/bin/agent-guard"
-  [ -x "$bin_path" ] || die "expected executable not found after extraction: $bin_path"
-  [ -x "$HOME_DIR/install.sh" ] || die "expected installer not found after extraction: $HOME_DIR/install.sh"
-
+  mkdir -p "$HOME_DIR/bin"
   mkdir -p "$BIN_DIR"
-  ln -sf "$bin_path" "$BIN_DIR/agent-guard"
-  info "$prog: linked $BIN_DIR/agent-guard -> $bin_path"
+  HOME_DIR=$(CDPATH= cd -- "$HOME_DIR" && pwd -P)
+  BIN_DIR=$(CDPATH= cd -- "$BIN_DIR" && pwd -P)
+  payload_bin_dir=$(CDPATH= cd -- "$HOME_DIR/bin" && pwd -P)
+  # Refuse directory targets rather than copying into them or deleting data.
+  [ ! -d "$HOME_DIR/bin/agent-guard" ] || die "executable destination is a directory"
+  [ ! -L "$HOME_DIR/bin/agent-guard" ] || die "executable destination must not be a symlink"
+  [ ! -d "$BIN_DIR/agent-guard" ] || die "link destination is a directory"
+  # Retain tar's replacement semantics: an existing installer symlink must be
+  # replaced, not followed (or rejected partway through by BSD cp -R).
+  tar -xzf "$tmp/$archive" -C "$HOME_DIR" || die "installation extraction failed"
+  bin_path="$HOME_DIR/bin/agent-guard"
+  if [ "$BIN_DIR" = "$payload_bin_dir" ]; then
+    info "$prog: executable already lives in $BIN_DIR; no symlink needed"
+  else
+    ln -sf "$bin_path" "$BIN_DIR/agent-guard"
+    info "$prog: linked $BIN_DIR/agent-guard -> $bin_path"
+  fi
 
   case ":$PATH:" in
     *":$BIN_DIR:"*) ;;

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -5609,8 +5609,16 @@ do_update() {
   curl -fsSL "https://github.com/JeongJaeSoon/agent-guard/releases/latest/download/bootstrap.sh" \
     -o "$update_script" || die "update: failed to download bootstrap.sh"
   sh -n "$update_script" || die "update: downloaded bootstrap.sh failed syntax validation"
+  # BIN_DIR is the resolved payload directory, not the public symlink's
+  # directory. Preserve the invocation location (including custom installs)
+  # unless the caller explicitly requests a different link directory.
+  update_bin_dir=${AGENT_GUARD_BIN_DIR:-}
+  if [ -z "$update_bin_dir" ]; then
+    update_bin_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P) \
+      || die "update: cannot resolve the invocation directory"
+  fi
   AGENT_GUARD_HOME="$ROOT_DIR" \
-    AGENT_GUARD_BIN_DIR="$(CDPATH= cd -- "$BIN_DIR/../bin" 2>/dev/null && pwd -P || printf '%s' "$HOME/.local/bin")" \
+    AGENT_GUARD_BIN_DIR="$update_bin_dir" \
     sh "$update_script"
 }
 

--- a/tests/bootstrap-update.sh
+++ b/tests/bootstrap-update.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env sh
+# Offline integration: only curl downloads are substituted; checksum, payload
+# validation, installation, CLI update, shell setup and version execute for real.
+set -eu
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd -P)
+CASE_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/agent-guard-update-test.XXXXXX")
+CASE_ROOT=$(CDPATH= cd -- "$CASE_ROOT" && pwd -P)
+trap 'rm -rf "$CASE_ROOT"' EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+mkdir -p "$CASE_ROOT/download/bin" "$CASE_ROOT/home"
+"$ROOT/scripts/build-release-tarball.sh" 2.0.0 "$CASE_ROOT/download/agent-guard-2.0.0.tar.gz"
+(cd "$CASE_ROOT/download" && shasum -a 256 agent-guard-2.0.0.tar.gz >agent-guard-2.0.0.tar.gz.sha256)
+QA_REAL_GITLEAKS=$(command -v gitleaks 2>/dev/null || :)
+cat >"$CASE_ROOT/download/bin/curl" <<'STUB'
+#!/bin/sh
+out=
+while [ "$#" -gt 0 ]; do
+  case "$1" in -o) shift; out=${1:-} ;; esac
+  shift
+done
+case "$out" in
+  */bootstrap.sh) cp "$QA_SOURCE/bootstrap.sh" "$out" ;;
+  *.tar.gz) cp "$QA_DOWNLOAD/agent-guard-2.0.0.tar.gz" "$out" ;;
+  *.tar.gz.sha256) cp "$QA_DOWNLOAD/agent-guard-2.0.0.tar.gz.sha256" "$out" ;;
+  *) exit 2 ;;
+esac
+STUB
+chmod +x "$CASE_ROOT/download/bin/curl"
+export QA_SOURCE="$ROOT" QA_DOWNLOAD="$CASE_ROOT/download"
+# All install and shell state belongs to this one temporary test environment.
+export HOME="$CASE_ROOT/home" SHELL=/bin/zsh AGENT_GUARD_VERSION=2.0.0
+export PATH="$CASE_ROOT/download/bin:/usr/bin:/bin"
+if [ -n "$QA_REAL_GITLEAKS" ]; then
+  PATH="$CASE_ROOT/download/bin:$(dirname "$QA_REAL_GITLEAKS"):/usr/bin:/bin"
+  export PATH
+fi
+export AGENT_GUARD_HOME="$CASE_ROOT/payload"
+check() { printf 'ok - %s\n' "$1"; }
+healthy() {
+  [ ! -L "$AGENT_GUARD_HOME/bin/agent-guard" ]
+  "$1" version >"$CASE_ROOT/version"
+  grep -q agent-guard "$CASE_ROOT/version"
+}
+installed_state_unchanged() {
+  [ "$payload_before" = "$(shasum -a 256 "$AGENT_GUARD_HOME/bin/agent-guard")" ]
+  [ "$public_target_before" = "$(readlink "$CASE_ROOT/custom bin/agent-guard")" ]
+  grep -q 'keep user data' "$AGENT_GUARD_HOME/local-note"
+  healthy "$CASE_ROOT/custom bin/agent-guard"
+}
+real_runtime_qa() {
+  [ -n "$QA_REAL_GITLEAKS" ] || return 0
+  run "$1" version
+  run "$1" doctor
+  run "$1" check
+  run "$1" smoke-test
+}
+run() { "$@" >"$CASE_ROOT/out" 2>"$CASE_ROOT/err" || { cat "$CASE_ROOT/err" >&2; return 1; }; }
+AGENT_GUARD_BIN_DIR="$CASE_ROOT/custom bin" run sh "$ROOT/bootstrap.sh"
+healthy "$CASE_ROOT/custom bin/agent-guard"
+real_runtime_qa "$CASE_ROOT/custom bin/agent-guard"
+printf 'keep user data\n' >"$AGENT_GUARD_HOME/local-note"
+run "$CASE_ROOT/custom bin/agent-guard" update
+healthy "$CASE_ROOT/custom bin/agent-guard"
+real_runtime_qa "$CASE_ROOT/custom bin/agent-guard"
+[ "$(readlink "$CASE_ROOT/custom bin/agent-guard")" = "$AGENT_GUARD_HOME/bin/agent-guard" ]
+grep -q 'keep user data' "$AGENT_GUARD_HOME/local-note"
+check 'standalone update preserves custom public link and unrelated files'
+if [ -n "$QA_REAL_GITLEAKS" ]; then
+  check 'real gitleaks version, doctor, check and smoke pass before and after update'
+else
+  printf 'skip - real gitleaks unavailable; runtime update QA not run\n'
+fi
+
+(cd "$CASE_ROOT" && run './custom bin/agent-guard' update)
+healthy "$CASE_ROOT/custom bin/agent-guard"
+check 'relative symlink invocation updates without a self-link'
+
+PATH="$CASE_ROOT/custom bin:$PATH" run agent-guard update
+healthy "$CASE_ROOT/custom bin/agent-guard"
+check 'PATH invocation updates without a self-link'
+
+run "$AGENT_GUARD_HOME/bin/agent-guard" update
+healthy "$AGENT_GUARD_HOME/bin/agent-guard"
+healthy "$CASE_ROOT/custom bin/agent-guard"
+check 'direct payload invocation skips a redundant symlink'
+
+AGENT_GUARD_BIN_DIR="$CASE_ROOT/override" run "$CASE_ROOT/custom bin/agent-guard" update
+healthy "$CASE_ROOT/override/agent-guard"
+check 'explicit update link-directory override is honored'
+
+ln -s "$AGENT_GUARD_HOME/bin" "$CASE_ROOT/bin-alias"
+AGENT_GUARD_BIN_DIR="$CASE_ROOT/bin-alias" run sh "$ROOT/bootstrap.sh"
+healthy "$CASE_ROOT/bin-alias/agent-guard"
+check 'physical directory aliases cannot create executable self-links'
+
+mv "$AGENT_GUARD_HOME/install.sh" "$CASE_ROOT/external-installer"
+external_before=$(shasum -a 256 "$CASE_ROOT/external-installer")
+ln -s "$CASE_ROOT/external-installer" "$AGENT_GUARD_HOME/install.sh"
+run "$CASE_ROOT/custom bin/agent-guard" update
+healthy "$CASE_ROOT/custom bin/agent-guard"
+[ ! -L "$AGENT_GUARD_HOME/install.sh" ]
+[ -x "$AGENT_GUARD_HOME/install.sh" ]
+[ "$external_before" = "$(shasum -a 256 "$CASE_ROOT/external-installer")" ]
+check 'update replaces an installer symlink without modifying its external target'
+
+payload_before=$(shasum -a 256 "$AGENT_GUARD_HOME/bin/agent-guard")
+public_target_before=$(readlink "$CASE_ROOT/custom bin/agent-guard")
+mkdir -p "$CASE_ROOT/invalid/bin"
+printf '#!/bin/sh\nexit 0\n' >"$CASE_ROOT/invalid/bin/agent-guard"
+chmod +x "$CASE_ROOT/invalid/bin/agent-guard"
+cp "$CASE_ROOT/download/agent-guard-2.0.0.tar.gz" "$CASE_ROOT/valid.tar.gz"
+tar -C "$CASE_ROOT/invalid" -czf "$CASE_ROOT/download/agent-guard-2.0.0.tar.gz" .
+(cd "$CASE_ROOT/download" && shasum -a 256 agent-guard-2.0.0.tar.gz >agent-guard-2.0.0.tar.gz.sha256)
+if AGENT_GUARD_BIN_DIR="$CASE_ROOT/custom bin" sh "$ROOT/bootstrap.sh" >"$CASE_ROOT/out" 2>"$CASE_ROOT/err"; then exit 1; fi
+installed_state_unchanged
+check 'checksum-valid incomplete archive leaves working executable untouched'
+
+mkdir -p "$CASE_ROOT/invalid-policy"
+tar -xzf "$CASE_ROOT/valid.tar.gz" -C "$CASE_ROOT/invalid-policy"
+mv "$CASE_ROOT/invalid-policy/config/gitleaks.toml" "$CASE_ROOT/invalid-policy/config/gitleaks.toml.original"
+mkdir "$CASE_ROOT/invalid-policy/config/gitleaks.toml"
+tar -C "$CASE_ROOT/invalid-policy" -czf "$CASE_ROOT/download/agent-guard-2.0.0.tar.gz" .
+(cd "$CASE_ROOT/download" && shasum -a 256 agent-guard-2.0.0.tar.gz >agent-guard-2.0.0.tar.gz.sha256)
+if AGENT_GUARD_BIN_DIR="$CASE_ROOT/custom bin" sh "$ROOT/bootstrap.sh" >"$CASE_ROOT/out" 2>"$CASE_ROOT/err"; then exit 1; fi
+installed_state_unchanged
+check 'checksum-valid non-regular policy leaves working installation untouched'
+
+cp "$CASE_ROOT/valid.tar.gz" "$CASE_ROOT/download/agent-guard-2.0.0.tar.gz"
+if AGENT_GUARD_BIN_DIR="$CASE_ROOT/custom bin" sh "$ROOT/bootstrap.sh" >"$CASE_ROOT/out" 2>"$CASE_ROOT/err"; then exit 1; fi
+installed_state_unchanged
+check 'checksum failure preserves the installed executable'
+(cd "$CASE_ROOT/download" && shasum -a 256 agent-guard-2.0.0.tar.gz >agent-guard-2.0.0.tar.gz.sha256)
+
+mkdir -p "$CASE_ROOT/directory-target/agent-guard"
+printf 'preserve\n' >"$CASE_ROOT/directory-target/agent-guard/note"
+if AGENT_GUARD_BIN_DIR="$CASE_ROOT/directory-target" sh "$ROOT/bootstrap.sh" >"$CASE_ROOT/out" 2>"$CASE_ROOT/err"; then exit 1; fi
+grep -q preserve "$CASE_ROOT/directory-target/agent-guard/note"
+installed_state_unchanged
+check 'directory link target is rejected without changing existing data'

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -147,6 +147,8 @@ fi
 # while AGENT_GUARD_COMMAND_WRAPPING=off is a persistent install-time opt-out.
 # Stub only the release downloads; archive verification, extraction, linking,
 # setup-shell, and rc generation all run through the real implementation.
+run_expect 0 "standalone update preserves executable and link destinations" \
+  sh "$ROOT/tests/bootstrap-update.sh"
 bootstrap_fixture="$TESTTMP/bootstrap-fixture"
 mkdir -p "$bootstrap_fixture/bin"
 "$ROOT/scripts/build-release-tarball.sh" 2.0.0 "$bootstrap_fixture/agent-guard-2.0.0.tar.gz"


### PR DESCRIPTION
## 사용자 영향

standalone v3.1.1에서 외부 public bin 경로로 `agent-guard update`를 실행하면 명령은 성공(exit 0)하지만 payload 실행 파일이 자기 자신을 가리키는 symlink로 바뀔 수 있었습니다. 이후 `version`/`doctor`와 동일 실행 파일을 사용하는 shell wrapper·Git hook이 `Too many levels of symbolic links`로 실패합니다.

관련 이슈: #194

## 원인과 변경

- `do_update`가 실제 호출 위치가 아니라 이미 해석된 payload bin 디렉터리를 bootstrap의 `AGENT_GUARD_BIN_DIR`로 넘기던 동작을 수정했습니다. 명시적 override가 없으면 `$0`의 호출 디렉터리를 물리 경로로 보존합니다.
- bootstrap은 checksum 확인 후 archive를 임시 경로에 먼저 풀고, 실행 파일·installer·필수 정책이 regular non-symlink 파일인지와 shell 문법을 검사한 뒤 기존 설치에 적용합니다.
- public bin과 payload bin이 같은 물리 디렉터리(직접 호출 또는 symlink alias)이면 중복 symlink를 만들지 않습니다. payload 실행 파일 symlink 및 실행/public 대상 디렉터리는 데이터를 지우지 않고 거부합니다.
- 기존 tar 교체 동작을 유지해 installer symlink를 외부 원본을 따라가며 덮어쓰지 않고 symlink 자체만 교체합니다.
- README에 v3.1.1 영향 범위, 이미 손상된 설치에서 전체 디렉터리를 삭제하지 않는 복구 경계, 전체 설치가 원자적 transaction은 아니라는 한계를 명시했습니다.

## 재현과 검증

- 기준 `a2ca2c5`에서 오프라인 고정 archive로 재현: 외부 public bin을 통한 update는 exit 0이었지만 직후 payload executable이 symlink가 되어 건강성 검사가 exit 1로 실패했습니다.
- 집중 회귀 `sh tests/bootstrap-update.sh`: **12/12 통과**
  - 공백 경로, 상대/PATH/직접 payload 호출, 명시적 bin override
  - public/payload 동일 물리 경로 및 symlink directory alias
  - checksum 오류, 불완전 archive, non-regular policy, 디렉터리 link target 실패에서 기존 payload hash·public link target·사용자 파일·실행 가능 상태 보존
  - installer symlink 교체 시 외부 원본 hash 보존
- 실제 QA: macOS arm64에서 gitleaks 8.30.1을 사용한 격리 설치의 update 전후 `version`, `doctor`, `check`, `smoke-test` 통과. 임시 HOME/install/bin만 사용했고 기존 사용자 설치와 전역 rc는 변경하지 않았습니다.
- 전체 회귀 `sh tests/run.sh`: **1,248 passed / 0 failed**
- `git diff --check`, 관련 shell `sh -n`: 통과
- 독립 보안/회귀 리뷰: 최종 diff **no findings**. 리뷰 중 정책 경로가 readable directory/symlink를 허용할 수 있는 preflight 누락을 발견해 regular non-symlink 검증과 회귀를 추가한 뒤 재검토했습니다.

## 검증 한계

- 테스트는 release 다운로드만 고정된 로컬 fixture로 대체하고 checksum·추출·설치·update·shell setup·CLI 실행은 실제 구현을 사용합니다.
- macOS/Linux GitHub Actions 결과는 이 PR에서 확인합니다. 실제 후속 공개 release asset을 사용한 설치→update 검증은 릴리스 게시 뒤 별도로 수행해야 합니다.
- 최종 tar 적용 중 모든 중간 실패를 되돌리는 전체 원자적 rollback은 이 변경의 범위가 아닙니다.
