### PR TITLE
fix(setup): 의존성 진단과 실제 호스트 보호 상태 구분

### DIFF
--- a/README.md
+++ b/README.md
@@ -708,6 +708,12 @@ plugins/agent-guard/bin/agent-guard check
 plugins/agent-guard/bin/agent-guard smoke-test
 ```
 
+`setup` and `doctor` check only local dependencies. Their
+`host hook protection: unverified (dependency checks do not observe tool
+dispatch)` notice is expected whether those checks pass or fail. A `setup ok
+(dependencies only)` result does not establish that Claude Code or Codex is
+dispatching plugin hooks.
+
 The whole `smoke-test` command must exit `0`. Its output should include
 `scan-path blocks a private-key fixture`,
 `native pre-commit hook blocks staged fixture`, and `smoke-test ok`.
@@ -744,10 +750,12 @@ forwarding their events; success at one boundary does not prove the other.
 | Symptom | Next step |
 |---|---|
 | `agent-guard` not found | Plugin-only installs do not add it to `PATH`; use the setup skill or the plugin-local executable. |
-| CLI works, host probe does not | Check plugin enablement and hook trust, reload/restart, and retry the actual tool route. Report unobserved dispatch as unverified. |
-| A host denies a read that the direct guard permits | Check the host's permission settings. A host denial before dispatch is not an Agent Guard block. If the source is unavailable, report it as unknown. Do not automatically remove deny rules. |
-| `DEGRADED` or scanner error | Run `doctor` and `check` on that installation. Repair the named dependency or policy; this is not a clean scan. |
-| Different CLI, plugin, or shell versions | Update each with its owning manager. Refresh shell setup and restart sessions. Known cache-selection behavior is tracked in [#195](https://github.com/JeongJaeSoon/agent-guard/issues/195). |
+| CLI works, host probe does not | Check plugin enablement and hook trust, reload/restart, and retry the exact tool route. Report it as unobserved/unknown; passing CLI checks are not dispatch evidence. |
+| A host denies a read that the direct guard permits | Treat a host-identified pre-dispatch refusal as host-owned, not an Agent Guard block. A generic `PreToolUse blocked` message has unknown source unless Agent Guard hook output is also visible. Do not automatically remove deny rules. |
+| An Agent Guard hook rejects the harmless probe | This is an observed Guard denial for that route. Review the reported policy match without weakening unrelated protection; it does not prove clean command completion. |
+| `DEGRADED` or scanner error | A visible Agent Guard `DEGRADED` response means the hook reached an unavailable dependency or policy. Run `doctor` and `check`; this is not a clean scan. |
+| A harmless probe receives a hook response | This is dispatch-only evidence for that route. Call it normal completion only after a separate harmless command on the same route actually exits `0`. |
+| Different CLI, plugin, or shell versions | Update each with its owning manager. If optional shell integration is used, rerun `agent-guard setup-shell` and restart the shell and host sessions. |
 | Standalone update reports a symlink loop | Follow the separate-install recovery guidance in [Direct CLI](#direct-cli); do not delete the old installation blindly. |
 | Action checksum mismatch | Match the exact gitleaks version, OS, and architecture printed by `agent-guard checksum`. |
 

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -556,6 +556,11 @@ EOF
   setup_status_line jq       || jq_ok=0
   setup_status_line git      || git_ok=0
   setup_gitleaks_status_line || gitleaks_ok=0
+  # setup and doctor can establish only local dependencies.
+  # A host must still dispatch one of its hook commands before runtime
+  # protection can be observed; never imply that this CLI has inspected that
+  # boundary or authenticated a host decision.
+  info "$PROGRAM: host hook protection: unverified (dependency checks do not observe tool dispatch)"
 
   if [ "$install" -eq 1 ]; then
     if [ "$gitleaks_ok" -eq 1 ]; then
@@ -597,7 +602,7 @@ EOF
     return 1
   fi
 
-  info "$PROGRAM: setup ok"
+  info "$PROGRAM: setup ok (dependencies only)"
   return 0
 }
 

--- a/plugins/agent-guard/skills/setup-agent-guard/SKILL.md
+++ b/plugins/agent-guard/skills/setup-agent-guard/SKILL.md
@@ -22,6 +22,10 @@ Make Agent Guard operational without silently changing the machine. Diagnose fir
    "<agent-guard-bin>" setup
    ```
 
