### PR TITLE
fix(shell): 정상 current 캐시 우선과 불완전 payload 재진입 차단

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,7 @@ jobs:
             bootstrap.sh \
             githooks/pre-commit \
             tests/bootstrap-update.sh \
+            tests/shell-cache-authority.sh \
             tests/run.sh \
             bench/run.sh \
             scripts/build-release-tarball.sh \

--- a/README.md
+++ b/README.md
@@ -571,24 +571,37 @@ agent-guard setup-shell --no-command-wrapping  # persistent opt-out
 
 For plugin installs, every execution refreshes a sibling
 `current/bin/agent-guard` symlink and `setup-shell` records only that stable
-path. Hooks and shell snippets use `current` first, then select the newest
-installed semantic-version directory if symlinks are unavailable. This keeps an
-already-running session valid when the host removes an older cache directory.
+path. Shell snippets treat a healthy `current` as authoritative even when a
+higher version directory is already cached. Only when `current` is missing or
+invalid do they recover through the newest complete cache payload whose
+directory and embedded versions agree. Relative PATH entries and symlink
+aliases cannot re-admit a rejected cache payload. This is recovery based on the
+existing `current` contract; it does not read the host plugin registry or infer
+which cached version the user selected. A newly host-selected plugin becomes
+authoritative after that plugin binary runs and safely advances `current`.
 Standalone CLI installs continue to use their stable `~/.agent-guard` /
-`~/.local/bin` paths.
+`~/.local/bin` paths and retain an independent PATH fallback.
 
-The shell resolver order is an explicit `$AGENT_GUARD_BIN`, the stable baked
-path, the newest plugin-cache version fallback, then `agent-guard` on `$PATH`.
+The managed rc block embeds this resolver. After installing a plugin version
+that changes shell resolution, rerun the plugin-local `agent-guard setup-shell`
+(preserving `--no-command-wrapping` if that is your choice), then start a new
+shell and restart Claude Code. Updating plugin files alone does not rewrite an
+older rc block. Confirm the new shell's `AGENT_GUARD_SHELL_INIT_VERSION`; do not
+assume an already-running shell changed in place.
+
+The shell resolver order is an explicit `$AGENT_GUARD_BIN`, a healthy stable
+`current` path, the newest validated plugin-cache fallback only when `current`
+is unavailable, then an independent `agent-guard` on `$PATH`.
 Both transparent wrapping and `agx` preflight dependencies and use the same
 infrastructure policy: default `open` runs the original command with one clear
 `output is NOT masked` warning per shell session; set
 `AGENT_GUARD_INFRA_FAILURE_MODE=closed` to refuse execution instead.
 
-Because the plugin (auto-updated by `claude plugin update`) and the binary the integration actually resolves update independently, updating only one side can silently leave `agx` / `!`-command masking on older rules. To catch that, the `shell-init` snippet exports `AGENT_GUARD_SHELL_INIT_VERSION` — the version of the binary it resolved at rc-eval time (whichever of the three paths above won) — and a Claude Code `SessionStart` hook compares that marker against the plugin's own version, showing a **non-blocking warning** on mismatch. Because the marker records what the integration resolved at shell start (not a re-derivation the hook would have to guess), it stays silent unless the integration is genuinely loaded *and* drifting: a user who has `agent-guard` on `$PATH` but never ran `setup-shell` gets no warning, and a plugin-only install pinned to a stale baked binary is still covered. It is a start-up snapshot, so if you upgrade the resolved binary *in place* inside a long-lived shell and then launch Claude Code from it without opening a new shell, the warning reflects the version from when that shell started until you re-source your rc.
+Because the plugin (auto-updated by `claude plugin update`) and the binary the integration actually resolves update independently, updating only one side can silently leave `agx` / `!`-command masking on older rules. To catch that, the `shell-init` snippet exports `AGENT_GUARD_SHELL_INIT_VERSION` — the version of the binary selected by the resolver at rc-eval time — and a Claude Code `SessionStart` hook compares that marker against the plugin's own version, showing a **non-blocking warning** on mismatch. Because the marker records what the integration resolved at shell start (not a re-derivation the hook would have to guess), it stays silent unless the integration is genuinely loaded *and* drifting: a user who has `agent-guard` on `$PATH` but never ran `setup-shell` gets no warning, and a plugin-only install pinned to a stale baked binary is still covered. It is a start-up snapshot, so if you upgrade the resolved binary *in place* inside a long-lived shell and then launch Claude Code from it without opening a new shell, the warning reflects the version from when that shell started until you re-source your rc.
 
 The marker can only reach the hook through the environment of the shell that **launched** Claude Code, and some launches never evaluate an rc at all: a fish (or other non-POSIX) login shell, or starting Claude Code from a GUI or IDE launcher. The wrapping is still loaded in those cases — Claude Code's own bash/zsh snapshot reads the rc — so a missing marker is not evidence that setup is missing. Before reporting `command wrapping is not loaded`, `SessionStart` therefore reads the managed block out of the rc the snapshot shell uses (`~/.bashrc` when `$SHELL` ends in `bash`, otherwise `~/.zshrc`) and checks that it can still **load** ([#139](https://github.com/JeongJaeSoon/agent-guard/issues/139)).
 
