### PR TITLE
fix(bootstrap): 추출 뒤 교체된 payload bin 경로 재확인

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -94,7 +94,6 @@ main() {
   mkdir -p "$BIN_DIR"
   HOME_DIR=$(CDPATH= cd -- "$HOME_DIR" && pwd -P)
   BIN_DIR=$(CDPATH= cd -- "$BIN_DIR" && pwd -P)
-  payload_bin_dir=$(CDPATH= cd -- "$HOME_DIR/bin" && pwd -P)
   # Refuse directory targets rather than copying into them or deleting data.
   [ ! -d "$HOME_DIR/bin/agent-guard" ] || die "executable destination is a directory"
   [ ! -L "$HOME_DIR/bin/agent-guard" ] || die "executable destination must not be a symlink"
@@ -102,6 +101,10 @@ main() {
   # Retain tar's replacement semantics: an existing installer symlink must be
   # replaced, not followed (or rejected partway through by BSD cp -R).
   tar -xzf "$tmp/$archive" -C "$HOME_DIR" || die "installation extraction failed"
+  # tar may replace a pre-existing HOME_DIR/bin symlink with the archive's real
+  # bin directory. Resolve it after extraction so a former alias of BIN_DIR does
+  # not make us skip creation of the public executable link.
+  payload_bin_dir=$(CDPATH= cd -- "$HOME_DIR/bin" && pwd -P)
   bin_path="$HOME_DIR/bin/agent-guard"
   if [ "$BIN_DIR" = "$payload_bin_dir" ]; then
     info "$prog: executable already lives in $BIN_DIR; no symlink needed"

--- a/tests/bootstrap-update.sh
+++ b/tests/bootstrap-update.sh
@@ -94,6 +94,41 @@ AGENT_GUARD_BIN_DIR="$CASE_ROOT/bin-alias" run sh "$ROOT/bootstrap.sh"
 healthy "$CASE_ROOT/bin-alias/agent-guard"
 check 'physical directory aliases cannot create executable self-links'
 
+# A legacy layout may have made the payload bin itself a symlink to the public
+# bin directory. macOS tar replaces that symlink with the archive's real bin
+# directory, so the post-extraction paths must control whether a public link is
+# needed.
+legacy_empty_home="$CASE_ROOT/legacy-empty-home"
+legacy_empty_public="$CASE_ROOT/legacy-empty-public"
+mkdir -p "$legacy_empty_home" "$legacy_empty_public"
+printf 'preserve empty public data\n' >"$legacy_empty_public/user-note"
+ln -s "$legacy_empty_public" "$legacy_empty_home/bin"
+(AGENT_GUARD_HOME="$legacy_empty_home" AGENT_GUARD_BIN_DIR="$legacy_empty_public" \
+  run sh "$ROOT/bootstrap.sh")
+[ -d "$legacy_empty_home/bin" ] && [ ! -L "$legacy_empty_home/bin" ]
+[ -f "$legacy_empty_home/bin/agent-guard" ] && [ ! -L "$legacy_empty_home/bin/agent-guard" ]
+run "$legacy_empty_public/agent-guard" version
+[ "$(readlink "$legacy_empty_public/agent-guard")" = "$legacy_empty_home/bin/agent-guard" ]
+grep -q 'preserve empty public data' "$legacy_empty_public/user-note"
+check 'replaced payload-bin alias creates the missing public executable link'
+
+legacy_stale_home="$CASE_ROOT/legacy-stale-home"
+legacy_stale_public="$CASE_ROOT/legacy-stale-public"
+legacy_external="$CASE_ROOT/legacy-external-agent-guard"
+mkdir -p "$legacy_stale_home" "$legacy_stale_public"
+printf '#!/bin/sh\nprintf stale-external\\n\n' >"$legacy_external"
+chmod +x "$legacy_external"
+legacy_external_before=$(shasum -a 256 "$legacy_external")
+ln -s "$legacy_external" "$legacy_stale_public/agent-guard"
+ln -s "$legacy_stale_public" "$legacy_stale_home/bin"
+if AGENT_GUARD_HOME="$legacy_stale_home" AGENT_GUARD_BIN_DIR="$legacy_stale_public" \
+  sh "$ROOT/bootstrap.sh" >"$CASE_ROOT/out" 2>"$CASE_ROOT/err"; then exit 1; fi
+[ -L "$legacy_stale_home/bin" ]
+[ "$(readlink "$legacy_stale_home/bin")" = "$legacy_stale_public" ]
+[ "$(readlink "$legacy_stale_public/agent-guard")" = "$legacy_external" ]
+[ "$legacy_external_before" = "$(shasum -a 256 "$legacy_external")" ]
+check 'stale public link is rejected without touching its external target or payload alias'
+
 mv "$AGENT_GUARD_HOME/install.sh" "$CASE_ROOT/external-installer"
 external_before=$(shasum -a 256 "$CASE_ROOT/external-installer")
 ln -s "$CASE_ROOT/external-installer" "$AGENT_GUARD_HOME/install.sh"


### PR DESCRIPTION
기존 설치의 `HOME_DIR/bin`이 public bin 디렉터리를 가리키는 링크일 때 tar가 이를 실제 payload 디렉터리로 교체해도, 추출 전 경로 비교값을 재사용하여 public executable 링크를 만들지 않는 문제를 수정합니다. 추출 후 실제 payload 경로를 다시 계산합니다.

- 빈 public 디렉터리에서 실행 링크를 복구하고 무관한 사용자 파일을 보존합니다.
- 기존 executable 링크가 외부 대상을 가리키는 경우 추출 전에 거부하여 외부 대상과 기존 alias를 보존합니다.
- 독립 실제 Git clone 전체 검사 1248/0, 최신 main 통합 후 bootstrap 집중 검사 14/14, diff 검증 통과. Ubuntu/macOS CI 결과도 병합 전에 확인합니다.

#207 늦은 리뷰의 후속 수정이며 #194의 공개 후속 릴리스 설치/update 검증은 별도로 남겨둡니다.