+   `setup` and `doctor` report only local dependencies. Their
+   `host hook protection: unverified` notice is expected even when they exit
+   `0`; do not call that result runtime protection.
+
 3. If `jq` is missing, identify the available system package manager and show the exact install command. Ask for explicit user approval before running it. Do not use `sudo` unless the user explicitly approves elevated installation.
 
 4. If `gitleaks` is missing, prefer Agent Guard's private, checksum-pinned installer:
@@ -84,6 +88,30 @@ Make Agent Guard operational without silently changing the machine. Diagnose fir
    - If either probe bypasses the hook, report that route as unsupported in the current host instead of claiming successful setup.
 
 9. After dependency, enablement, or trust changes, restart the active host and run both live probes again in a new task. In Codex, plugin hooks provide the supported command boundary; do not configure Claude-specific command wrapping as a Codex setup step. In Claude Code, restart the shell and Claude Code only when the optional shell integration changed.
+
+10. Classify each exact host route from the visible host result and Agent Guard
+    hook output. Do not invent a CLI subcommand, collect settings or traces, or
+    ask the CLI to attest who made a host decision.
+    - **Host pre-hook denial:** classify this only when the host itself identifies
+      a refusal before dispatch and there is no Agent Guard hook response. This
+      is a host-reported observation; Agent Guard cannot independently verify it.
+      A generic `PreToolUse blocked` message is not enough to identify the
+      source.
+    - **Observed Guard denial:** an Agent Guard policy message and blocked probe
+      show that this hook route dispatched and denied that probe. It does not
+      prove a clean command would complete.
+    - **DEGRADED:** an Agent Guard `DEGRADED` response shows a dispatched hook
+      whose dependency or policy check could not run. It is neither a clean scan
+      nor proof of protection.
+    - **Dispatch only:** a visible response to a harmless sentinel shows only
+      that exact hook route was reached. It is not normal command completion.
+    - **Normal completion:** report this only when the hook response is observed
+      and a separate harmless command on that same route actually exits `0`.
+      Keep those two observations distinct in the report.
+    - **Unobserved/unknown:** if no Agent Guard response is visible, dispatch was
+      not observed, or the source of a generic host message is unclear, report
+      the route as unobserved/unknown. Do not count a local fixture that bypasses
+      host dispatch as a successful live probe.
 
 ## Safety And Host Boundaries
 