-The delimiters alone are not that proof. The block's `eval` emits nothing once the binary it resolves has disappeared — a plugin cache update or uninstall, or a hand-edited block — so neither the wrapping nor the marker is installed, and treating the delimiters as sufficient would silence the warning on exactly the sessions that are unprotected. The hook instead replays the block's own resolution order against the paths baked into it: the stable/self path, then the newest versioned binary under the plugin cache base, then `agent-guard` on `$PATH`. Those are `stat`-level checks — nothing is executed, no subshell is forked — so the three outcomes are:
+The delimiters alone are not that proof. The block's `eval` emits nothing once the binary it resolves has disappeared — a plugin cache update or uninstall, or a hand-edited block — so neither the wrapping nor the marker is installed, and treating the delimiters as sufficient would silence the warning on exactly the sessions that are unprotected. The hook instead replays the block's own resolution order against the paths baked into it: the stable/self path, then a versioned binary under the plugin cache base, then `agent-guard` on `$PATH`. Those are `stat`-level checks — nothing is executed, no subshell is forked — so they remain a diagnostic heuristic rather than proof of the runtime choice. They do not validate payload completeness and embedded-version agreement as deeply as the shell resolver or prove which binary a new shell executed. The three outcomes are:
 
 | rc state | `SessionStart` |
 | --- | --- |

--- a/plugins/agent-guard/README.md
+++ b/plugins/agent-guard/README.md
@@ -43,8 +43,14 @@ installing software and requires the published SHA-256 for the selected
 gitleaks archive.
 
 Plugin executions maintain a version-independent sibling path at
-`current/bin/agent-guard`; hook manifests and `setup-shell` use it and can fall
-back to the newest installed version directory after a cache upgrade. Scanner
+`current/bin/agent-guard`; hook manifests and `setup-shell` use it. A healthy
+`current` remains authoritative over merely cached higher versions. If it is
+missing or invalid, the shell resolver can recover only through the newest
+complete semantic-version sibling whose embedded version agrees; it does not
+infer host plugin-registry selection. Existing managed rc blocks embed the
+resolver, so rerun the plugin-local `agent-guard setup-shell` after a resolver
+upgrade (preserving `--no-command-wrapping` when selected), then start a new
+shell and restart Claude Code. Scanner
 infrastructure failures use `AGENT_GUARD_INFRA_FAILURE_MODE=open|closed`
 (`open` by default) and warn once per session. Secret detections always block.
 

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -65,14 +65,26 @@ fi
 # and embedded version agree. An interrupted plugin update can leave a
 # higher-looking directory with only bin/agent-guard; selecting it would turn a
 # healthy installation into a default-open DEGRADED hook.
