### PR TITLE
fix(pii): Tier-2 정규식에 숫자 경계와 Luhn 검증을 추가한다

### DIFF
--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -779,26 +779,59 @@ function pii_bounded(kind, before, after) {
   if (kind == "ipv4") { return (before !~ /[0-9][.]?$/ && after !~ /^[.]?[0-9]/) }
   return (before !~ /[0-9]$/ && after !~ /^[0-9]/)
 }
-function mask_re(s, re, repl, kind,   out, pre, m, after, skip) {
+BEGIN {
+  # awk cannot start match() at an offset, so mask_re walks a sliding window
+  # rather than re-slicing the whole remainder after every candidate — that
+  # copy is per-candidate and turns one long line of card-shaped rejects
+  # quadratic, past the 10s PreToolUse timeout in hooks/hooks.json.
+  # PII_MARGIN must exceed the longest text any pattern can match (19 digits
+  # plus three separators), so a match landing clear of the margin is whole.
+  PII_WIN = 512
+  PII_MARGIN = 64
+}
+function mask_re(s, re, repl, kind,   out, n, pos, win, wlen, mstart, mlen, mend, pre, m, after, skip) {
+  n = length(s)
   out = ""
-  while (match(s, re)) {
-    pre = substr(s, 1, RSTART - 1)
-    m = substr(s, RSTART, RLENGTH)
-    after = substr(s, RSTART + RLENGTH)
+  pos = 1
+  while (pos <= n) {
+    win = substr(s, pos, PII_WIN)
+    wlen = length(win)
+    if (!match(win, re)) {
+      # Nothing here. The tail margin may hold the start of a match that runs
+      # past this window, so emit everything before it and slide.
+      if (pos + wlen > n) { break }
+      out = out substr(win, 1, wlen - PII_MARGIN)
+      pos = pos + wlen - PII_MARGIN
+      continue
+    }
+    mstart = RSTART
+    mlen = RLENGTH
+    mend = mstart + mlen - 1
+    if (mstart > 1 && mend > wlen - PII_MARGIN && pos + wlen <= n) {
+      # The match reaches into the margin with more input behind it, so it may
+      # be truncated. Re-window from its start and look again.
+      out = out substr(win, 1, mstart - 1)
+      pos = pos + mstart - 1
+      continue
+    }
+    pre = substr(win, 1, mstart - 1)
+    m = substr(win, mstart, mlen)
+    after = substr(win, mend + 1, 2)
     if (pii_bounded(kind, tail2(tail2(out) pre), after) \
         && (kind != "luhn" || luhn(m))) {
       out = out pre repl
-      s = after
+      pos = pos + mend
     } else {
       # A rejected candidate cannot start again inside its own leading digit
       # run: every position in there has a digit in front of it, which the
       # boundary rule refuses. Skip the whole run, not one character.
       skip = match(m, /^[0-9]+/) ? RLENGTH : 1
       out = out pre substr(m, 1, skip)
-      s = substr(m, skip + 1) after
+      pos = pos + mstart - 1 + skip
     }
   }
-  return out s
+  if (pos <= n) { out = out substr(s, pos) }
+  return out
 }
 function mask_tier2(s) {
   s = mask_re(s, CC19_RE, "[PII:CREDIT_CARD]", "luhn")

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -744,17 +744,79 @@ pii_provider() {
 # so `awk -v` passes them through unchanged. mask_pii_response_json is a jq
 # transcription of the same shapes and still has to change alongside them;
 # tests/run.sh drives one sample of each through all three.
-PII_CREDIT_CARD_RE='[0-9][0-9][0-9][0-9][ -]?[0-9][0-9][0-9][0-9][ -]?[0-9][0-9][0-9][0-9][ -]?[0-9][0-9][0-9][0-9]([ -]?[0-9][0-9][0-9])?'
+# The 19-digit PAN is a separate pattern rather than an optional tail group:
+# greedy matching would otherwise swallow a following 3-digit number, fail Luhn
+# on the 19 digits, and lose the valid 16-digit card inside it. Longest first.
+PII_CREDIT_CARD_RE='[0-9][0-9][0-9][0-9][ -]?[0-9][0-9][0-9][0-9][ -]?[0-9][0-9][0-9][0-9][ -]?[0-9][0-9][0-9][0-9]'
+PII_CREDIT_CARD19_RE="$PII_CREDIT_CARD_RE"'[ -]?[0-9][0-9][0-9]'
 PII_AMEX_RE='3[47][0-9][0-9][ -]?[0-9][0-9][0-9][0-9][0-9][0-9][ -]?[0-9][0-9][0-9][0-9][0-9]'
 PII_SSN_RE='[0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9][0-9][0-9]'
 PII_KR_RRN_RE='[0-9][0-9][0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9][0-9][0-9][0-9]'
+PII_IPV4_RE='(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])([.](25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9]))([.](25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9]))([.](25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9]))'
+
+# awk has no \b and its gsub() cannot veto an individual match, so every
+# validated pattern goes through mask_re(): it walks matches left to right,
+# requires non-digit boundaries, and lets a validator reject a candidate. That
+# is what keeps epoch-nanosecond timestamps and Snowflake ids — card-shaped but
+# unbounded and Luhn-invalid — out of the Tier-2 verdict. Shared verbatim by
+# pii_regex_adapter_filter and pii_tier2_present; mask_pii_response_json is the
+# jq transcription (Oniguruma lookaround in place of the boundary checks) and
+# must change alongside it. tests/run.sh drives every case through all three.
+PII_AWK_LIB='
+function tail2(s) { return (length(s) > 2) ? substr(s, length(s) - 1) : s }
+function luhn(s,   i, d, sum, alt) {
+  gsub(/[^0-9]/, "", s)
+  sum = 0; alt = 0
+  for (i = length(s); i >= 1; i--) {
+    d = substr(s, i, 1) + 0
+    if (alt) { d *= 2; if (d > 9) { d -= 9 } }
+    sum += d
+    alt = !alt
+  }
+  return (length(s) > 0 && sum % 10 == 0)
+}
+function pii_bounded(kind, before, after) {
+  if (kind == "ipv4") { return (before !~ /[0-9][.]?$/ && after !~ /^[.]?[0-9]/) }
+  return (before !~ /[0-9]$/ && after !~ /^[0-9]/)
+}
+function mask_re(s, re, repl, kind,   out, pre, m, after, skip) {
+  out = ""
+  while (match(s, re)) {
+    pre = substr(s, 1, RSTART - 1)
+    m = substr(s, RSTART, RLENGTH)
+    after = substr(s, RSTART + RLENGTH)
+    if (pii_bounded(kind, tail2(tail2(out) pre), after) \
+        && (kind != "luhn" || luhn(m))) {
+      out = out pre repl
+      s = after
+    } else {
+      # A rejected candidate cannot start again inside its own leading digit
+      # run: every position in there has a digit in front of it, which the
+      # boundary rule refuses. Skip the whole run, not one character.
+      skip = match(m, /^[0-9]+/) ? RLENGTH : 1
+      out = out pre substr(m, 1, skip)
+      s = substr(m, skip + 1) after
+    }
+  }
+  return out s
+}
+function mask_tier2(s) {
+  s = mask_re(s, CC19_RE, "[PII:CREDIT_CARD]", "luhn")
+  s = mask_re(s, CC16_RE, "[PII:CREDIT_CARD]", "luhn")
+  s = mask_re(s, AMEX_RE, "[PII:CREDIT_CARD]", "luhn")
+  s = mask_re(s, KR_RRN_RE, "[PII:KR_RRN]", "digits")
+  s = mask_re(s, SSN_RE, "[PII:SSN]", "digits")
+  return s
+}
+'
 
 pii_regex_adapter_filter() {
   need_cmd awk
-  awk -v credit_card="$PII_CREDIT_CARD_RE" -v amex="$PII_AMEX_RE" \
-      -v ssn="$PII_SSN_RE" -v kr_rrn="$PII_KR_RRN_RE" '
+  awk -v CC16_RE="$PII_CREDIT_CARD_RE" -v CC19_RE="$PII_CREDIT_CARD19_RE" \
+      -v AMEX_RE="$PII_AMEX_RE" -v SSN_RE="$PII_SSN_RE" \
+      -v KR_RRN_RE="$PII_KR_RRN_RE" -v IPV4_RE="$PII_IPV4_RE" \
+      "$PII_AWK_LIB"'
     BEGIN {
-      ip_addr = "[0-9][0-9]?[0-9]?[.][0-9][0-9]?[0-9]?[.][0-9][0-9]?[0-9]?[.][0-9][0-9]?[0-9]?"
       email = "[[:alnum:]_%+.-]+@[[:alnum:].-]+[.][[:alpha:]][[:alpha:]][[:alpha:]]*"
       kr_mobile = "01[0-9][ -]?[0-9][0-9][0-9][0-9][ -]?[0-9][0-9][0-9][0-9]"
       phone = "([+]?[0-9][ .-]?)?([(][0-9][0-9][0-9][)]|[0-9][0-9][0-9])[ .-]?[0-9][0-9][0-9][ .-]?[0-9][0-9][0-9][0-9]"
@@ -763,15 +825,15 @@ pii_regex_adapter_filter() {
       if (NR > 1) {
         printf "%s", ORS
       }
-      gsub(credit_card, "[PII:CREDIT_CARD]")
-      gsub(amex, "[PII:CREDIT_CARD]")
-      gsub(kr_rrn, "[PII:KR_RRN]")
-      gsub(ssn, "[PII:SSN]")
-      gsub(ip_addr, "[PII:IP_ADDRESS]")
-      gsub(email, "[PII:EMAIL]")
-      gsub(kr_mobile, "[PII:PHONE]")
-      gsub(phone, "[PII:PHONE]")
-      printf "%s", $0
+      line = mask_tier2($0)
+      line = mask_re(line, IPV4_RE, "[PII:IP_ADDRESS]", "ipv4")
+      gsub(email, "[PII:EMAIL]", line)
+      # Phone needs the same digit boundary: without it the generic 3-3-4 shape
+      # matches the first 10 digits of any long numeric id, which the credit
+      # card false positive used to hide.
+      line = mask_re(line, kr_mobile, "[PII:PHONE]", "digits")
+      line = mask_re(line, phone, "[PII:PHONE]", "digits")
+      printf "%s", line
     }
   '
 }
@@ -928,9 +990,11 @@ pii_tier2_present() {
   text=$1
   [ -n "$text" ] || return 1
   need_cmd awk
-  printf '%s' "$text" | awk -v cc="$PII_CREDIT_CARD_RE" -v amex="$PII_AMEX_RE" \
-      -v ssn="$PII_SSN_RE" -v rrn="$PII_KR_RRN_RE" '
-    $0 ~ cc || $0 ~ amex || $0 ~ ssn || $0 ~ rrn { found = 1 }
+  printf '%s' "$text" | awk -v CC16_RE="$PII_CREDIT_CARD_RE" \
+      -v CC19_RE="$PII_CREDIT_CARD19_RE" -v AMEX_RE="$PII_AMEX_RE" \
+      -v SSN_RE="$PII_SSN_RE" -v KR_RRN_RE="$PII_KR_RRN_RE" \
+      "$PII_AWK_LIB"'
+    mask_tier2($0) != $0 { found = 1 }
     END { exit (found ? 0 : 1) }
   '
 }
@@ -4310,23 +4374,40 @@ redact_response_whole_leaf_fail_closed() {
 # original shape. The regex patterns mirror pii_regex_adapter_filter (the CLI
 # adapter) so the hook and `agent-guard pii-filter` mask the same things; Tier-2
 # (credit card / KR resident reg. no. / SSN) is masked first so a Tier-1 pattern
-# can't shadow it, and KR mobile before the generic phone pattern. Like the
+# can't shadow it, and KR mobile before the generic phone pattern. Oniguruma
+# lookaround stands in for the digit boundaries mask_re() checks by hand in awk,
+# and the Luhn filter for cards is the same rule expressed as a conditional
+# gsub replacement — both must change with PII_AWK_LIB. Like the
 # secret redactor, this masks string VALUES only — object KEYS are left as-is
 # (masking keys risks collapsing distinct keys onto one placeholder); PII in a
 # JSON key is a documented limitation (README). Prints the masked JSON, or
-# nothing on failure (e.g. a jq build without Oniguruma gsub).
+# nothing on failure (e.g. a jq build without Oniguruma gsub, or one whose
+# Oniguruma lacks the lookbehind the boundaries need) — the caller then leaves
+# the response unmasked. Only masking degrades that way: the input hard-block
+# gate is the awk path, which needs no regex features beyond POSIX ERE.
 mask_pii_response_json() {
   resp=$1
   printf '%s' "$resp" | jq -c "$JQ_WALK"'
+    def luhn:
+      ([gsub("[^0-9]"; "") | explode | .[] | . - 48] | reverse
+       | to_entries
+       | map(if .key % 2 == 1
+             then (.value * 2 | if . > 9 then . - 9 else . end)
+             else .value end)
+       | add) as $sum
+      | $sum != null and $sum % 10 == 0;
+    def mask_card($re): gsub($re;
+      if (.pan | luhn) then "[PII:CREDIT_CARD]" else .pan end);
     def mask_pii:
-      gsub("[0-9]{4}[ -]?[0-9]{4}[ -]?[0-9]{4}[ -]?[0-9]{4}([ -]?[0-9]{3})?"; "[PII:CREDIT_CARD]")
-      | gsub("3[47][0-9]{2}[ -]?[0-9]{6}[ -]?[0-9]{5}"; "[PII:CREDIT_CARD]")
-      | gsub("[0-9]{6}-[0-9]{7}"; "[PII:KR_RRN]")
-      | gsub("[0-9]{3}-[0-9]{2}-[0-9]{4}"; "[PII:SSN]")
-      | gsub("[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}"; "[PII:IP_ADDRESS]")
+      mask_card("(?<![0-9])(?<pan>[0-9]{4}[ -]?[0-9]{4}[ -]?[0-9]{4}[ -]?[0-9]{4}[ -]?[0-9]{3})(?![0-9])")
+      | mask_card("(?<![0-9])(?<pan>[0-9]{4}[ -]?[0-9]{4}[ -]?[0-9]{4}[ -]?[0-9]{4})(?![0-9])")
+      | mask_card("(?<![0-9])(?<pan>3[47][0-9]{2}[ -]?[0-9]{6}[ -]?[0-9]{5})(?![0-9])")
+      | gsub("(?<![0-9])[0-9]{6}-[0-9]{7}(?![0-9])"; "[PII:KR_RRN]")
+      | gsub("(?<![0-9])[0-9]{3}-[0-9]{2}-[0-9]{4}(?![0-9])"; "[PII:SSN]")
+      | gsub("(?<![0-9])(?<![0-9]\\.)(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(\\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])){3}(?![0-9])(?!\\.[0-9])"; "[PII:IP_ADDRESS]")
       | gsub("[A-Za-z0-9_%+.-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}"; "[PII:EMAIL]")
-      | gsub("01[0-9][ -]?[0-9]{4}[ -]?[0-9]{4}"; "[PII:PHONE]")
-      | gsub("(\\+?[0-9][ .-]?)?(\\([0-9]{3}\\)|[0-9]{3})[ .-]?[0-9]{3}[ .-]?[0-9]{4}"; "[PII:PHONE]");
+      | gsub("(?<![0-9])01[0-9][ -]?[0-9]{4}[ -]?[0-9]{4}(?![0-9])"; "[PII:PHONE]")
+      | gsub("(?<![0-9])(\\+?[0-9][ .-]?)?(\\([0-9]{3}\\)|[0-9]{3})[ .-]?[0-9]{3}[ .-]?[0-9]{4}(?![0-9])"; "[PII:PHONE]");
     walk(if type == "string" then mask_pii else . end)
   ' 2>/dev/null
 }

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -9410,6 +9410,27 @@ else
   printf '%s\n' "  cli : $pii_ip_cli" "  hook: $pii_ip_hook"
 fi
 
+# The Tier-2 gate scans one awk record at a time, so a single long line packed
+# with card-shaped rejects is the worst case: every candidate re-examines the
+# rest of the record. It has to clear the PreToolUse timeout in
+# plugins/agent-guard/hooks/hooks.json (10s) — past that the host kills the hook
+# and the input is neither cleared nor reported as a detector failure.
+PII_BIG="$TMP_ROOT/pii-big-line.txt"
+awk 'BEGIN { for (i = 0; i < 14700; i++) printf "1234567812345678 " }' > "$PII_BIG"
+printf '{"session_id":"t","tool_name":"Write","tool_input":{"file_path":"a.ts","content":%s}}' \
+  "$(jq -Rs . < "$PII_BIG")" > "$TMP_ROOT/pii-big-payload.json"
+pii_big_start=$(date +%s)
+AGENT_GUARD_PII_HOOK_MODE=mask "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool \
+  < "$TMP_ROOT/pii-big-payload.json" >/dev/null 2>"$ERR"
+status=$?
+pii_big_elapsed=$(( $(date +%s) - pii_big_start ))
+if [ "$status" -eq 0 ] && [ "$pii_big_elapsed" -lt 10 ]; then
+  ok "PII gate clears a 250 KB single-line record within the PreToolUse timeout (${pii_big_elapsed}s)"
+else
+  not_ok "PII gate clears a 250 KB single-line record within the PreToolUse timeout (exit $status, ${pii_big_elapsed}s)"
+  sed 's/^/  stderr: /' "$ERR"
+fi
+
 # --- agent-guard exec (shell-escape output masking) --------------------------
 # `agent-guard exec` runs a command and masks secret-like values in its captured
 # output before printing. Secret VALUE assembled at runtime from fragments so this

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -9382,6 +9382,9 @@ pii_expect_clean "a Luhn-invalid 16-digit order number" 'order 1234567812345678 
 pii_expect_clean "out-of-range dotted numbers" 'build 999.888.777.666'
 pii_expect_clean "a 5-part dotted version" 'ver 1.2.3.4.5'
 pii_expect_clean "an SSN shape inside a longer digit run" 'id 5123-45-67890'
+# The generic phone shape is 10-11 digits, so an unseparated numeric id longer
+# than that used to be mangled into [PII:PHONE] plus its leftover digits.
+pii_expect_clean "a 12-digit numeric id" 'id 123456789012'
 pii_expect_clean "an RRN shape inside a longer digit run" 'id 5900101-12345670'
 
 # Card numbers assembled at runtime so this test file holds no contiguous PAN.

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -2755,6 +2755,28 @@ else
   sed 's/^/  stderr: /' "$ERR"
 fi
 
+# mask mode fails closed: a Tier-2 detector that errors blocks even clean input.
+# The stub fails only the gate's own awk program, so the dependency checks stay
+# green and this isolates block_on_pii_text from an infra-degraded exit.
+if [ -x /usr/bin/awk ]; then
+  PII_STUB_BIN="$TMP_ROOT/pii-stub-bin"
+  mkdir -p "$PII_STUB_BIN"
+  printf '%s\n' '#!/bin/sh' 'for a in "$@"; do' \
+    '  case $a in *mask_tier2*) exit 3 ;; esac' 'done' \
+    'exec /usr/bin/awk "$@"' > "$PII_STUB_BIN/awk"
+  chmod +x "$PII_STUB_BIN/awk"
+  printf '%s' '{"tool_name":"Write","tool_input":{"file_path":"note.txt","content":"clean"}}' \
+    | PATH="$PII_STUB_BIN:$PATH" AGENT_GUARD_PII_HOOK_MODE=mask \
+      "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool >"$OUT" 2>"$ERR"
+  status=$?
+  if [ "$status" -eq 2 ] && grep -q 'Tier-2 PII detector failed' "$ERR"; then
+    ok "PII mask mode fails closed when the Tier-2 detector errors"
+  else
+    not_ok "PII mask mode fails closed when the Tier-2 detector errors (expected 2, got $status)"
+    sed 's/^/  stderr: /' "$ERR"
+  fi
+fi
+
 TEST_REPO="$TMP_ROOT/repo"
 mkdir -p "$TEST_REPO"
 (
@@ -9296,6 +9318,93 @@ if [ -n "$sync_hook" ] && [ "$sync_cli" = "$sync_hook" ] \
 else
   not_ok "CLI pii-filter and hook output masker mask identically"
   printf '%s\n' "  cli : $sync_cli" "  hook: $sync_hook"
+fi
+
+# --- PII false positives: digit boundaries, Luhn, octet range -----------------
+# awk has no \b and its gsub cannot veto a match, so Tier-2 detection anchors on
+# non-digit boundaries and validates (Luhn for cards, 0-255 octets for IPv4).
+# Every case runs through all three mirrored sites — the CLI masker
+# (pii_regex_adapter_filter), the hook output masker (mask_pii_response_json)
+# and the mask-mode input gate (pii_tier2_present) — so a drift in one fails.
+pii_cli_mask() { printf '%s' "$1" | "$PLUGIN_ROOT/bin/agent-guard" pii-filter 2>/dev/null; }
+
+pii_hook_mask() { # empty output means the masker left the response unchanged
+  printf '{"tool_name":"Read","tool_input":{"file_path":"m"},"tool_response":%s}' \
+    "$(printf '%s' "$1" | jq -Rs .)" \
+    | (cd "$TMP_ROOT" && AGENT_GUARD_PII_HOOK_MODE=mask "$PLUGIN_ROOT/bin/agent-guard" hook-post-tool 2>/dev/null) \
+    | jq -r '.hookSpecificOutput.updatedToolOutput // empty'
+}
+
+pii_gate_status() { # stderr lands in $ERR so a block can be attributed to the gate
+  printf '{"tool_name":"Write","tool_input":{"file_path":"a.ts","content":%s}}' \
+    "$(printf '%s' "$1" | jq -Rs .)" \
+    | AGENT_GUARD_PII_HOOK_MODE=mask "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool \
+      >/dev/null 2>"$ERR"
+}
+
+# must-pass: ordinary code reaches tools untouched and is not masked on the way out.
+pii_expect_clean() { # $1 label, $2 text
+  fp_cli=$(pii_cli_mask "$2")
+  fp_hook=$(pii_hook_mask "$2")
+  pii_gate_status "$2"
+  fp_gate=$?
+  if [ "$fp_cli" = "$2" ] && [ -z "$fp_hook" ] && [ "$fp_gate" -eq 0 ]; then
+    ok "PII leaves $1 alone (CLI, output masker, input gate)"
+  else
+    not_ok "PII leaves $1 alone (expected unchanged, empty rewrite, exit 0)"
+    printf '%s\n' "  cli : $fp_cli" "  hook: $fp_hook" "  gate: $fp_gate"
+  fi
+}
+
+# must-fail: real Tier-2 PII stays masked on both output paths and blocked on input.
+pii_expect_tier2() { # $1 label, $2 text, $3 expected marker
+  t2_cli=$(pii_cli_mask "$2")
+  t2_hook=$(pii_hook_mask "$2")
+  pii_gate_status "$2"
+  t2_gate=$?
+  # The gate's own message is checked, not just exit 2: another guard blocking
+  # for an unrelated reason would otherwise let this control pass while the
+  # Tier-2 rule is broken.
+  if printf '%s' "$t2_cli" | grep -q "$3" \
+     && printf '%s' "$t2_hook" | grep -q "$3" \
+     && [ "$t2_gate" -eq 2 ] && grep -q 'high-sensitivity PII' "$ERR"; then
+    ok "PII still catches $1 (CLI, output masker, input gate)"
+  else
+    not_ok "PII still catches $1 (expected $3 on both maskers and a Tier-2 gate block)"
+    printf '%s\n' "  cli : $t2_cli" "  hook: $t2_hook" "  gate: $t2_gate"
+    sed 's/^/  stderr: /' "$ERR"
+  fi
+}
+
+pii_expect_clean "an epoch-nanosecond timestamp" 'const ts = 1757347200123456789;'
+pii_expect_clean "a Snowflake-style 18-digit id" 'user_id 123456789012345678'
+pii_expect_clean "a Luhn-invalid 16-digit order number" 'order 1234567812345678 shipped'
+pii_expect_clean "out-of-range dotted numbers" 'build 999.888.777.666'
+pii_expect_clean "a 5-part dotted version" 'ver 1.2.3.4.5'
+pii_expect_clean "an SSN shape inside a longer digit run" 'id 5123-45-67890'
+pii_expect_clean "an RRN shape inside a longer digit run" 'id 5900101-12345670'
+
+# Card numbers assembled at runtime so this test file holds no contiguous PAN.
+t2_pan16="4111""1111""1111""1111"
+t2_pan19="4111""1111""1111""1111""003"
+t2_amex="3782""822463""10005"
+pii_expect_tier2 "an unseparated 16-digit PAN" "pan $t2_pan16 end" '\[PII:CREDIT_CARD\]'
+pii_expect_tier2 "a 19-digit PAN" "pan $t2_pan19 end" '\[PII:CREDIT_CARD\]'
+pii_expect_tier2 "an unseparated 15-digit Amex" "amex $t2_amex end" '\[PII:CREDIT_CARD\]'
+pii_expect_tier2 "a PAN trailed by a 3-digit number" "pan $t2_pan16 123" '\[PII:CREDIT_CARD\]'
+pii_expect_tier2 "a US SSN" 'ssn 123-45-6789' '\[PII:SSN\]'
+pii_expect_tier2 "a KR resident reg. no." 'rrn 900101-1234567' '\[PII:KR_RRN\]'
+
+# A syntactically valid dotted quad stays masked even when it reads like a build
+# version: 1.2.3.4 is a real IPv4, and no context-free rule separates the two.
+pii_ip_cli=$(pii_cli_mask 'app version 1.2.3.4')
+pii_ip_hook=$(pii_hook_mask 'app version 1.2.3.4')
+if [ "$pii_ip_cli" = 'app version [PII:IP_ADDRESS]' ] \
+   && printf '%s' "$pii_ip_hook" | grep -q '\[PII:IP_ADDRESS\]'; then
+  ok "PII masks a valid dotted quad even in version-like context"
+else
+  not_ok "PII masks a valid dotted quad even in version-like context"
+  printf '%s\n' "  cli : $pii_ip_cli" "  hook: $pii_ip_hook"
 fi
 
 # --- agent-guard exec (shell-escape output masking) --------------------------


### PR DESCRIPTION
## 개요

`AGENT_GUARD_PII_HOOK_MODE=mask`의 입력 하드블록이 정상 코드를 오탐으로 차단하고 있었다. Tier-2 정규식에 숫자 경계도 값 검증도 없고 구분자가 선택적(`[ -]?`)이라, 16자리 이상 연속 숫자가 부분 매치로 걸린다.

epoch 나노초 타임스탬프와 Snowflake ID는 일상적인 코드다. 이 상태로는 `mask`를 기본값으로 올릴 수 없었다.

## 변경 내용

코드에 "한 곳을 바꾸면 세 곳 모두 바꿀 것"이라고 명시된 미러 구현 — `pii_tier2_present`(입력 하드블록 게이트), `pii_regex_adapter_filter`(CLI 마스커), `mask_pii_response_json`(PostToolUse 출력 마스커) — 을 동시에 수정한다.

- **숫자 경계**: awk에는 `\b`가 없고 `gsub()`는 개별 매치를 거부할 수 없다. 그래서 `mask_re()`가 매치를 왼쪽부터 걸으며 비-숫자 경계를 요구하고 검증기에 거부권을 준다. jq 쪽은 Oniguruma lookaround로 같은 판정을 표현한다.
- **신용카드**: 경계에 더해 Luhn 검증. 경계만으로 epoch·Snowflake는 배제되지만 16자리 주문번호 같은 카드 모양 ID가 남는다. 입력 하드블록은 오탐이 곧 작업 중단이라 Luhn까지 넣었다.
- **19자리 PAN**: 선택적 꼬리 그룹이 아니라 독립 패턴으로 먼저 돌린다. 그리디 매칭이 뒤따르는 3자리 숫자를 삼켜 19자리 Luhn에 실패하면, 그 안에 있는 유효한 16자리 카드를 놓치기 때문이다.
- **IPv4**: 옥텟 범위(0-255) 검증과 경계.
- **US SSN / 한국 주민번호**: 숫자 경계. 더 긴 숫자열 안의 부분 매치를 배제한다.
- **공유화**: awk 마스커와 입력 게이트가 공유 awk 라이브러리(`PII_AWK_LIB`)를 쓰도록 통합했다. 기존에는 패턴 문자열만 공유하고 판정 로직은 별개 구현이었다.

### 범위 밖이지만 필요했던 수정

전화 패턴은 원래 지시 범위 밖이었으나, 카드 오탐이 먼저 소비하던 긴 숫자열을 generic phone 패턴이 대신 잡는 완전히 같은 종류의 경계 결함이 드러났다(`ts=1757347200123456789` → `ts=[PII:PHONE]23456789`). 명시된 must-pass에 도달할 수 없어 `kr_mobile` / `phone`에도 같은 경계 규칙을 적용했다. Tier-1이라 입력 블록 판정에는 영향이 없다.

## 동작 확인

테스트 방법과 실출력 전문은 sticky comment(`<!-- test-results -->`)에 있다. 요약:

| 입력 | 수정 전 | 수정 후 |
| --- | --- | --- |
| `ts=1757347200123456789` | `[PII:CREDIT_CARD]` | 원문 유지 |
| `user_id 123456789012345678` | `[PII:CREDIT_CARD]78` | 원문 유지 |
| `build 999.888.777.666` | `[PII:IP_ADDRESS]` | 원문 유지 |
| Write `const ts = 1757…789;` | exit 2 | **exit 0** |
| Bash `echo user 1234…678` | exit 2 | **exit 0** |
| Write 실제 카드 / SSN / 주민번호 | exit 2 | **exit 2 유지** |

`block_on_pii_text`의 fail-closed 동작은 유지한다. Tier-2 게이트의 awk 프로그램만 실패시키는 스텁으로 격리해, 깨끗한 입력에서도 `exit 2` / `Tier-2 PII detector failed (status 3)`이 되는 것을 실측하고 회귀 테스트로 고정했다.

## 의도적으로 남긴 오탐

형태만으로는 일반 ID와 구별할 수 없어 무리한 휴리스틱을 넣지 않은 항목. 전부 기존대로 탐지·차단된다.

1. **`order 123-45-6789`** — SSN 형식과 문자열상 구별 불가. 경계는 이미 통과하는 형태라 무력하다.
2. **`900101-1234567` 형태의 비-주민번호 13자리 ID** — 동일.
3. **Luhn을 우연히 통과하는 16자리 비카드 ID** — 무작위 16자리의 약 10%. 기존 100%에서 1/10로 줄었지만 0은 아니다.
4. **`1.2.3.4`** — 문법적으로 유효하고 실제 라우팅 가능한 IPv4라 빌드 버전과 형태로 구별할 수 없다. 문맥 휴리스틱(직전에 `version`이 오면 제외 등)은 취약하고 실제 IP 마스킹을 우회하는 통로가 되므로 넣지 않았다. IP는 Tier-1이라 입력을 차단하지 않으므로 이 잔여 오탐의 비용은 출력 정보 손실뿐이다.

## `mask` 기본값 승격 판단 (이번 범위 밖 · 판단만)

**승격 가능한 상태에 도달했으나, 플립 전 실사용 코퍼스 드라이런을 한 번 권한다.**

하드블록을 실제로 유발하던 지배적 오탐 계열(epoch 나노초·Snowflake·긴 수치 ID)이 사라졌다. 본 리포지토리의 전체 추적 파일을 게이트에 통과시킨 결과 유기적 오탐 0건(해당 줄은 전부 의도된 테스트 픽스처와 패턴 정의 자체).

반면 위 1~3은 원리적으로 제거할 수 없다. 게이트 오탐은 곧 작업 중단이고, 본 리포지토리는 shell/markdown 중심이라 대시 구분 숫자 ID가 흔한 도메인(수주·청구·재고 계열)을 대표하지 않는다. 그런 코드베이스 샘플에서 0건을 확인한 뒤 기본값을 올리는 편이 안전하다.

## 리뷰 대응

Codex 리뷰 P1 — **거부된 후보 주사가 이차 시간**. `mask_re`가 후보마다 남은 레코드 전체를 `after`로 복사하고 `s`를 재구성해, 카드 모양 Luhn 실패 값이 많은 한 줄에서 이차 시간이 됐다. 250KB 한 줄 실측으로 게이트가 10초를 소모했고, 이는 `hooks/hooks.json`의 PreToolUse 타임아웃과 정확히 같다. 호스트가 훅을 죽이면 입력이 통과 판정도 탐지기 실패 보고도 받지 못한 채 넘어간다.

awk는 `match()`를 오프셋에서 시작할 수 없으므로 슬라이딩 윈도우로 주사하도록 바꿨다. `PII_MARGIN`이 어떤 패턴의 최대 매치 길이(19자리 + 구분자 3)보다 크므로, 마진 앞에서 끝난 매치는 잘리지 않은 온전한 매치다. 마진에 걸친 매치는 그 시작점으로 윈도우를 옮겨 다시 본다.

| | base `f7176fe` | 수정 전 | 수정 후 |
| --- | --- | --- | --- |
| 250KB 한 줄 게이트 | 0초 (단, 오탐 차단 exit 2) | 10초 | **2초** |

회귀 테스트는 임의의 초 수가 아니라 실제 PreToolUse 타임아웃(10초)을 경계로 삼는다.

## 주기

`mask_pii_response_json`은 Oniguruma lookbehind에 의존하게 됐다. lookbehind가 없는 jq 빌드에서는 gsub가 에러가 되어 출력 마스킹이 무언 중 무효화된다(기존 fail-safe에 의해 응답은 그대로 통과). 입력 하드블록 게이트는 awk 경로이고 POSIX ERE 이상의 기능을 요구하지 않으므로 영향을 받지 않는다. 이 점은 코드 주석에도 명시했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