--- a/tests/hook-outcome-contract.sh
+++ b/tests/hook-outcome-contract.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env sh
+# These are synthetic executions of the existing Claude and Codex manifest
+# commands. They verify the CLI contract after each manifest resolver has
+# selected the plugin binary. They deliberately cannot prove a host's own
+# pre-hook denial or that a real host executed an allowed command.
+set -u
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd -P)
+PLUGIN_ROOT="$ROOT/plugins/agent-guard"
+GUARD="$PLUGIN_ROOT/bin/agent-guard"
+MOCK_GITLEAKS="$ROOT/tests/fixtures/mock-gitleaks"
+CASE_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/agent-guard-hook-outcome.XXXXXX") || exit 1
+trap 'rm -rf "$CASE_ROOT"' EXIT HUP INT TERM
+
+failed=0
+checked=0
+
+ok() {
+  checked=$((checked + 1))
+  printf 'ok - %s\n' "$1"
+}
+
+not_ok() {
+  checked=$((checked + 1))
+  failed=$((failed + 1))
+  printf 'not ok - %s\n' "$1"
+  sed 's/^/  stderr: /' "$CASE_ROOT/err"
+}
+
+run_cli() {
+  AGENT_GUARD_GITLEAKS_BIN="$MOCK_GITLEAKS" "$GUARD" "$1" \
+    >"$CASE_ROOT/out" 2>"$CASE_ROOT/err"
+}
+
+run_missing_cli() {
+  AGENT_GUARD_GITLEAKS_BIN="$CASE_ROOT/no-gitleaks" "$GUARD" "$1" \
+    >"$CASE_ROOT/out" 2>"$CASE_ROOT/err"
+}
+
+run_manifest() {
+  host=$1
+  failure_mode=$2
+  scanner=$3
+  payload=$4
+  case "$host" in
+    claude)
+      root_name=CLAUDE_PLUGIN_ROOT
+      command=$(jq -r '.hooks.PreToolUse[0].hooks[0].command' \
+        "$PLUGIN_ROOT/hooks/hooks.json")
+      ;;
+    codex)
+      root_name=PLUGIN_ROOT
+      command=$(jq -r '.hooks.PreToolUse[0].hooks[0].command' \
+        "$PLUGIN_ROOT/hooks.json")
+      ;;
+    *) return 64 ;;
+  esac
+  printf '%s' "$payload" \
+    | (cd "$CASE_ROOT" && env "$root_name=$PLUGIN_ROOT" \
+        AGENT_GUARD_GITLEAKS_BIN="$scanner" \
+        AGENT_GUARD_INFRA_FAILURE_MODE="$failure_mode" \
+        AGENT_GUARD_WARNING_DIR="$CASE_ROOT/warnings-$host-$failure_mode" \
+        sh -c "$command") >"$CASE_ROOT/out" 2>"$CASE_ROOT/err"
+}
+
+# setup and doctor have one implementation. Test their actual stderr contract
+# in both healthy and dependency-failure paths; neither outcome is host proof.
+for diagnosis in setup doctor; do
+  run_cli "$diagnosis"
+  status=$?
+  if [ "$status" -eq 0 ] \
+     && grep -Fq 'setup ok (dependencies only)' "$CASE_ROOT/err" \
+     && grep -Fq 'host hook protection: unverified (dependency checks do not observe tool dispatch)' "$CASE_ROOT/err"; then
+    ok "$diagnosis reports dependencies only and leaves host dispatch unverified"
+  else
+    not_ok "$diagnosis healthy output retains the unverified host boundary (status $status)"
+  fi
+
+  run_missing_cli "$diagnosis"
+  status=$?
+  if [ "$status" -eq 1 ] \
+     && grep -Fq 'host hook protection: unverified (dependency checks do not observe tool dispatch)' "$CASE_ROOT/err"; then
+    ok "$diagnosis dependency failure retains the unverified host boundary"
+  else
+    not_ok "$diagnosis dependency failure retains the unverified host boundary (status $status)"
+  fi
+done
+
+for host in claude codex; do
+  # An observed policy diagnostic is a Guard denial for this manifest path.
+  run_manifest "$host" open "$MOCK_GITLEAKS" \
+    '{"tool_name":"Bash","tool_input":{"command":"cat .env"}}'
+  status=$?
+  if [ "$status" -eq 2 ] && grep -Fq 'agent-guard: blocked' "$CASE_ROOT/err"; then
+    ok "$host manifest path reports an observed Guard denial"
+  else
+    not_ok "$host manifest path reports an observed Guard denial (status $status)"
+  fi
+
+  # A clean pre-hook result is dispatch-only: this synthetic call never asks a
+  # host to execute the command after returning zero.
+  run_manifest "$host" open "$MOCK_GITLEAKS" \
+    '{"tool_name":"Bash","tool_input":{"command":"printf clean"}}'
+  status=$?
+  if [ "$status" -eq 0 ] && [ ! -s "$CASE_ROOT/err" ]; then
+    ok "$host manifest path allows a clean pre-hook input"
+  else
+    not_ok "$host manifest path allows a clean pre-hook input (status $status)"
+  fi
+
+  run_manifest "$host" open "$MOCK_GITLEAKS" \
+    '{"tool_name":"FutureTool","tool_input":{"x":1}}'
+  status=$?
+  if [ "$status" -eq 0 ] && [ ! -s "$CASE_ROOT/err" ]; then
+    ok "$host manifest path preserves unknown-tool passthrough"
+  else
+    not_ok "$host manifest path preserves unknown-tool passthrough (status $status)"
+  fi
+
+  run_manifest "$host" open "$CASE_ROOT/no-gitleaks" \
+    '{"session_id":"outcome-open","tool_name":"Bash","tool_input":{"command":"printf clean"}}'
+  status=$?
+  if [ "$status" -eq 0 ] && grep -Fq 'DEGRADED' "$CASE_ROOT/err" \
+     && grep -Fq 'AGENT_GUARD_INFRA_FAILURE_MODE=open' "$CASE_ROOT/err"; then
+    ok "$host manifest path reports degraded open infrastructure"
+  else
+    not_ok "$host manifest path reports degraded open infrastructure (status $status)"
+  fi
+
+  run_manifest "$host" closed "$CASE_ROOT/no-gitleaks" \
+    '{"session_id":"outcome-closed","tool_name":"Bash","tool_input":{"command":"printf clean"}}'
+  status=$?
+  if [ "$status" -eq 2 ] && grep -Fq 'DEGRADED' "$CASE_ROOT/err"; then
+    ok "$host manifest path applies closed infrastructure policy"
+  else
+    not_ok "$host manifest path applies closed infrastructure policy (status $status)"
+  fi
+done
+
+printf '%s hook outcome contract checks, %s failed\n' "$checked" "$failed"
+[ "$failed" -eq 0 ]

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -122,6 +122,7 @@ for file in \
   "$ROOT/scripts/build-release-tarball.sh" \
   "$ROOT/githooks/pre-commit" \
   "$PLUGIN_ROOT/scripts/gitleaks-checksum.sh" \
