### PR TITLE
feat(pii): pleno 연동과 endpoint 응답·오류 출력 보호

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Agent Guard — discoverability layer for the existing scripts.
 # Each target is a thin pass-through to install.sh or plugins/agent-guard/bin/agent-guard.
 
-.PHONY: help check install test smoke-test bench scan scan-staged checksum formula submission-check submission-artifact
+.PHONY: help check install test test-pleno-integration smoke-test bench scan scan-staged checksum formula submission-check submission-artifact
 
 help:
 	@printf 'Agent Guard — make targets\n'
@@ -10,6 +10,7 @@ help:
 	@printf '  make check         Verify deps and print installed gitleaks version.\n'
 	@printf '  make install       Configure the native git pre-commit hook.\n'
 	@printf '  make test          Run the test suite (uses a mock gitleaks).\n'
+	@printf '  make test-pleno-integration  Run opt-in tests against a real pleno endpoint.\n'
 	@printf '  make smoke-test    Run real git/jq/gitleaks end-to-end checks.\n'
 	@printf '  make bench         Run the leak-prevention channel-coverage benchmark (real gitleaks).\n'
 	@printf '  make scan          Scan the working tree for secrets.\n'
@@ -27,6 +28,9 @@ install:
 
 test:
 	@tests/run.sh
+
+test-pleno-integration:
+	@tests/run-pleno-integration.sh
 
 smoke-test:
 	@plugins/agent-guard/bin/agent-guard smoke-test

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -46,9 +46,10 @@ The following explicit actions use the network:
   tool content.
 - The standalone `bootstrap.sh` install path downloads Agent Guard's release
   archive and checksum from this project's GitHub Releases page.
-- If the user selects the experimental `AGENT_GUARD_PII_PROVIDER=http` adapter,
-  `agent-guard pii-filter` sends the complete text provided on stdin to the
-  exact URL in `AGENT_GUARD_PII_REDACT_URL`. In
+- If the user selects the experimental `AGENT_GUARD_PII_PROVIDER=http` adapter
+  or the `AGENT_GUARD_PII_PROVIDER=pleno` adapter, `agent-guard pii-filter`
+  sends the complete text provided on stdin to the exact URL in
+  `AGENT_GUARD_PII_REDACT_URL`. In
   `AGENT_GUARD_PII_HOOK_MODE=block`, supported tool-input text is sent to that
   same endpoint to determine whether it contains PII, and so is the complete
   text of every prompt the user submits. A prompt is not a tool input: it
@@ -58,8 +59,8 @@ The following explicit actions use the network:
 
 PII hook handling defaults to `off`; the default provider is the local `regex`
 adapter. `mask` mode performs input Tier-2 detection and output masking locally,
-even if the HTTP adapter is configured. Agent Guard never chooses or enables a
-remote PII endpoint on the user's behalf.
+even if an endpoint-backed adapter is configured. Agent Guard never chooses or
+enables a remote PII endpoint on the user's behalf.
 
 ## User controls
 

--- a/README.md
+++ b/README.md
@@ -135,11 +135,12 @@ tree. Default hook processing is local: Agent Guard has no telemetry, developer
 service, account, or analytics endpoint, and it does not retain inspected data.
 
 PII hook handling is off by default. The built-in `regex` provider stays local.
-If you explicitly select the experimental `http` adapter, text passed to
+If you explicitly select the experimental `http` adapter or the `pleno`
+provider, text passed to
 `pii-filter`—and supported tool-input text in PII `block` mode—is sent to the
 exact endpoint in `AGENT_GUARD_PII_REDACT_URL`. Review that endpoint's privacy
-and retention terms before enabling it. Agent Guard does not guarantee
-compatibility with any specific service.
+and retention terms before enabling it. The generic `http` adapter does not
+guarantee compatibility with any specific service.
 
 Dependency downloads never happen from a lifecycle hook. The guided setup asks
 before installing anything and requires a published SHA-256 for the gitleaks
@@ -330,6 +331,7 @@ Choose a provider with `AGENT_GUARD_PII_PROVIDER`. Accepted values are:
 
 - `regex` — the supported built-in local adapter, and the default. No network access.
 - `http` — an experimental bring-your-own-endpoint adapter. No compatibility with a specific service is guaranteed.
+- `pleno` — an opt-in adapter verified against pleno-anonymize `/api/redact`.
 
 Any other value fails closed with the accepted-value list; PII redaction never degrades to pass-through on an unrecognised provider.
 
