### PR TITLE
fix(scan): 누락된 스캔 의존성을 unavailable 상태로 구분

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,10 +217,9 @@ agent-guard checksum
 ```
 
 Scan commands return `0` for a clean scan and `1` for a detection. Non-zero
-errors do not clear the input: `2` covers invalid arguments, scanner execution
-errors, and currently missing dependencies; `3` covers unavailable repository
-or diff access, such as `scan-staged` outside a Git work tree. Missing
-dependencies are not yet consistently classified as `3` ([#196](https://github.com/JeongJaeSoon/agent-guard/issues/196)).
+errors do not clear the input: `2` covers invalid arguments and scanner
+execution errors; `3` means the direct scan could not run because its scanner,
+scanner configuration, Git dependency, or repository state is unavailable.
 Check the error message and treat every non-zero result as uncleared.
 
 At a host hook boundary, scanner-infrastructure failures (missing dependencies,

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -195,12 +195,19 @@ $stdin_line"
 }
 
 die() {
+  die_with_status 2 "$@"
+}
+
+die_with_status() {
+  failure_status=$1
+  shift
   info "$PROGRAM: $*"
-  exit 2
+  exit "$failure_status"
 }
 
 need_cmd() {
-  command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+  command -v "$1" >/dev/null 2>&1 \
+    || die_with_status "${2:-2}" "required command not found: $1"
 }
 
 resolve_gitleaks() {
@@ -222,8 +229,9 @@ resolve_gitleaks() {
 
 need_gitleaks() {
   GITLEAKS_BIN=$(resolve_gitleaks) \
-    || die "required command not found: gitleaks (run: $PROGRAM setup)"
-  [ -f "$GITLEAKS_CONFIG" ] || die "gitleaks config not found: $GITLEAKS_CONFIG"
+    || die_with_status "${1:-2}" "required command not found: gitleaks (run: $PROGRAM setup)"
+  [ -f "$GITLEAKS_CONFIG" ] \
+    || die_with_status "${1:-2}" "gitleaks config not found: $GITLEAKS_CONFIG"
 }
 
 hook_dependencies_ready() {
@@ -1698,8 +1706,8 @@ extract_git_diff_added() {
 }
 
 scan_staged() {
-  need_cmd git
-  need_gitleaks
+  need_cmd git "$SCAN_STATUS_UNAVAILABLE"
+  need_gitleaks "$SCAN_STATUS_UNAVAILABLE"
   require_git_repo || return $?
   repo_root=$(git rev-parse --show-toplevel 2>/dev/null) \
     || return "$SCAN_STATUS_UNAVAILABLE"
@@ -1770,8 +1778,8 @@ scan_untracked_files() {
 }
 
 scan_working_tree() {
-  need_cmd git
-  need_gitleaks
+  need_cmd git "$SCAN_STATUS_UNAVAILABLE"
+  need_gitleaks "$SCAN_STATUS_UNAVAILABLE"
   require_git_repo || return $?
   repo_root=$(git rev-parse --show-toplevel 2>/dev/null) \
     || return "$SCAN_STATUS_UNAVAILABLE"
@@ -1816,7 +1824,7 @@ $unstaged"
 }
 
 scan_path() {
-  need_gitleaks
+  need_gitleaks "$SCAN_STATUS_UNAVAILABLE"
   if [ "${1:-}" = "--" ]; then
     shift
   fi

--- a/tests/direct-scan-status.sh
+++ b/tests/direct-scan-status.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env sh
+# Direct scan dependency failures have a distinct public status. Keep this
+# focused check runnable on its own as well as from the main suite.
+set -u
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd -P)
+GUARD="$ROOT/plugins/agent-guard/bin/agent-guard"
+SCANNER="$ROOT/tests/fixtures/mock-gitleaks"
+POLICY="$ROOT/plugins/agent-guard/config/gitleaks.toml"
+CASE_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/agent-guard-status.XXXXXX") || exit 1
+trap 'rm -rf "$CASE_ROOT"' EXIT HUP INT TERM
+
+export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null
+mkdir "$CASE_ROOT/repo" "$CASE_ROOT/no-git"
+git -C "$CASE_ROOT/repo" -c init.templateDir= init -q || exit 1
+printf 'ordinary app source\n' >"$CASE_ROOT/repo/app.txt"
+git -C "$CASE_ROOT/repo" add app.txt || exit 1
+
+for dep in sh dirname pwd readlink awk; do
+  dep_path=$(command -v "$dep") || exit 1
+  ln -s "$dep_path" "$CASE_ROOT/no-git/$dep"
+done
+
+printf '#!/bin/sh\nexit 42\n' >"$CASE_ROOT/scanner-crash"
+chmod +x "$CASE_ROOT/scanner-crash"
+cd "$CASE_ROOT/repo" || exit 1
+
+failed=0
+checked=0
+expect() {
+  expected=$1
+  label=$2
+  shift 2
+  "$@" >"$CASE_ROOT/out" 2>"$CASE_ROOT/err"
+  actual=$?
+  checked=$((checked + 1))
+  if [ "$actual" -eq "$expected" ]; then
+    printf 'ok - %s\n' "$label"
+  else
+    printf 'not ok - %s (expected %s, got %s)\n' "$label" "$expected" "$actual"
+    sed 's/^/  stderr: /' "$CASE_ROOT/err"
+    failed=$((failed + 1))
+  fi
+}
+
+for scan in scan-path scan-staged scan-working-tree; do
+  expect 3 "$scan reports missing scanner as unavailable" \
+    env AGENT_GUARD_GITLEAKS_BIN="$CASE_ROOT/missing-scanner" \
+      AGENT_GUARD_GITLEAKS_CONFIG="$POLICY" "$GUARD" "$scan" .
+  expect 3 "$scan reports missing policy as unavailable" \
+    env AGENT_GUARD_GITLEAKS_BIN="$SCANNER" \
+      AGENT_GUARD_GITLEAKS_CONFIG="$CASE_ROOT/missing-policy" "$GUARD" "$scan" .
+  expect 0 "$scan recovers to clean when dependencies return" \
+    env AGENT_GUARD_GITLEAKS_BIN="$SCANNER" \
+      AGENT_GUARD_GITLEAKS_CONFIG="$POLICY" "$GUARD" "$scan" .
+done
+
+for scan in scan-staged scan-working-tree; do
+  expect 3 "$scan reports missing git as unavailable" \
+    env PATH="$CASE_ROOT/no-git" AGENT_GUARD_GITLEAKS_BIN="$SCANNER" \
+      AGENT_GUARD_GITLEAKS_CONFIG="$POLICY" "$GUARD" "$scan"
+done
+
+expect 3 'native Git hook retains unavailable status' \
+  env AGENT_GUARD_GITLEAKS_BIN="$CASE_ROOT/missing-scanner" \
+    AGENT_GUARD_GITLEAKS_CONFIG="$POLICY" "$ROOT/githooks/pre-commit"
+expect 2 'scanner crash remains a scanner error' \
+  env AGENT_GUARD_GITLEAKS_BIN="$CASE_ROOT/scanner-crash" \
+    AGENT_GUARD_GITLEAKS_CONFIG="$POLICY" "$GUARD" scan-path .
+expect 2 'explicit exec retains its fail-closed dependency status' \
+  env AGENT_GUARD_OUTPUT_REDACT=mask \
+    AGENT_GUARD_GITLEAKS_BIN="$CASE_ROOT/missing-scanner" \
+    AGENT_GUARD_GITLEAKS_CONFIG="$POLICY" "$GUARD" exec -- sh -c 'touch should-not-run'
+checked=$((checked + 1))
+if [ ! -e should-not-run ]; then
+  printf 'ok - unavailable exec does not run its command\n'
+else
+  printf 'not ok - unavailable exec ran its command\n'
+  failed=$((failed + 1))
+fi
+
+printf '%s direct scan status checks, %s failed\n' "$checked" "$failed"
+[ "$failed" -eq 0 ]

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -4459,11 +4459,14 @@ ln -s "$(command -v awk)" "$NO_GITLEAKS_BIN/awk"
 AGENT_GUARD_GITLEAKS_BIN=/nonexistent/gitleaks PATH="$NO_GITLEAKS_BIN" \
   "$PLUGIN_ROOT/bin/agent-guard" scan-path "$CLEAN_DIR" >"$OUT" 2>"$ERR"
 status=$?
-if [ "$status" -eq 2 ]; then
-  ok "scan-path dies when gitleaks is unavailable"
+if [ "$status" -eq 3 ]; then
+  ok "scan-path reports unavailable when gitleaks is missing"
 else
-  not_ok "scan-path dies when gitleaks is unavailable (expected 2, got $status)"
+  not_ok "scan-path reports unavailable when gitleaks is missing (expected 3, got $status)"
 fi
+
+run_expect 0 "direct scan dependency statuses and recovery" \
+  "$REAL_SH" "$ROOT/tests/direct-scan-status.sh"
 
 # Reuse NO_GITLEAKS_BIN: jq must remain reachable so setup can report jq ok
 # while gitleaks is missing.


### PR DESCRIPTION
## 요약

직접 scan 명령에서 scanner, scanner 설정, Git 의존성을 사용할 수 없을 때 종료 상태를 `3`으로 반환하도록 정리했습니다. clean은 `0`, 탐지는 `1`, 잘못된 인자와 scanner 실행 오류는 `2`를 유지합니다.

호스트 훅의 `AGENT_GUARD_INFRA_FAILURE_MODE` 정책과 explicit `exec`의 fail-closed 사전 점검은 변경하지 않았습니다. 따라서 Git hook과 GitHub Action은 새 `3`도 기존처럼 non-zero 실패로 처리합니다.

README의 종료 상태 설명도 같은 계약으로 갱신했습니다.

## 검증

- `sh tests/direct-scan-status.sh` — 15/15 통과: scanner/config/Git 누락=3, 복구 clean=0, scanner 실행 오류=2, explicit exec 미실행=2, native Git hook non-zero 전파
- `plugins/agent-guard/bin/agent-guard smoke-test` — 실제 gitleaks 8.30.1로 clean과 탐지, native Git hook 확인
- `git diff --check`

`sh tests/run.sh`는 이 Codex 호스트의 단일 명령 실행 제한으로 완료 집계를 얻지 못했습니다. 최종 병합 전 CI 또는 제한 없는 환경에서의 전체 회귀 확인이 필요합니다.

관련 이슈: #196. 공개 후속 릴리스 확인까지 남아 있어 소스 병합만으로 자동 종료하지 않습니다.