+policy_file_has_active_rule() {
+  [ -r "$1" ] && [ -s "$1" ] \
+    && awk '$0 !~ /^[[:space:]]*(#|$)/ { found = 1; exit } END { exit !found }' "$1"
+}
+
+cache_policy_file_usable() {
+  [ -f "$1" ] && [ ! -L "$1" ] && policy_file_has_active_rule "$1"
+}
+
 plugin_cache_root_usable() (
   candidate_root=$1
   expected_version=${2:-}
   candidate_bin="$candidate_root/bin/agent-guard"
-  [ -x "$candidate_bin" ] \
-    && [ -r "$candidate_root/config/gitleaks.toml" ] \
-    && [ -r "$candidate_root/config/deny-read-paths.txt" ] \
-    && [ -r "$candidate_root/config/deny-bash-patterns.txt" ] \
+  [ -d "$candidate_root" ] && [ ! -L "$candidate_root" ] \
+    && [ -d "$candidate_root/bin" ] && [ ! -L "$candidate_root/bin" ] \
+    && [ -d "$candidate_root/config" ] && [ ! -L "$candidate_root/config" ] \
+    && [ -f "$candidate_bin" ] && [ ! -L "$candidate_bin" ] && [ -x "$candidate_bin" ] \
+    && cache_policy_file_usable "$candidate_root/config/gitleaks.toml" \
+    && cache_policy_file_usable "$candidate_root/config/deny-read-paths.txt" \
+    && cache_policy_file_usable "$candidate_root/config/deny-bash-patterns.txt" \
     || return 1
   embedded_version=
   while IFS= read -r candidate_line; do
@@ -237,9 +249,9 @@ need_gitleaks() {
 hook_dependencies_ready() {
   command -v jq >/dev/null 2>&1 || return 1
   resolve_gitleaks >/dev/null 2>&1 || return 1
-  [ -f "$GITLEAKS_CONFIG" ] || return 1
-  [ -f "$DENY_READ_PATHS" ] || return 1
-  [ -f "$DENY_BASH_PATTERNS" ] || return 1
+  [ -f "$GITLEAKS_CONFIG" ] && policy_file_has_active_rule "$GITLEAKS_CONFIG" || return 1
+  [ -f "$DENY_READ_PATHS" ] && policy_file_has_active_rule "$DENY_READ_PATHS" || return 1
+  [ -f "$DENY_BASH_PATTERNS" ] && policy_file_has_active_rule "$DENY_BASH_PATTERNS" || return 1
 }
 
 infrastructure_failure_mode() {
@@ -5257,6 +5269,147 @@ unset __ag_name __ag_alias
 EOF
 }
 
+# The rc bootstrap and a loaded shell use the same cache authority and recovery
+# rules. Emit functions so a managed rc can still resolve after its original
+# version directory disappears, without executing unvalidated cached binaries.
+shell_init_resolver() {
+  cat <<'EOF'
+__agentguard_policy_file_usable() {
+  [ -f "$1" ] && [ ! -L "$1" ] && [ -r "$1" ] && [ -s "$1" ] \
+    && awk '$0 !~ /^[[:space:]]*(#|$)/ { found = 1; exit } END { exit !found }' "$1"
+}
+__agentguard_cache_bin_usable() {
+  __ag_candidate=$1
+  __ag_expected=${2:-}
+  __ag_root=${__ag_candidate%/bin/agent-guard}
+  [ -d "$__ag_root" ] && [ ! -L "$__ag_root" ] \
+    && [ -d "$__ag_root/bin" ] && [ ! -L "$__ag_root/bin" ] \
+    && [ -d "$__ag_root/config" ] && [ ! -L "$__ag_root/config" ] \
+    && [ -f "$__ag_candidate" ] && [ ! -L "$__ag_candidate" ] && [ -x "$__ag_candidate" ] \
+    && __agentguard_policy_file_usable "$__ag_root/config/gitleaks.toml" \
+    && __agentguard_policy_file_usable "$__ag_root/config/deny-read-paths.txt" \
+    && __agentguard_policy_file_usable "$__ag_root/config/deny-bash-patterns.txt" \
+    || return 1
+  __ag_embedded=
+  while IFS= read -r __ag_line; do
+    case "$__ag_line" in
+      VERSION=*) __ag_embedded=${__ag_line#VERSION=}; break ;;
+    esac
+  done <"$__ag_candidate"
+  [ -n "$__ag_embedded" ] \
+    && { [ -z "$__ag_expected" ] || [ "$__ag_embedded" = "$__ag_expected" ]; }
+}
+__agentguard_latest_plugin_bin() {
+  [ -n "${__agentguard_plugin_base:-}" ] || return 1
+  __ag_latest=$(
+    for __ag_candidate in "$__agentguard_plugin_base"/[0-9]*.[0-9]*.[0-9]*/bin/agent-guard; do
+      [ -x "$__ag_candidate" ] || continue
+      __ag_root=${__ag_candidate%/bin/agent-guard}
+      [ -d "$__ag_root" ] && [ ! -L "$__ag_root" ] || continue
+      __ag_version=${__ag_candidate%/bin/agent-guard}
+      __ag_version=${__ag_version##*/}
+      __agentguard_cache_bin_usable "$__ag_candidate" "$__ag_version" || continue
+      printf '%s\t%s\n' "$__ag_version" "$__ag_candidate"
+    done \
+      | awk -F '\t' '$1 ~ /^[0-9]+\.[0-9]+\.[0-9]+$/' \
+      | sort -t. -k1,1n -k2,2n -k3,3n \
+      | tail -n 1 \
+      | cut -f 2-
+  )
+  [ -n "$__ag_latest" ] && [ -x "$__ag_latest" ] || return 1
+  printf '%s' "$__ag_latest"
+}
+__agentguard_semver() {
+  __ag_version=$1
+  __ag_major=${__ag_version%%.*}
+  __ag_rest=${__ag_version#*.}
+  [ "$__ag_rest" != "$__ag_version" ] || return 1
+  __ag_minor=${__ag_rest%%.*}
+  __ag_patch=${__ag_rest#*.}
+  [ "$__ag_patch" != "$__ag_rest" ] || return 1
+  case "$__ag_major" in ''|*[!0-9]*) return 1 ;; esac
+  case "$__ag_minor" in ''|*[!0-9]*) return 1 ;; esac
+  case "$__ag_patch" in ''|*[!0-9]*) return 1 ;; esac
+  return 0
+}
+__agentguard_physical_path() (
+  __ag_physical=$1
+  case "$__ag_physical" in
+    /*) ;;
+    *)
+      __ag_pwd=$(pwd -P 2>/dev/null) || return 1
+      __ag_physical=$__ag_pwd/$__ag_physical
+      ;;
+  esac
+  __ag_hops=0
+  while [ -L "$__ag_physical" ]; do
+    __ag_hops=$((__ag_hops + 1))
+    [ "$__ag_hops" -le 40 ] || return 1
+    __ag_target=$(readlink -- "$__ag_physical" 2>/dev/null) || return 1
+    case "$__ag_target" in
+      /*) __ag_physical=$__ag_target ;;
+      *) __ag_physical=${__ag_physical%/*}/$__ag_target ;;
+    esac
+  done
+  __ag_name=${__ag_physical##*/}
+  __ag_parent=${__ag_physical%/*}
+  [ "$__ag_parent" != "$__ag_physical" ] || __ag_parent=.
+  __ag_parent=$(CDPATH= cd -- "$__ag_parent" 2>/dev/null && pwd -P) || return 1
+  printf '%s/%s' "$__ag_parent" "$__ag_name"
+)
+__agentguard_path_bin() {
+  __ag_path=$(command -v agent-guard 2>/dev/null) || __ag_path=
+  if [ -n "$__ag_path" ]; then
+    # setup-shell adds current/bin to PATH. Do not re-admit an invalid cache
+    # through a relative entry or an external symlink alias after rejecting its
+    # payload above. Canonicalize only in plugin mode; standalone PATH fallback
+    # retains support for command wrappers that are not payload-shaped paths.
+    if [ -n "${__agentguard_plugin_base:-}" ]; then
+      __ag_path=$(__agentguard_physical_path "$__ag_path") || return 1
+      __ag_base=$(CDPATH= cd -- "$__agentguard_plugin_base" 2>/dev/null && pwd -P) \
+        || __ag_base=
+      if [ -n "$__ag_base" ]; then
+        case "$__ag_path" in "$__ag_base"|"$__ag_base"/*) return 1 ;; esac
+      fi
+    fi
+    printf '%s' "$__ag_path"; return 0
+  fi
+  return 1
+}
+__agentguard_exe() {
+  if [ -n "${AGENT_GUARD_BIN:-}" ] && [ -x "$AGENT_GUARD_BIN" ]; then
+    printf '%s' "$AGENT_GUARD_BIN"; return 0
+  fi
+  __ag_current_target=
+  if [ -n "${__agentguard_plugin_base:-}" ] \
+     && [ -L "$__agentguard_plugin_base/current" ]; then
+    __ag_current_target=$(readlink "$__agentguard_plugin_base/current" 2>/dev/null) \
+      || __ag_current_target=
+    __agentguard_semver "$__ag_current_target" || __ag_current_target=
+  fi
+  if [ -n "${__agentguard_bin:-}" ] && [ -x "$__agentguard_bin" ] \
+     && [ -n "${__agentguard_plugin_base:-}" ] \
+     && [ -n "$__ag_current_target" ] \
+     && [ -d "$__agentguard_plugin_base/$__ag_current_target" ] \
+     && [ ! -L "$__agentguard_plugin_base/$__ag_current_target" ] \
+     && __agentguard_cache_bin_usable \
+          "$__agentguard_plugin_base/$__ag_current_target/bin/agent-guard" \
+          "$__ag_current_target"; then
+    printf '%s' "$__agentguard_bin"; return 0
+  fi
+  __ag_latest=$(__agentguard_latest_plugin_bin) || __ag_latest=
+  if [ -n "$__ag_latest" ]; then
+    printf '%s' "$__ag_latest"; return 0
+  fi
+  if [ -z "${__agentguard_plugin_base:-}" ] \
+     && [ -n "${__agentguard_bin:-}" ] && [ -x "$__agentguard_bin" ]; then
+    printf '%s' "$__agentguard_bin"; return 0
+  fi
+  __agentguard_path_bin
+}
+EOF
+}
+
 shell_init() {
   # Propagate a die from inside the command substitution: without this an
   # unknown argument printed its error but still emitted the full snippet with
@@ -5303,68 +5456,9 @@ shell_init() {
 # Resolve the agent-guard binary at call time: an explicit $AGENT_GUARD_BIN wins,
 # then the stable baked path, then the newest installed plugin version as a
 # recovery fallback, then $PATH for standalone CLI installs.
-__agentguard_cache_bin_usable() {
-  __ag_candidate=$1
-  __ag_expected=${2:-}
-  __ag_root=${__ag_candidate%/bin/agent-guard}
-  [ -x "$__ag_candidate" ] \
-    && [ -r "$__ag_root/config/gitleaks.toml" ] \
-    && [ -r "$__ag_root/config/deny-read-paths.txt" ] \
-    && [ -r "$__ag_root/config/deny-bash-patterns.txt" ] \
-    || return 1
-  __ag_embedded=
-  while IFS= read -r __ag_line; do
-    case "$__ag_line" in
-      VERSION=*) __ag_embedded=${__ag_line#VERSION=}; break ;;
-    esac
-  done <"$__ag_candidate"
-  [ -n "$__ag_embedded" ] \
-    && { [ -z "$__ag_expected" ] || [ "$__ag_embedded" = "$__ag_expected" ]; }
-}
-__agentguard_latest_plugin_bin() {
-  [ -n "${__agentguard_plugin_base:-}" ] || return 1
-  __ag_latest=$(
-    for __ag_candidate in "$__agentguard_plugin_base"/[0-9]*.[0-9]*.[0-9]*/bin/agent-guard; do
-      [ -x "$__ag_candidate" ] || continue
-      __ag_version=${__ag_candidate%/bin/agent-guard}
-      __ag_version=${__ag_version##*/}
-      __agentguard_cache_bin_usable "$__ag_candidate" "$__ag_version" || continue
-      printf '%s\t%s\n' "$__ag_version" "$__ag_candidate"
-    done \
-      | awk -F '\t' '$1 ~ /^[0-9]+\.[0-9]+\.[0-9]+$/' \
-      | sort -t. -k1,1n -k2,2n -k3,3n \
-      | tail -n 1 \
-      | cut -f 2-
-  )
-  [ -n "$__ag_latest" ] && [ -x "$__ag_latest" ] || return 1
-  printf '%s' "$__ag_latest"
-}
-__agentguard_exe() {
-  if [ -n "${AGENT_GUARD_BIN:-}" ] && [ -x "$AGENT_GUARD_BIN" ]; then
-    printf '%s' "$AGENT_GUARD_BIN"; return 0
-  fi
-  __ag_current_target=
-  if [ -n "${__agentguard_plugin_base:-}" ] \
-     && [ -L "$__agentguard_plugin_base/current" ]; then
-    __ag_current_target=$(readlink "$__agentguard_plugin_base/current" 2>/dev/null) \
-      || __ag_current_target=
-  fi
-  if [ -n "${__agentguard_bin:-}" ] && [ -x "$__agentguard_bin" ] \
-     && [ -n "${__agentguard_plugin_base:-}" ] \
-     && [ -n "$__ag_current_target" ] \
-     && __agentguard_cache_bin_usable "$__agentguard_bin" "$__ag_current_target"; then
-    printf '%s' "$__agentguard_bin"; return 0
-  fi
-  __ag_latest=$(__agentguard_latest_plugin_bin) || __ag_latest=
-  if [ -n "$__ag_latest" ]; then
-    printf '%s' "$__ag_latest"; return 0
-  fi
-  if [ -n "${__agentguard_bin:-}" ] && [ -x "$__agentguard_bin" ]; then
-    printf '%s' "$__agentguard_bin"; return 0
-  fi
-  if command -v agent-guard >/dev/null 2>&1; then printf '%s' agent-guard; return 0; fi
-  return 1
-}
+EOF
+  shell_init_resolver
+  cat <<'EOF'
 
 __agentguard_infra_closed() {
   [ "${AGENT_GUARD_INFRA_FAILURE_MODE:-open}" = closed ]
@@ -5620,14 +5714,30 @@ do_setup_shell() {
     case "$sh_target" in bash) rc=$HOME/.bashrc ;; fish) rc= ;; *) rc=$HOME/.zshrc ;; esac
   fi
 
-  # Invoke only the stable path for plugin installs. If `current` is unavailable
-  # (for example, the cache is read-only), select the newest semantic-version
-  # directory at rc-eval time; a standalone PATH install remains the last
-  # compatibility fallback. The output probe prevents a stale stub from
-  # shadowing a working stable/plugin binary.
+  # Bootstrap through the same validated resolver as a loaded shell. A healthy
+  # current wins; only an unavailable current permits complete-cache recovery.
   stable=$(sh_squote "$STABLE_BIN")
   cache_base=$(sh_squote "$PLUGIN_CACHE_BASE")
-  line="eval \"\$(_agbin=$stable; _agbase=$cache_base; if [ -n \"\$_agbase\" ]; then _aglatest=\$(for _agc in \"\$_agbase\"/[0-9]*.[0-9]*.[0-9]*/bin/agent-guard; do [ -x \"\$_agc\" ] || continue; _agv=\${_agc%/bin/agent-guard}; printf '%s\\t%s\\n' \"\${_agv##*/}\" \"\$_agc\"; done | awk -F '\\t' '\$1 ~ /^[0-9]+\\.[0-9]+\\.[0-9]+\$/' | sort -t. -k1,1n -k2,2n -k3,3n | tail -n 1 | cut -f 2-); [ -n \"\$_aglatest\" ] && _agbin=\$_aglatest; fi; _agi=; [ -x \"\$_agbin\" ] && _agi=\$(\"\$_agbin\" shell-init${wrapping} 2>/dev/null); if [ -z \"\$_agi\" ] && command -v agent-guard >/dev/null 2>&1; then _agi=\$(agent-guard shell-init${wrapping} 2>/dev/null); fi; [ -n \"\$_agi\" ] && printf '%s\\n' \"\$_agi\")\""
+  resolver=$(sh_squote "$(shell_init_resolver)")
+  line="eval \"\$(
+_agbin=$stable
+_agbase=$cache_base
+__agentguard_bin=\$_agbin
+__agentguard_plugin_base=\$_agbase
+eval $resolver
+_agi=
+_agresolved=\$(__agentguard_exe) || _agresolved=
+if [ -n \"\$_agresolved\" ]; then
+  _agi=\$(\"\$_agresolved\" shell-init${wrapping} 2>/dev/null) || _agi=
+fi
+if [ -z \"\$_agi\" ]; then
+  _agfallback=\$(__agentguard_path_bin) || _agfallback=
+  if [ -n \"\$_agfallback\" ] && [ \"\$_agfallback\" != \"\$_agresolved\" ]; then
+    _agi=\$(\"\$_agfallback\" shell-init${wrapping} 2>/dev/null) || _agi=
+  fi
+fi
+[ -n \"\$_agi\" ] && printf '%s\\n' \"\$_agi\"
+)\""
   path_line=
   if [ -n "$PLUGIN_CACHE_BASE" ]; then
     stable_dir=$(sh_squote "$PLUGIN_CACHE_BASE/current/bin")

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -4893,6 +4893,21 @@ else
   sed 's/^/  stderr: /' "$ERR"
 fi
 
+INACTIVE_POLICY="$TESTTMP/inactive-deny-read-policy.txt"
+printf ' \r\n\t# interrupted policy extraction\r\n' >"$INACTIVE_POLICY"
+printf '%s' '{"session_id":"inactive-policy","tool_name":"Bash","tool_input":{"command":"echo clean"}}' \
+  | AGENT_GUARD_INFRA_FAILURE_MODE=closed \
+    AGENT_GUARD_DENY_READ_PATHS="$INACTIVE_POLICY" \
+    AGENT_GUARD_GITLEAKS_BIN="$MOCK_BIN/gitleaks" \
+    "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool >"$OUT" 2>"$ERR"
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "hook dependencies reject a policy file with no active rules"
+else
+  not_ok "inactive hook policy follows the closed infrastructure policy (expected 2, got $status)"
+  sed 's/^/  stderr: /' "$ERR"
+fi
+
 EXEC_NOT_RUN="$TESTTMP/exec-not-run.txt"
 AGENT_GUARD_GITLEAKS_BIN=/nonexistent/gitleaks PATH="$NO_GITLEAKS_BIN" \
   "$PLUGIN_ROOT/bin/agent-guard" exec -- sh -c 'printf ran >"$1"' _ "$EXEC_NOT_RUN" >"$OUT" 2>"$ERR"
@@ -10560,10 +10575,12 @@ else
 fi
 # Self-healing invocation: the rc line prefers the stable absolute path and
 # keeps an output-checked PATH fallback for standalone installs.
+run_expect 0 "shell startup respects selected current before cached versions" \
+  sh "$ROOT/tests/shell-cache-authority.sh"
 ss_heal="$TESTTMP/setup-heal.rc"
 "$PLUGIN_ROOT/bin/agent-guard" setup-shell --rc "$ss_heal" >/dev/null 2>&1
 if grep -q '_agbin=' "$ss_heal" 2>/dev/null \
-   && grep -Fq '_agi=$("$_agbin" shell-init' "$ss_heal" 2>/dev/null \
+   && grep -Fq '_agi=$("$_agresolved" shell-init' "$ss_heal" 2>/dev/null \
    && grep -q 'command -v agent-guard' "$ss_heal" 2>/dev/null; then
   ok "setup-shell bakes the stable invocation with resolver fallbacks"
 else

--- a/tests/shell-cache-authority.sh
+++ b/tests/shell-cache-authority.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env sh
+# Actual generated rc + shell-init in a private synthetic plugin cache. No host
+# registry, installed cache, or user's rc is modified.
+set -eu
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd -P)
+CASE_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/agent-guard-cache-test.XXXXXX")
+QA_REAL_GITLEAKS=$(command -v gitleaks 2>/dev/null || :)
+trap 'rm -rf "$CASE_ROOT"' EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+CACHE="$CASE_ROOT/cache with ' quote"
+RC="$CASE_ROOT/test.rc"
+mkdir -p "$CACHE" "$CASE_ROOT/home"
+payload() {
+  mkdir -p "$CACHE/$1/bin"
+  sed "s/^VERSION=.*/VERSION=$1/" "$ROOT/plugins/agent-guard/bin/agent-guard" >"$CACHE/$1/bin/agent-guard"
+  chmod +x "$CACHE/$1/bin/agent-guard"
+  cp -R "$ROOT/plugins/agent-guard/config" "$CACHE/$1/config"
+}
+run_guard() {
+  env HOME="$CASE_ROOT/home" "$CACHE/$1/bin/agent-guard" "$2" ${3+"$3"} ${4+"$4"} >"$CASE_ROOT/out" 2>"$CASE_ROOT/err"
+}
+assert_current() {
+  [ "$(readlink "$CACHE/current")" = "$1" ] || {
+    printf 'not ok - current should remain %s\n' "$1"; exit 1;
+  }
+}
+snapshot_with_path() {
+  env HOME="$CASE_ROOT/home" PATH="$2" AGENT_GUARD_BIN= \
+    AGENT_GUARD_SHELL_INIT_VERSION= QA_CACHE_EXECUTED="$CASE_ROOT/partial-executed" \
+    QA_VALID_GUARD="$ROOT/plugins/agent-guard/bin/agent-guard" \
+    "$1" -c 'cd "$2"; . "$1"; printf "%s\n" "${AGENT_GUARD_SHELL_INIT_VERSION:-missing}"' \
+    _ "$RC" "$CASE_ROOT" 2>"$CASE_ROOT/err"
+}
+snapshot() { snapshot_with_path "$1" /usr/bin:/bin; }
+runtime_qa() {
+  [ -n "$QA_REAL_GITLEAKS" ] || return 0
+  env HOME="$CASE_ROOT/home" PATH="$(dirname "$QA_REAL_GITLEAKS"):/usr/bin:/bin" \
+    AGENT_GUARD_BIN= AGENT_GUARD_SHELL_INIT_VERSION= \
+    /bin/sh -c '
+      cd "$2"
+      . "$1"
+      [ "${AGENT_GUARD_SHELL_INIT_VERSION:-missing}" = 3.1.1 ]
+      selected=$(__agentguard_exe)
+      "$selected" check >/dev/null 2>&1
+      [ "$(agx printf %s runtime-ok)" = runtime-ok ]
+    ' _ "$RC" "$CASE_ROOT"
+}
+check() { printf 'ok - %s\n' "$1"; }
+payload 3.1.0
+payload 3.1.1
+payload 3.2.0
+run_guard 3.1.1 setup-shell --rc "$RC"
+assert_current 3.1.1
+for shell in /bin/sh /bin/bash /bin/zsh; do
+  [ -x "$shell" ] || continue
+  [ "$(snapshot "$shell")" = 3.1.1 ]
+  assert_current 3.1.1
+  check "${shell##*/} rc keeps healthy selected current over a newer cached sibling"
+done
+runtime_qa
+if [ -n "$QA_REAL_GITLEAKS" ]; then
+  check 'real gitleaks check and agx run through the selected current payload'
+else
+  printf 'skip - real gitleaks unavailable; selected-current runtime QA not run\n'
+fi
+
+run_guard 3.2.0 version
+[ "$(snapshot /bin/sh)" = 3.2.0 ]
+assert_current 3.2.0
+check 'existing rc follows a newer version after that host-selected binary runs'
+run_guard 3.1.0 version
+assert_current 3.2.0
+check 'a stale binary cannot move current backward'
+
+payload 8.0.0
+sed 's/^VERSION=.*/VERSION=7.0.0/' "$CACHE/8.0.0/bin/agent-guard" >"$CASE_ROOT/mismatch"
+cp "$CASE_ROOT/mismatch" "$CACHE/8.0.0/bin/agent-guard"
+mkdir -p "$CACHE/9.0.0/bin"
+cat >"$CACHE/9.0.0/bin/agent-guard" <<'STUB'
+#!/bin/sh
+VERSION=9.0.0
+printf 'partial payload executed\n' >>"$QA_CACHE_EXECUTED"
+STUB
+chmod +x "$CACHE/9.0.0/bin/agent-guard"
+payload 10.0.0
+mv "$CACHE/10.0.0/config/gitleaks.toml" "$CACHE/10.0.0/config/gitleaks.toml.original"
+mkdir "$CACHE/10.0.0/config/gitleaks.toml"
+payload 11.0.0
+printf ' \r\n\t# interrupted policy extraction\r\n' \
+  >"$CACHE/11.0.0/config/deny-read-paths.txt"
+rm "$CACHE/current"
+[ "$(snapshot /bin/sh)" = 3.2.0 ]
+assert_current 3.2.0
+check 'missing current recovers from the newest complete version, skipping partial, mismatched, non-regular and inactive-policy payloads'
+
+rm "$CACHE/current"
+ln -s 9.0.0 "$CACHE/current"
+[ "$(snapshot /bin/sh)" = 3.2.0 ]
+assert_current 3.2.0
+[ ! -e "$CASE_ROOT/partial-executed" ]
+check 'invalid current recovers without executing a partial cache payload'
+
+mkdir -p "$CASE_ROOT/outside/bin"
+cp -R "$ROOT/plugins/agent-guard/config" "$CASE_ROOT/outside/config"
+cat >"$CASE_ROOT/outside/bin/agent-guard" <<'STUB'
+#!/bin/sh
+VERSION=../outside
+printf 'outside current executed\n' >>"$QA_CACHE_EXECUTED"
+exec "$QA_VALID_GUARD" "$@"
+STUB
+chmod +x "$CASE_ROOT/outside/bin/agent-guard"
+rm "$CACHE/current"
+ln -s ../outside "$CACHE/current"
+[ "$(snapshot /bin/sh)" = 3.2.0 ]
+assert_current 3.2.0
+[ ! -e "$CASE_ROOT/partial-executed" ]
+check 'current must name a direct semantic-version cache sibling and cannot escape the cache base'
+
+mkdir -p "$CACHE/1.2.3:4/bin"
+cp -R "$ROOT/plugins/agent-guard/config" "$CACHE/1.2.3:4/config"
+cat >"$CACHE/1.2.3:4/bin/agent-guard" <<'STUB'
+#!/bin/sh
+VERSION=1.2.3:4
+printf 'malformed current executed\n' >>"$QA_CACHE_EXECUTED"
+exec "$QA_VALID_GUARD" "$@"
+STUB
+chmod +x "$CACHE/1.2.3:4/bin/agent-guard"
+rm "$CACHE/current"
+ln -s '1.2.3:4' "$CACHE/current"
+[ "$(snapshot /bin/sh)" = 3.2.0 ]
+assert_current 3.2.0
+[ ! -e "$CASE_ROOT/partial-executed" ]
+check 'current target requires three numeric semantic-version components'
+
+mkdir -p "$CASE_ROOT/symlink-outside/bin"
+cp -R "$ROOT/plugins/agent-guard/config" "$CASE_ROOT/symlink-outside/config"
+cat >"$CASE_ROOT/symlink-outside/bin/agent-guard" <<'STUB'
+#!/bin/sh
+VERSION=12.0.0
+printf 'symlinked cache root executed\n' >>"$QA_CACHE_EXECUTED"
+exec "$QA_VALID_GUARD" "$@"
+STUB
+chmod +x "$CASE_ROOT/symlink-outside/bin/agent-guard"
+ln -s "$CASE_ROOT/symlink-outside" "$CACHE/12.0.0"
+rm "$CACHE/current"
+[ "$(snapshot /bin/sh)" = 3.2.0 ]
+[ ! -e "$CASE_ROOT/partial-executed" ]
+ln -s 12.0.0 "$CACHE/current"
+[ "$(snapshot /bin/sh)" = 3.2.0 ]
+assert_current 3.2.0
+[ ! -e "$CASE_ROOT/partial-executed" ]
+check 'fallback and current reject a semantic-version cache entry that is a directory symlink'
+
+mkdir -p "$CACHE/13.0.0/bin"
+sed 's/^VERSION=.*/VERSION=13.0.0/' \
+  "$ROOT/plugins/agent-guard/bin/agent-guard" >"$CACHE/13.0.0/bin/agent-guard"
+chmod +x "$CACHE/13.0.0/bin/agent-guard"
+ln -s "$ROOT/plugins/agent-guard/config" "$CACHE/13.0.0/config"
+rm "$CACHE/current"
+[ "$(snapshot /bin/sh)" = 3.2.0 ]
+assert_current 3.2.0
+check 'fallback rejects a payload whose required directory is a symlink'
+
+rm "$CACHE/current"
+mkdir "$CACHE/current"
+[ "$(snapshot /bin/sh)" = 3.2.0 ]
+[ -d "$CACHE/current" ] && [ ! -L "$CACHE/current" ]
+check 'unreplaceable current directory is preserved while a complete fallback loads'
+
+rmdir "$CACHE/current"
+ln -s 9.0.0 "$CACHE/current"
+rm -rf "$CACHE/3.1.0" "$CACHE/3.1.1" "$CACHE/3.2.0"
+[ "$(snapshot /bin/sh)" = missing ]
+[ ! -e "$CASE_ROOT/partial-executed" ]
+check 'no complete cache does not execute a rejected current through the stable or PATH fallback'
+
+rm "$CACHE/current"
+cache_relative=${CACHE#"$CASE_ROOT"/}
+[ "$(snapshot_with_path /bin/sh "$cache_relative/9.0.0/bin:/usr/bin:/bin")" = missing ]
+[ ! -e "$CASE_ROOT/partial-executed" ]
+check 'relative PATH cannot re-enter a rejected partial cache payload'
+
+cat >"$CACHE/8.0.0/bin/agent-guard" <<'STUB'
+#!/bin/sh
+VERSION=7.0.0
+printf 'mismatched payload executed\n' >>"$QA_CACHE_EXECUTED"
+exec "$QA_VALID_GUARD" "$@"
+STUB
+chmod +x "$CACHE/8.0.0/bin/agent-guard"
+mkdir "$CASE_ROOT/external-alias"
+ln -s "$CACHE/8.0.0/bin/agent-guard" "$CASE_ROOT/external-alias/agent-guard"
+[ "$(snapshot_with_path /bin/sh "$CASE_ROOT/external-alias:/usr/bin:/bin")" = missing ]
+[ ! -e "$CASE_ROOT/partial-executed" ]
+check 'external symlink alias cannot re-enter a rejected mismatched cache payload'
+
+# Standalone installs retain the existing output-probed PATH recovery if their
+# baked executable is still executable but can no longer emit shell-init.
+mkdir -p "$CASE_ROOT/standalone/bin" "$CASE_ROOT/path-bin"
+cp "$ROOT/plugins/agent-guard/bin/agent-guard" "$CASE_ROOT/standalone/bin/agent-guard"
+cp -R "$ROOT/plugins/agent-guard/config" "$CASE_ROOT/standalone/config"
+env HOME="$CASE_ROOT/home" "$CASE_ROOT/standalone/bin/agent-guard" \
+  setup-shell --rc "$RC" >"$CASE_ROOT/out" 2>"$CASE_ROOT/err"
+printf '#!/bin/sh\nexit 3\n' >"$CASE_ROOT/standalone/bin/agent-guard"
+ln -s "$ROOT/plugins/agent-guard/bin/agent-guard" "$CASE_ROOT/path-bin/agent-guard"
+for shell in /bin/sh /bin/bash /bin/zsh; do
+  [ -x "$shell" ] || continue
+  recovered=$(env HOME="$CASE_ROOT/home" PATH="$CASE_ROOT/path-bin:/usr/bin:/bin" \
+    AGENT_GUARD_BIN= AGENT_GUARD_SHELL_INIT_VERSION= \
+    "$shell" -ec '. "$1"; printf "%s\n" "${AGENT_GUARD_SHELL_INIT_VERSION:-missing}"' \
+    _ "$RC" 2>"$CASE_ROOT/err")
+  [ "$recovered" != missing ]
+  check "${shell##*/} set -e recovers a stale standalone shell-init through an independent PATH executable"
+done


### PR DESCRIPTION
새 셸이 사용자가 선택한 정상 `current` 대신 더 새롭지만 미선택인 캐시를 먼저 실행하거나, 거부한 불완전 캐시를 PATH alias로 다시 실행하는 문제를 수정합니다. rc 초기화와 실행 중 셸은 동일한 resolver를 사용합니다.

- 명시 AGENT_GUARD_BIN → 정상 current → current 손상 시 검증된 최신 sibling → 독립 standalone PATH 순서를 유지합니다.
- current의 direct semver sibling, payload 실행 파일/정책/버전 일치와 regular-file 조건을 확인하고 root/bin/config symlink 및 relative PATH·외부 alias 재진입을 거부합니다.
- set -e에서도 기존 standalone의 shell-init 실패 뒤 복구하며 관리 rc 재설치의 멱등성·사용자 문구·opt-out을 유지합니다.
- 기존 rc에는 수정 버전 설치 후 setup-shell 재실행이 필요함을 두 README에 명시했습니다. SessionStart의 파일 메타데이터 기반 상태는 heuristic이며 host registry 확인으로 주장하지 않습니다.

검증: 실제 Git clone에서 최신 main ee6df84에 통합한 53961ab, 전체 tests/run.sh 1281/0, 실제 생성 rc focused19/19(sh/bash/zsh 및 gitleaks8.30.1), shell 문법/diff 검사 통과. 독립 최종 리뷰 additional P1/P2 없음. native fish는 미설치로 미실행이며 기존 fish 사용자용 bash/zsh snapshot rc fixture 범위만 통과했습니다. 최종 CI 및 부모 main 교차검사를 이어서 확인합니다.

Closes #195.