@@ -351,6 +353,38 @@ printf '%s\n' 'Customer jane@example.com' \
 ```
 
 `http` POSTs JSON as `{"text":"..."}` and reads a redacted string from `redacted_text`, `anonymized_text`, `text`, or `data.redacted_text`. It requires `curl`, `jq`, and `AGENT_GUARD_PII_REDACT_URL`; missing tools, missing URL, HTTP errors, invalid JSON, or unexpected response shapes fail closed. This generic contract is exercised with local mock fixtures, but compatibility with a real external service is not yet part of Agent Guard's supported surface.
+
+For pleno-anonymize, run the service separately and point Agent Guard at its
+`/api/redact` endpoint:
+
+```sh
+printf '%s\n' 'Contact Alice at alice@example.com' \
+  | AGENT_GUARD_PII_PROVIDER=pleno \
+    AGENT_GUARD_PII_REDACT_URL=http://127.0.0.1:8080/api/redact \
+    AGENT_GUARD_PII_LANGUAGE=en \
+    agent-guard pii-filter
+```
+
+The `pleno` adapter was verified against upstream commit
+`ba3a14bc125fd6c6eb80aa5b24c22f6b99801126`. It sends exactly `text` and an
+explicit `language`, then accepts only a JSON object with a string `text`.
+`AGENT_GUARD_PII_LANGUAGE` accepts `en` or `ja` and defaults to `en`; this is an
+Agent Guard default, while upstream defaults to `ja`. Upstream's server default
+engine is `default`; Agent Guard does not override it. Endpoint requests have a
+30-second default timeout, configurable with a positive integer
+`AGENT_GUARD_PII_TIMEOUT_SECONDS`. Endpoint calls made by the 10-second input
+hooks are capped at 5 seconds so the CLI can fail closed before the host's hook
+deadline; a smaller configured timeout remains in effect.
+
+Agent Guard does not install, import, start, or manage pleno-anonymize, Python,
+Docker, models, or a hosted service. To test an endpoint you operate with
+synthetic English, Japanese, and clean text, run:
+
+```sh
+AGENT_GUARD_PII_INTEGRATION_PLENO=1 \
+AGENT_GUARD_PII_REDACT_URL=http://127.0.0.1:8080/api/redact \
+make test-pleno-integration
+```
 
 PII handling in hooks is off by default. Two opt-in modes:
 

--- a/plugins/agent-guard/PRIVACY.md
+++ b/plugins/agent-guard/PRIVACY.md
@@ -46,9 +46,10 @@ The following explicit actions use the network:
   tool content.
 - The standalone `bootstrap.sh` install path downloads Agent Guard's release
   archive and checksum from this project's GitHub Releases page.
-- If the user selects the experimental `AGENT_GUARD_PII_PROVIDER=http` adapter,
-  `agent-guard pii-filter` sends the complete text provided on stdin to the
-  exact URL in `AGENT_GUARD_PII_REDACT_URL`. In
+- If the user selects the experimental `AGENT_GUARD_PII_PROVIDER=http` adapter
+  or the `AGENT_GUARD_PII_PROVIDER=pleno` adapter, `agent-guard pii-filter`
+  sends the complete text provided on stdin to the exact URL in
+  `AGENT_GUARD_PII_REDACT_URL`. In
   `AGENT_GUARD_PII_HOOK_MODE=block`, supported tool-input text is sent to that
   same endpoint to determine whether it contains PII, and so is the complete
   text of every prompt the user submits. A prompt is not a tool input: it
@@ -58,8 +59,8 @@ The following explicit actions use the network:
 
 PII hook handling defaults to `off`; the default provider is the local `regex`
 adapter. `mask` mode performs input Tier-2 detection and output masking locally,
-even if the HTTP adapter is configured. Agent Guard never chooses or enables a
-remote PII endpoint on the user's behalf.
+even if an endpoint-backed adapter is configured. Agent Guard never chooses or
+enables a remote PII endpoint on the user's behalf.
 
 ## User controls
 

--- a/plugins/agent-guard/README.md
+++ b/plugins/agent-guard/README.md
@@ -80,9 +80,12 @@ policy, and template-named symlinks are checked against their resolved target.
 Template contents still undergo normal secret scanning on writes.
 
 Default processing is local, ephemeral, and has no telemetry. PII hook handling
-is off by default. Selecting the experimental `http` PII adapter sends
-the text described in [PRIVACY.md](PRIVACY.md) to the user-configured endpoint.
-Compatibility with a specific external service is not guaranteed.
+is off by default. Explicitly selecting the experimental `http` adapter or the
+`pleno` provider sends the text described in [PRIVACY.md](PRIVACY.md) to the
+user-configured endpoint. The generic `http` adapter does not guarantee
+compatibility with any specific service; `pleno` is verified only against the
+pleno-anonymize `/api/redact` contract at upstream commit
+`ba3a14bc125fd6c6eb80aa5b24c22f6b99801126`.
 
 ## Requirements and platforms
 

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -690,10 +690,12 @@ Usage:
   agent-guard pii-filter [--check]
 
 Reads text from stdin and writes masked text to stdout.
-Set AGENT_GUARD_PII_PROVIDER=regex|http to choose a provider (default: regex).
+Set AGENT_GUARD_PII_PROVIDER=regex|http|pleno to choose a provider (default: regex).
   regex  built-in local adapter; no network access.
   http   experimental bring-your-own-endpoint adapter; needs
          AGENT_GUARD_PII_REDACT_URL; no service compatibility guarantee.
+  pleno  verified pleno-anonymize /api/redact adapter; needs
+         AGENT_GUARD_PII_REDACT_URL. AGENT_GUARD_PII_LANGUAGE defaults to en.
 EOF
 }
 
@@ -701,13 +703,13 @@ EOF
 # drift apart. Unknown values fail closed rather than reaching pass-through
 # output or an unvalidated endpoint contract.
 pii_unsupported_provider() {
-  die "pii-filter: unsupported provider: $1 (expected regex or http)"
+  die "pii-filter: unsupported provider: $1 (expected regex, http, or pleno)"
 }
 
 pii_provider() {
   provider=${AGENT_GUARD_PII_PROVIDER:-regex}
   case "$provider" in
-    regex|http) printf '%s' "$provider" ;;
+    regex|http|pleno) printf '%s' "$provider" ;;
     *) pii_unsupported_provider "$provider" ;;
   esac
 }
@@ -749,26 +751,73 @@ pii_endpoint_adapter_filter() {
   url=${AGENT_GUARD_PII_REDACT_URL:-}
   [ -n "$url" ] || die "pii-filter: AGENT_GUARD_PII_REDACT_URL is required for provider: $provider"
 
-  payload=$(jq -Rs '{text: .}') \
-    || die "pii-filter: $provider provider request serialization failed"
-  out=$(mktemp_file) || die "pii-filter: failed to create temp file"
-  if ! printf '%s' "$payload" \
-    | curl -fsS -H 'Content-Type: application/json' -d @- "$url" >"$out"; then
-    rm -f "$out"
-    die "pii-filter: $provider provider request failed: $url"
+  timeout=${AGENT_GUARD_PII_TIMEOUT_SECONDS:-30}
+  case "$timeout" in
+    ''|*[!0-9]*) die "pii-filter: AGENT_GUARD_PII_TIMEOUT_SECONDS must be a positive integer" ;;
+  esac
+  [ "$timeout" -gt 0 ] 2>/dev/null \
+    || die "pii-filter: AGENT_GUARD_PII_TIMEOUT_SECONDS must be a positive integer"
+  if [ "${AGENT_GUARD_PII_HOOK_REQUEST:-}" = 1 ] && [ "$timeout" -gt 5 ]; then
+    timeout=5
   fi
 
-  if ! jq -er '
-    if type == "object" and (.redacted_text | type == "string") then .redacted_text
-    elif type == "object" and (.anonymized_text | type == "string") then .anonymized_text
-    elif type == "object" and (.text | type == "string") then .text
-    elif type == "object" and (.data.redacted_text | type == "string") then .data.redacted_text
-    else error("missing redacted text")
-    end
-  ' "$out"; then
+  case "$provider" in
+    http)
+      payload=$(jq -Rs '{text: .}') \
+        || die "pii-filter: $provider provider request serialization failed"
+      ;;
+    pleno)
+      language=${AGENT_GUARD_PII_LANGUAGE:-en}
+      case "$language" in
+        en|ja) ;;
+        *) die "pii-filter: AGENT_GUARD_PII_LANGUAGE must be en or ja for provider: pleno" ;;
+      esac
+      payload=$(jq -Rs --arg language "$language" '{text: ., language: $language}') \
+        || die "pii-filter: $provider provider request serialization failed"
+      ;;
+    *) pii_unsupported_provider "$provider" ;;
+  esac
+  out=$(mktemp_file) || die "pii-filter: failed to create temp file"
+  if ! printf '%s' "$payload" \
+    | curl -fsS --max-time "$timeout" -H 'Content-Type: application/json' -d @- "$url" \
+      >"$out" 2>/dev/null; then
     rm -f "$out"
-    die "pii-filter: $provider provider returned invalid response; expected JSON with redacted_text, anonymized_text, text, or data.redacted_text"
+    die "pii-filter: $provider provider request failed"
   fi
+
+  case "$provider" in
+    http)
+      if ! jq -e -r -s -j '
+        if length != 1 or (.[0] | type != "object") then
+          error("expected exactly one JSON object")
+        else .[0]
+        end
+        | if (.redacted_text | type == "string") then .redacted_text
+        elif (.anonymized_text | type == "string") then .anonymized_text
+        elif (.text | type == "string") then .text
+        elif (.data.redacted_text | type == "string") then .data.redacted_text
+        else error("missing redacted text")
+        end
+      ' "$out"; then
+        rm -f "$out"
+        die "pii-filter: $provider provider returned invalid response; expected JSON with redacted_text, anonymized_text, text, or data.redacted_text"
+      fi
+      ;;
+    pleno)
+      if ! jq -e -r -s -j '
+        if length != 1 or (.[0] | type != "object") then
+          error("expected exactly one JSON object")
+        else .[0]
+        end
+        | if (.text | type == "string") then .text
+        else error("missing redacted text")
+        end
+      ' "$out"; then
+        rm -f "$out"
+        die "pii-filter: pleno provider returned invalid response; expected JSON with string text"
+      fi
+      ;;
+  esac
   rm -f "$out"
 }
 
@@ -782,7 +831,7 @@ pii_adapter_filter() {
   fi
   case "$provider" in
     regex) pii_regex_adapter_filter ;;
-    http) pii_endpoint_adapter_filter "$provider" ;;
+    http|pleno) pii_endpoint_adapter_filter "$provider" ;;
     *) pii_unsupported_provider "$provider" ;;
   esac
 }
@@ -794,7 +843,7 @@ pii_adapter_check() {
       need_cmd awk
       info "$PROGRAM: PII provider regex ok"
       ;;
-    http)
+    http|pleno)
       printf '%s' "agent-guard pii provider check" | pii_endpoint_adapter_filter "$provider" >/dev/null
       status=$?
       [ "$status" -eq 0 ] || exit "$status"
@@ -829,7 +878,7 @@ pii_filter() {
 pii_text_has_match() {
   text=$1
   [ -n "$text" ] || return 1
-  masked=$(printf '%s' "$text" | pii_adapter_filter)
+  masked=$(printf '%s' "$text" | AGENT_GUARD_PII_HOOK_REQUEST=1 pii_adapter_filter)
   status=$?
   [ "$status" -eq 0 ] || exit "$status"
   [ "$masked" != "$text" ]

--- a/tests/run-pleno-integration.sh
+++ b/tests/run-pleno-integration.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env sh
+set -u
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd -P)
+BIN="$ROOT/plugins/agent-guard/bin/agent-guard"
+
+if [ "${AGENT_GUARD_PII_INTEGRATION_PLENO:-}" != 1 ]; then
+  printf '%s\n' 'set AGENT_GUARD_PII_INTEGRATION_PLENO=1 to run real pleno endpoint tests' >&2
+  exit 2
+fi
+
+if [ -z "${AGENT_GUARD_PII_REDACT_URL:-}" ]; then
+  printf '%s\n' 'AGENT_GUARD_PII_REDACT_URL is required' >&2
+  exit 2
+fi
+
+run_pleno() {
+  language=$1
+  text=$2
+  printf '%s' "$text" \
+    | AGENT_GUARD_PII_PROVIDER=pleno \
+      AGENT_GUARD_PII_LANGUAGE="$language" \
+      AGENT_GUARD_PII_TIMEOUT_SECONDS="${AGENT_GUARD_PII_TIMEOUT_SECONDS:-90}" \
+      "$BIN" pii-filter
+}
+
+english='Contact Alice Smith at alice@example.com or +1 415-555-0199.'
+english_out=$(run_pleno en "$english") || exit 1
+case "$english_out" in
+  *alice@example.com*|*415-555-0199*)
+    printf '%s\n' 'English integration failed: identifiers remained in output' >&2
+    exit 1
+    ;;
+esac
+[ "$english_out" != "$english" ] || {
+  printf '%s\n' 'English integration failed: response was unchanged' >&2
+  exit 1
+}
+
+japanese='山田太郎のメールはtaro.yamada@example.jp、電話は090-1234-5678です。'
+japanese_out=$(run_pleno ja "$japanese") || exit 1
+case "$japanese_out" in
+  *taro.yamada@example.jp*|*090-1234-5678*)
+    printf '%s\n' 'Japanese integration failed: identifiers remained in output' >&2
+    exit 1
+    ;;
+esac
+[ "$japanese_out" != "$japanese" ] || {
+  printf '%s\n' 'Japanese integration failed: response was unchanged' >&2
+  exit 1
+}
+
+clean='The sky is blue.'
+clean_out=$(run_pleno en "$clean") || exit 1
+[ "$clean_out" = "$clean" ] || {
+  printf '%s\n' 'Clean-text integration failed: response changed unexpectedly' >&2
+  exit 1
+}
+
+AGENT_GUARD_PII_PROVIDER=pleno \
+AGENT_GUARD_PII_LANGUAGE=en \
+AGENT_GUARD_PII_TIMEOUT_SECONDS="${AGENT_GUARD_PII_TIMEOUT_SECONDS:-90}" \
+  "$BIN" pii-filter --check >/dev/null || exit 1
+
+printf '%s\n' 'pleno integration ok: English, Japanese, clean text, and provider check'

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -3364,7 +3364,7 @@ else
   sed 's/^/  stderr: /' "$ERR"
 fi
 
-if grep -q 'expected regex or http' "$ERR"; then
+if grep -q 'expected regex, http, or pleno' "$ERR"; then
   ok "pii-filter provider error lists the accepted values"
 else
   not_ok "pii-filter provider error lists the accepted values"
@@ -3398,7 +3398,7 @@ else
   sed 's/^/  stderr: /' "$ERR"
 fi
 
-if "$PLUGIN_ROOT/bin/agent-guard" pii-filter --help 2>&1 | grep -q 'AGENT_GUARD_PII_PROVIDER=regex|http'; then
+if "$PLUGIN_ROOT/bin/agent-guard" pii-filter --help 2>&1 | grep -q 'AGENT_GUARD_PII_PROVIDER=regex|http|pleno'; then
   ok "pii-filter help lists the accepted values"
 else
   not_ok "pii-filter help lists the accepted values"
@@ -3413,6 +3413,7 @@ fi
 PII_MOCK_CURL_DIR="$TMP_ROOT/pii-curl-bin"
 PII_REQUEST_FILE="$TMP_ROOT/pii-request.json"
 PII_URL_FILE="$TMP_ROOT/pii-url.txt"
+PII_TIMEOUT_FILE="$TMP_ROOT/pii-timeout.txt"
 mkdir -p "$PII_MOCK_CURL_DIR"
 cat > "$PII_MOCK_CURL_DIR/curl" <<'EOSH'
 #!/usr/bin/env sh
@@ -3425,6 +3426,12 @@ if [ -n "${PII_MOCK_CURL_URL:-}" ]; then
 fi
 while [ "$#" -gt 0 ]; do
   case "$1" in
+    --max-time)
+      shift
+      if [ -n "${PII_MOCK_CURL_TIMEOUT:-}" ]; then
+        printf '%s\n' "${1:-}" >"$PII_MOCK_CURL_TIMEOUT"
+      fi
+      ;;
     -d|--data|--data-raw|--data-binary)
       shift
       if [ "${1:-}" = "@-" ]; then
@@ -3438,9 +3445,19 @@ done
 case "${PII_MOCK_CURL_MODE:-ok}" in
   ok) printf '%s\n' '{"redacted_text":"masked by endpoint"}' ;;
   data) printf '%s\n' '{"data":{"redacted_text":"masked by nested endpoint"}}' ;;
+  pleno) printf '%s\n' '{"text":"masked by pleno","items":["replace"]}' ;;
+  empty) printf '%s\n' '{"text":""}' ;;
+  empty-response) : ;;
+  multi) printf '%s\n' '{"text":"first"}' '{"text":"second"}' ;;
+  valid-bad-json) printf '%s\n' '{"text":"first"}' 'not json' ;;
+  wrong-type) printf '%s\n' '[]' ;;
+  exact) printf '%s\n' '{"text":"exact"}' ;;
+  exact-newline) printf '%s\n' '{"text":"exact\n"}' ;;
   bad-json) printf '%s\n' 'not json' ;;
   bad-response) printf '%s\n' '{"unexpected":"value"}' ;;
   fail) printf '%s\n' 'synthetic curl failure' >&2; exit 7 ;;
+  leak-fail) printf '%s\n' 'remote error contains SYNTHETIC_REMOTE_QA_SENTINEL' >&2; exit 22 ;;
+  timeout) printf '%s\n' 'synthetic timeout' >&2; exit 28 ;;
 esac
 EOSH
 chmod +x "$PII_MOCK_CURL_DIR/curl"
@@ -3520,6 +3537,284 @@ if [ "$(cat "$PII_URL_FILE")" = "http://127.0.0.1:8080/api/redact" ]; then
   ok "pii-filter endpoint adapter uses AGENT_GUARD_PII_REDACT_URL"
 else
   not_ok "pii-filter endpoint adapter uses AGENT_GUARD_PII_REDACT_URL"
+fi
+
+rm -f "$PII_REQUEST_FILE" "$PII_TIMEOUT_FILE"
+printf '%s' 'Contact Alice at alice@example.com' \
+  | PATH="$PII_MOCK_CURL_DIR:$PATH" \
+    AGENT_GUARD_PII_PROVIDER=pleno \
+    AGENT_GUARD_PII_REDACT_URL='http://127.0.0.1:8080/api/redact' \
+    PII_MOCK_CURL_REQUEST="$PII_REQUEST_FILE" \
+    PII_MOCK_CURL_TIMEOUT="$PII_TIMEOUT_FILE" \
+    PII_MOCK_CURL_MODE=pleno \
+    "$PLUGIN_ROOT/bin/agent-guard" pii-filter \
+    >"$OUT" 2>"$ERR"
+status=$?
+if [ "$status" -eq 0 ] && [ "$(cat "$OUT")" = 'masked by pleno' ]; then
+  ok "pii-filter pleno provider uses the verified text response"
+else
+  not_ok "pii-filter pleno provider uses the verified text response (status $status)"
+  sed 's/^/  stdout: /' "$OUT"
+  sed 's/^/  stderr: /' "$ERR"
+fi
+if jq -e \
+  '.text == "Contact Alice at alice@example.com" and .language == "en" and (keys | sort) == ["language", "text"]' \
+  "$PII_REQUEST_FILE" >/dev/null 2>&1; then
+  ok "pii-filter pleno provider sends text and explicit default language"
+else
+  not_ok "pii-filter pleno provider sends the verified request shape"
+  sed 's/^/  request: /' "$PII_REQUEST_FILE"
+fi
+if [ "$(cat "$PII_TIMEOUT_FILE")" = '30' ]; then
+  ok "pii-filter endpoint adapter applies a bounded default timeout"
+else
+  not_ok "pii-filter endpoint adapter applies a bounded default timeout"
+fi
+
+printf '%s' '山田太郎のメールはtaro@example.jpです' \
+  | PATH="$PII_MOCK_CURL_DIR:$PATH" \
+    AGENT_GUARD_PII_PROVIDER=pleno \
+    AGENT_GUARD_PII_LANGUAGE=ja \
+    AGENT_GUARD_PII_REDACT_URL='http://127.0.0.1:8080/api/redact' \
+    PII_MOCK_CURL_REQUEST="$PII_REQUEST_FILE" \
+    PII_MOCK_CURL_MODE=pleno \
+    "$PLUGIN_ROOT/bin/agent-guard" pii-filter \
+    >"$OUT" 2>"$ERR"
+status=$?
+if [ "$status" -eq 0 ] && jq -e '.language == "ja"' "$PII_REQUEST_FILE" >/dev/null 2>&1; then
+  ok "pii-filter pleno provider accepts explicit Japanese language"
+else
+  not_ok "pii-filter pleno provider accepts explicit Japanese language (status $status)"
+  sed 's/^/  stderr: /' "$ERR"
+fi
+
+rm -f "$PII_URL_FILE"
+printf '%s' 'x' \
+  | PATH="$PII_MOCK_CURL_DIR:$PATH" \
+    AGENT_GUARD_PII_PROVIDER=pleno \
+    AGENT_GUARD_PII_LANGUAGE=ko \
+    AGENT_GUARD_PII_REDACT_URL='http://127.0.0.1:8080/api/redact' \
+    PII_MOCK_CURL_URL="$PII_URL_FILE" \
+    "$PLUGIN_ROOT/bin/agent-guard" pii-filter \
+    >"$OUT" 2>"$ERR"
+status=$?
+if [ "$status" -eq 2 ] && [ ! -s "$OUT" ] && [ ! -e "$PII_URL_FILE" ]; then
+  ok "pii-filter pleno provider rejects invalid language before network access"
+else
+  not_ok "pii-filter pleno provider rejects invalid language before network access (expected 2, got $status)"
+fi
+
+printf '%s' 'x' \
+  | PATH="$PII_MOCK_CURL_DIR:$PATH" \
+    AGENT_GUARD_PII_PROVIDER=pleno \
+    AGENT_GUARD_PII_REDACT_URL='http://127.0.0.1:8080/api/redact' \
+    PII_MOCK_CURL_MODE=empty \
+    "$PLUGIN_ROOT/bin/agent-guard" pii-filter \
+    >"$OUT" 2>"$ERR"
+status=$?
+if [ "$status" -eq 0 ] && [ "$(cat "$OUT")" = '' ]; then
+  ok "pii-filter pleno provider accepts an empty string response"
+else
+  not_ok "pii-filter pleno provider accepts an empty string response (status $status)"
+fi
+
+printf '%s' 'x' \
+  | PATH="$PII_MOCK_CURL_DIR:$PATH" \
+    AGENT_GUARD_PII_PROVIDER=pleno \
+    AGENT_GUARD_PII_REDACT_URL='http://127.0.0.1:8080/api/redact' \
+    PII_MOCK_CURL_MODE=ok \
+    "$PLUGIN_ROOT/bin/agent-guard" pii-filter \
+    >"$OUT" 2>"$ERR"
+status=$?
+if [ "$status" -eq 2 ] && [ ! -s "$OUT" ]; then
+  ok "pii-filter pleno provider rejects generic http response aliases"
+else
+  not_ok "pii-filter pleno provider rejects generic http response aliases (expected 2, got $status)"
+fi
+
+printf '%s' 'x' \
+  | PATH="$PII_MOCK_CURL_DIR:$PATH" \
+    AGENT_GUARD_PII_PROVIDER=pleno \
+    AGENT_GUARD_PII_REDACT_URL='http://127.0.0.1:8080/api/redact' \
+    PII_MOCK_CURL_MODE=bad-json \
+    "$PLUGIN_ROOT/bin/agent-guard" pii-filter \
+    >"$OUT" 2>"$ERR"
+status=$?
+if [ "$status" -eq 2 ] && [ ! -s "$OUT" ]; then
+  ok "pii-filter pleno provider fails closed on malformed JSON"
+else
+  not_ok "pii-filter pleno provider fails closed on malformed JSON (expected 2, got $status)"
+fi
+
+for provider in http pleno; do
+  for mode in empty-response multi valid-bad-json wrong-type; do
+    printf '%s' 'x' \
+      | PATH="$PII_MOCK_CURL_DIR:$PATH" \
+        AGENT_GUARD_PII_PROVIDER="$provider" \
+        AGENT_GUARD_PII_REDACT_URL='http://127.0.0.1:8080/api/redact' \
+        PII_MOCK_CURL_MODE="$mode" \
+        "$PLUGIN_ROOT/bin/agent-guard" pii-filter \
+        >"$OUT" 2>"$ERR"
+    status=$?
+    if [ "$status" -eq 2 ] && [ ! -s "$OUT" ]; then
+      ok "pii-filter $provider provider fails closed without partial output on $mode response"
+    else
+      not_ok "pii-filter $provider provider fails closed without partial output on $mode response (expected 2, got $status)"
+      sed 's/^/  stdout: /' "$OUT"
+      sed 's/^/  stderr: /' "$ERR"
+    fi
+  done
+done
+
+printf '%s' 'x' \
+  | PATH="$PII_MOCK_CURL_DIR:$PATH" \
+    AGENT_GUARD_PII_PROVIDER=http \
+    AGENT_GUARD_PII_REDACT_URL='http://127.0.0.1:8080/api/redact' \
+    PII_MOCK_CURL_MODE=empty \
+    "$PLUGIN_ROOT/bin/agent-guard" pii-filter \
+    >"$OUT" 2>"$ERR"
+status=$?
+if [ "$status" -eq 0 ] && [ "$(cat "$OUT")" = '' ]; then
+  ok "pii-filter http provider accepts an empty string response"
+else
+  not_ok "pii-filter http provider accepts an empty string response (status $status)"
+fi
+
+PII_EXACT_FILE="$TMP_ROOT/pii-exact.txt"
+for provider in http pleno; do
+  for mode in exact exact-newline; do
+    if [ "$mode" = exact ]; then
+      printf '%s' 'exact' >"$PII_EXACT_FILE"
+    else
+      printf 'exact\n' >"$PII_EXACT_FILE"
+    fi
+    printf '%s' 'x' \
+      | PATH="$PII_MOCK_CURL_DIR:$PATH" \
+        AGENT_GUARD_PII_PROVIDER="$provider" \
+        AGENT_GUARD_PII_REDACT_URL='http://127.0.0.1:8080/api/redact' \
+        PII_MOCK_CURL_MODE="$mode" \
+        "$PLUGIN_ROOT/bin/agent-guard" pii-filter \
+        >"$OUT" 2>"$ERR"
+    status=$?
+    if [ "$status" -eq 0 ] && cmp -s "$OUT" "$PII_EXACT_FILE"; then
+      ok "pii-filter $provider provider preserves exact response bytes for $mode text"
+    else
+      not_ok "pii-filter $provider provider preserves exact response bytes for $mode text (status $status)"
+    fi
+  done
+done
+
+PATH="$PII_MOCK_CURL_DIR:$PATH" \
+  AGENT_GUARD_PII_PROVIDER=pleno \
+  AGENT_GUARD_PII_REDACT_URL='http://127.0.0.1:8080/api/redact' \
+  PII_MOCK_CURL_MODE=pleno \
+  "$PLUGIN_ROOT/bin/agent-guard" pii-filter --check \
+  >"$OUT" 2>"$ERR"
+status=$?
+if [ "$status" -eq 0 ]; then
+  ok "pii-filter pleno provider passes endpoint check"
+else
+  not_ok "pii-filter pleno provider passes endpoint check (expected 0, got $status)"
+  sed 's/^/  stderr: /' "$ERR"
+fi
+
+printf '%s' '{"tool_name":"Write","tool_input":{"file_path":"note.txt","content":"Contact Alice"}}' \
+  | PATH="$PII_MOCK_CURL_DIR:$PATH" \
+    AGENT_GUARD_PII_HOOK_MODE=block \
+    AGENT_GUARD_PII_PROVIDER=pleno \
+    AGENT_GUARD_PII_TIMEOUT_SECONDS=30 \
+    AGENT_GUARD_PII_REDACT_URL='http://127.0.0.1:8080/api/redact' \
+    PII_MOCK_CURL_TIMEOUT="$PII_TIMEOUT_FILE" \
+    PII_MOCK_CURL_MODE=pleno \
+    "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool \
+    >"$OUT" 2>"$ERR"
+status=$?
+if [ "$status" -eq 2 ] && grep -q 'blocked PII' "$ERR"; then
+  ok "PII hook block mode uses the pleno provider"
+else
+  not_ok "PII hook block mode uses the pleno provider (expected 2, got $status)"
+  sed 's/^/  stdout: /' "$OUT"
+  sed 's/^/  stderr: /' "$ERR"
+fi
+if [ "$(cat "$PII_TIMEOUT_FILE")" = 5 ]; then
+  ok "PII hook endpoint request is capped below the host timeout"
+else
+  not_ok "PII hook endpoint request is capped below the host timeout"
+fi
+
+printf '%s' 'x' \
+  | PATH="$PII_MOCK_CURL_DIR:$PATH" \
+    AGENT_GUARD_PII_PROVIDER=pleno \
+    AGENT_GUARD_PII_TIMEOUT_SECONDS=1 \
+    AGENT_GUARD_PII_REDACT_URL='http://127.0.0.1:8080/api/redact' \
+    PII_MOCK_CURL_MODE=timeout \
+    "$PLUGIN_ROOT/bin/agent-guard" pii-filter \
+    >"$OUT" 2>"$ERR"
+status=$?
+if [ "$status" -eq 2 ] && [ ! -s "$OUT" ]; then
+  ok "pii-filter pleno provider fails closed on timeout"
+else
+  not_ok "pii-filter pleno provider fails closed on timeout (expected 2, got $status)"
+fi
+
+printf '%s' 'x' \
+  | PATH="$PII_MOCK_CURL_DIR:$PATH" \
+    AGENT_GUARD_PII_PROVIDER=pleno \
+    AGENT_GUARD_PII_REDACT_URL='http://127.0.0.1:8080/api/redact' \
+    PII_MOCK_CURL_MODE=fail \
+    "$PLUGIN_ROOT/bin/agent-guard" pii-filter \
+    >"$OUT" 2>"$ERR"
+status=$?
+if [ "$status" -eq 2 ] && [ ! -s "$OUT" ]; then
+  ok "pii-filter pleno provider fails closed on HTTP failure"
+else
+  not_ok "pii-filter pleno provider fails closed on HTTP failure (expected 2, got $status)"
+fi
+
+printf '%s' 'x' \
+  | PATH="$PII_MOCK_CURL_DIR:$PATH" \
+    AGENT_GUARD_PII_PROVIDER=pleno \
+    AGENT_GUARD_PII_REDACT_URL='https://user:SYNTHETIC_URL_QA_SENTINEL@example.invalid/api/redact?key=SYNTHETIC_URL_QA_SENTINEL' \
+    PII_MOCK_CURL_MODE=leak-fail \
+    "$PLUGIN_ROOT/bin/agent-guard" pii-filter \
+    >"$OUT" 2>"$ERR"
+status=$?
+if [ "$status" -eq 2 ] \
+  && [ ! -s "$OUT" ] \
+  && grep -q 'pleno provider request failed' "$ERR" \
+  && ! grep -q 'SYNTHETIC_.*_QA_SENTINEL' "$ERR"; then
+  ok "pii-filter endpoint failure hides URL credentials and remote stderr"
+else
+  not_ok "pii-filter endpoint failure hides URL credentials and remote stderr (expected 2, got $status)"
+  sed 's/^/  stdout: /' "$OUT"
+  sed 's/^/  stderr: /' "$ERR"
+fi
+
+printf '%s' 'x' \
+  | env -u AGENT_GUARD_PII_REDACT_URL AGENT_GUARD_PII_PROVIDER=pleno \
+    "$PLUGIN_ROOT/bin/agent-guard" pii-filter \
+    >"$OUT" 2>"$ERR"
+status=$?
+if [ "$status" -eq 2 ] && [ ! -s "$OUT" ]; then
+  ok "pii-filter pleno provider fails closed when URL is missing"
+else
+  not_ok "pii-filter pleno provider fails closed when URL is missing (expected 2, got $status)"
+fi
+
+rm -f "$PII_URL_FILE"
+printf '%s' 'x' \
+  | PATH="$PII_MOCK_CURL_DIR:$PATH" \
+    AGENT_GUARD_PII_PROVIDER=pleno \
+    AGENT_GUARD_PII_TIMEOUT_SECONDS=0 \
+    AGENT_GUARD_PII_REDACT_URL='http://127.0.0.1:8080/api/redact' \
+    PII_MOCK_CURL_URL="$PII_URL_FILE" \
+    "$PLUGIN_ROOT/bin/agent-guard" pii-filter \
+    >"$OUT" 2>"$ERR"
+status=$?
+if [ "$status" -eq 2 ] && [ ! -s "$OUT" ] && [ ! -e "$PII_URL_FILE" ]; then
+  ok "pii-filter pleno provider rejects invalid timeout before network access"
+else
+  not_ok "pii-filter pleno provider rejects invalid timeout before network access (expected 2, got $status)"
 fi
 
 PATH="$PII_MOCK_CURL_DIR:$PATH" \

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -829,8 +829,16 @@ SUBRENDERER="$SUBMIRROR/scripts/render-submission-entry.sh"
 SUBREMOTE="$TMP_ROOT/submission-remote.git"
 mkdir -p "$SUBMIRROR"
 if git -C "$ROOT" archive HEAD | tar -x -C "$SUBMIRROR" 2>/dev/null; then
-  # Run the working-tree scripts and template under test, not HEAD's committed
-  # copies. The current worktree may not have been committed yet.
+  # Run the working-tree plugin payload, public policy mirrors, scripts, and
+  # template under test, not HEAD's committed copies. The current worktree may
+  # not have been committed yet; using only `git archive HEAD` here previously
+  # hid root/plugin policy drift until CI tested the resulting commit.
+  rm -rf "$SUBMIRROR/plugins/agent-guard"
+  mkdir -p "$SUBMIRROR/plugins/agent-guard"
+  cp -R "$PLUGIN_ROOT/." "$SUBMIRROR/plugins/agent-guard/"
+  for policy_file in README.md LICENSE PRIVACY.md SECURITY.md SUPPORT.md THIRD_PARTY_NOTICES.md; do
+    cp "$ROOT/$policy_file" "$SUBMIRROR/$policy_file"
+  done
   cp "$ROOT/scripts/validate-submission-readiness.sh" "$SUBVALIDATOR"
   cp "$ROOT/scripts/render-submission-entry.sh" "$SUBRENDERER"
   cp "$ROOT/scripts/marketplace-entry.template.json" "$SUBENTRY"


### PR DESCRIPTION
## 배경

Closes #53
Closes #204
Closes #205

`plenoai/pleno-anonymize`의 현재 API 계약을 다시 검증한 뒤, 기존 범용 HTTP transport를 재사용하는 opt-in `pleno` provider를 추가합니다.

검증 기준 upstream은 `plenoai/pleno-anonymize@ba3a14bc125fd6c6eb80aa5b24c22f6b99801126`입니다. 이 버전의 `/api/redact`는 `text`, `language(ja|en, upstream 기본 ja)`, 선택적 `engine(default|appi|openai-privacy-filter)` 등을 받고, text 요청의 성공 응답은 문자열 `text`와 `items`를 반환합니다. 200 응답의 OpenAPI schema는 비어 있으므로 Agent Guard는 upstream SDK와 같은 방향으로 문자열 `text`를 엄격히 확인합니다.

## 변경 사항

- `AGENT_GUARD_PII_PROVIDER=pleno`를 명시적 opt-in provider로 추가했습니다.
- pleno 요청은 `{text, language}`만 보내며 `AGENT_GUARD_PII_LANGUAGE=en|ja`를 검증합니다. Agent Guard 기본은 영어 사용자 흐름에 맞춘 `en`이고, upstream 기본 `ja`에 의존하지 않도록 항상 명시합니다.
- upstream 기본 `engine=default`를 사용하며 별도 engine 설정은 노출하지 않습니다.
- 범용 `http`의 기존 응답 별칭 호환성은 유지하고, `pleno`는 정확히 문자열 `text`만 받습니다.
- endpoint 요청 기본 timeout은 30초입니다. 10초짜리 PreToolUse/UserPromptSubmit에서 호출할 때는 5초로 제한해 host timeout보다 먼저 fail-closed 결과를 냅니다.
- #204: 응답 전체를 slurp한 뒤 정확히 하나의 JSON 객체인지 검증하고 나서만 출력합니다. 복수 객체나 `valid JSON + malformed tail`에서 부분 stdout이 더 이상 나오지 않습니다.
- #205: 요청 실패 진단에서 설정 URL과 curl/원격 stderr 원문을 제거해 userinfo/query credential 또는 provider 오류 본문이 로그로 노출되지 않게 했습니다.
- README/PRIVACY와 CLI help를 실제 전송 범위·언어·timeout·비관리 범위에 맞췄습니다.
- 실제 endpoint용 opt-in `make test-pleno-integration`을 추가했습니다. Agent Guard는 Python/Docker/model/service를 설치하거나 기동하지 않습니다.

## 검증

- pristine `origin/main@a2ca2c5`: `sh tests/run.sh` → 1,247 passed / 0 failed
- 최종 변경: `sh tests/run.sh` → 1,276 passed / 0 failed
- 독립 리뷰 snapshot: `sh tests/run.sh` → 1,276 passed / 0 failed
- `make smoke-test` → 실제 gitleaks 8.30.1, git pre-commit hook, CLI/hook smoke 모두 통과
- `git diff --check`, sh/dash/bash/zsh syntax → 통과
- 부모 독립 재현: http/pleno 각각 복수 object, valid+malformed, empty response, wrong text type는 exit 2/stdout 0; 정상 empty string은 exit 0/stdout 0. URL/curl stderr 합성 marker는 출력되지 않음(총 12개 케이스 기대 일치).

### 실제 pleno hosted QA

최종 SHA에서 `https://pleno-anonymize.fly.dev/api/redact`에 합성 데이터만 전송했습니다.

- 영어 + default engine: email/phone/person이 placeholder로 치환됨
- 일본어 + default engine: email/phone이 치환됨
- 영어 clean text + default engine: 원문 그대로 반환
- `pii-filter --check`: 통과
- live `/health`: 200 `{"status":"ok"}`
- live OpenAPI: source에서 확인한 language/engine 제약과 일치

공개 hosted endpoint의 실제 동작 호환성은 확인했지만 배포 서버의 commit identity를 인증한 것은 아닙니다. 로컬 Docker daemon은 사용 가능했으나, 공식 Dockerfile이 APPI 약 170MB와 privacy-filter 약 1.6GB 이상의 모델 다운로드를 포함하므로 이번 QA에서는 대규모 이미지를 새로 build/run하지 않았습니다. 따라서 pinned self-hosted Docker 실행은 미검증이고 hosted 실제 QA와 구분합니다.

## 독립 리뷰

초기 리뷰에서 후행 LF byte 보존, PRIVACY 고지, host timeout보다 긴 endpoint timeout 문제가 발견되어 모두 반영했습니다. 최신 diff 재리뷰 결과 actionable finding은 없습니다.