+  "$ROOT/tests/hook-outcome-contract.sh" \
   "$ROOT/tests/run.sh"; do
   run_expect 0 "shell syntax: $file" sh -n "$file"
 done
@@ -4773,6 +4774,8 @@ fi
 
 run_expect 0 "direct scan dependency statuses and recovery" \
   "$REAL_SH" "$ROOT/tests/direct-scan-status.sh"
+run_expect 0 "setup and manifest hook outcome contracts" \
+  "$REAL_SH" "$ROOT/tests/hook-outcome-contract.sh"
 
 # Reuse NO_GITLEAKS_BIN: jq must remain reachable so setup can report jq ok
 # while gitleaks is missing.


### PR DESCRIPTION
setup/doctor 성공을 실제 호스트 보호가 활성화됐다는 뜻으로 오해하지 않도록, 기존 의존성 진단에 host hook protection: unverified 안내를 추가하고 setup ok를 dependencies only로 명시합니다. 기존 종료 코드는 유지합니다.

기존 setup skill과 README에서 호스트가 밝힌 선행 거부, 관찰된 Guard 거부, DEGRADED, dispatch만 관찰, 실제 명령 완료, 출처 미확인을 구분합니다. CLI가 실행되지 않은 호스트 사건을 자동 판별하거나 사용자가 제공한 출처를 인증하는 새 분류 명령은 추가하지 않습니다. 설정/trace 수집이나 전역 권한 변경도 하지 않습니다.

검증: 정상/의존성 누락 setup·doctor 출력, 실제 Claude/Codex manifest 명령의 지원 Bash 경로에서 Guard 거부·clean input·unknown passthrough·infra open/closed 14개 contract 검사 통과. 이는 합성 manifest 실행이며 native host가 실제로 허용 명령을 실행했거나 선행 거부한 증거와 구분합니다. 실제 native QA의 Claude hook+명령0+HTTP204와 Codex startup exit1/unknown도 그 구분에 따라 기록했습니다. 호스트 선행 거부 안내는 호스트가 출처를 명시한 관찰에만 적용합니다.

전체 suite는 runtime-equivalent 35b84ee에서1281/0; 최종0746d7a는 문서/주석/지원되는fixture경로 보완 후 focused14/14와 실제gitleaks8.30.1 smoke 및 diff 검사를 통과했습니다. 최종 CI 전체검사·독립리뷰와 부모 main 통합을 확인한 뒤 병합합니다.

Closes #201.
