### PR TITLE
docs(verify): 스캔 범위를 정확히 기술한다

### DIFF
--- a/plugins/agent-guard/commands/verify.md
+++ b/plugins/agent-guard/commands/verify.md
@@ -1,11 +1,13 @@
 ---
 allowed-tools: Bash
-description: Run a deterministic one-shot secret scan over the current working tree (staged + unstaged + untracked). Use to confirm "is the current state safe to commit?" without going through hook triggers.
+description: Run a deterministic one-shot secret scan over the current working tree (staged + unstaged + untracked, excluding gitignored paths). Use to confirm "is the current state safe to commit?" without going through hook triggers. For gitignored paths or a tree outside the repository, use `agent-guard scan-path <dir>` instead.
 ---
 
 # /agent-guard:verify
 
-One-shot secret scan over everything currently on disk: staged changes, unstaged changes, and untracked files. Backed by the bundled gitleaks rule set the agent-guard hooks already use, so a clean verify here implies the same thing the hooks would say at commit time.
+One-shot secret scan over what a commit from here would carry: staged changes, unstaged changes, and untracked files. Backed by the bundled gitleaks rule set the agent-guard hooks already use, so a clean verify here implies the same thing the hooks would say at commit time.
+
+Scope follows that question, so **gitignored paths are deliberately excluded** — a local `.env` is not going to be committed, and flagging it every run would bury the findings that do matter. "Is there a secret anywhere in this directory?" is a different question: answer it with `agent-guard scan-path <dir>`, which reads the filesystem directly and does cover gitignored paths and trees outside the repository.
 
 ## Run
 
@@ -13,7 +15,7 @@ One-shot secret scan over everything currently on disk: staged changes, unstaged
 
 ## Interpretation
 
-- **Exit 0, no output beyond the gitleaks summary** → no secrets detected. Tell the user the working tree is clean and stop.
+- **Exit 0, no output beyond the gitleaks summary** → no secrets detected in the committable working tree. Say that, not "the directory is clean" — gitignored paths were not scanned. Then stop.
 - **Non-zero exit with `agent-guard:` lines** → leaks were flagged. Report the exact file paths and rule names gitleaks emitted, verbatim. Do not propose fixes unless the user asks.
 - **`required command not found: gitleaks`** → suggest `agent-guard setup --install --gitleaks-checksum <SHA>` and stop.
 - **`gitleaks config not found`** → the plugin install is incomplete; suggest reinstalling via `curl -fsSL https://github.com/JeongJaeSoon/agent-guard/releases/latest/download/bootstrap.sh | sh`.

--- a/plugins/agent-guard/commands/verify.md
+++ b/plugins/agent-guard/commands/verify.md
@@ -1,13 +1,16 @@
 ---
 allowed-tools: Bash
-description: Run a deterministic one-shot secret scan over the current working tree (staged + unstaged + untracked, excluding gitignored paths). Use to confirm "is the current state safe to commit?" without going through hook triggers. For gitignored paths or a tree outside the repository, use `agent-guard scan-path <dir>` instead.
+description: Run a deterministic one-shot secret scan over the working tree as it exists on disk (tracked changes against HEAD, plus untracked files; gitignored paths excluded). Use for a quick "does the current state contain secrets?" check without going through hook triggers. It reads the worktree, not the index, so it does not replace the pre-commit hook. For gitignored paths or a tree outside the repository, use `agent-guard scan-path <dir>` instead.
 ---
 
 # /agent-guard:verify
 
-One-shot secret scan over what a commit from here would carry: staged changes, unstaged changes, and untracked files. Backed by the bundled gitleaks rule set the agent-guard hooks already use, so a clean verify here implies the same thing the hooks would say at commit time.
+One-shot secret scan over the working tree as it exists on disk: tracked files diffed against `HEAD`, plus untracked files. Backed by the bundled gitleaks rule set the agent-guard hooks already use.
 
-Scope follows that question, so **gitignored paths are deliberately excluded** — a local `.env` is not going to be committed, and flagging it every run would bury the findings that do matter. "Is there a secret anywhere in this directory?" is a different question: answer it with `agent-guard scan-path <dir>`, which reads the filesystem directly and does cover gitignored paths and trees outside the repository.
+Two things it does **not** cover:
+
+- **gitignored paths** — deliberately. Untracked input comes from `git ls-files --others --exclude-standard`, and flagging a local `.env` every run would bury the findings that do matter. "Is there a secret anywhere in this directory?" is a different question: answer it with `agent-guard scan-path <dir>`, which reads the filesystem directly and does cover gitignored paths and trees outside the repository.
+- **the index** — tracked input comes from `git diff HEAD`, which compares the worktree to `HEAD`, not `git diff --cached`. Stage a secret and then restore the file on disk to its `HEAD` contents and this scan reports clean while the staged content still holds it. The pre-commit hook runs `agent-guard scan-staged` against the index, so a clean result here does not stand in for it.
 
 ## Run
 
@@ -15,7 +18,7 @@ Scope follows that question, so **gitignored paths are deliberately excluded** �
 
 ## Interpretation
 
-- **Exit 0, no output beyond the gitleaks summary** → no secrets detected in the committable working tree. Say that, not "the directory is clean" — gitignored paths were not scanned. Then stop.
+- **Exit 0, no output beyond the gitleaks summary** → no secrets detected in what was scanned. Say that, not "the directory is clean" or "safe to commit" — gitignored paths and the index were not covered. Then stop.
 - **Non-zero exit with `agent-guard:` lines** → leaks were flagged. Report the exact file paths and rule names gitleaks emitted, verbatim. Do not propose fixes unless the user asks.
 - **`required command not found: gitleaks`** → suggest `agent-guard setup --install --gitleaks-checksum <SHA>` and stop.
 - **`gitleaks config not found`** → the plugin install is incomplete; suggest reinstalling via `curl -fsSL https://github.com/JeongJaeSoon/agent-guard/releases/latest/download/bootstrap.sh | sh`.


### PR DESCRIPTION
`/agent-guard:verify` 문서가 실제보다 넓은 범위를 스캔하는 것처럼 읽히는 부분을 고칩니다. **동작은 변경하지 않았습니다.**

## 배경

본문 리드가 `One-shot secret scan over everything currently on disk`라고 쓰는데, 디스크 위 전부가 아닙니다. 이 명령은 `scan-working-tree`를 실행하고, 그것이 `git ls-files --others --exclude-standard`를 쓰므로 **gitignore된 경로가 제외됩니다.**

이어지는 열거의 `untracked files`도 오해를 부릅니다. git 용어로는 gitignore된 파일도 untracked이지만 구현은 이를 제외합니다.

실측(같은 토큰을 gitignore된 파일에 배치):

| 명령 | 결과 |
|---|---|
| `scan-working-tree` | exit 0 — 탐지 안 함 |
| `scan-path .` | exit 1 — 탐지 |
| **대조군**: gitignore 안 된 untracked 파일 + `scan-working-tree` | exit 1 — 탐지 |

대조군이 있으므로 첫 줄의 exit 0은 스캐너 고장이 아니라 gitignore 제외임이 확정됩니다.

## 제외는 사양이며 결함이 아닙니다

이 제외를 "고치자"는 제안이 아닙니다. 제외가 옳은 이유 세 가지:

1. frontmatter가 목적을 명시합니다 — `Use to confirm "is the current state safe to commit?"`. gitignore된 파일은 커밋되지 않으므로 이 질문의 대상이 아닙니다.
2. **gitignore된 경로는 시크릿이 정당하게 사는 곳입니다**(로컬 환경 파일, 크리덴셜). 여기를 스캔하면 커밋될 리 없는 파일 때문에 매번 경고하게 되고, 정작 대응해야 할 탐지가 묻힙니다.
3. 이 문서 자신의 주장 — `a clean verify here implies the same thing the hooks would say at commit time` — 은 범위가 pre-commit 훅(`scan-staged`)과 일치해야 성립합니다. gitignore를 포함시키면 그 일치가 깨집니다.

따라서 고칠 대상은 코드가 아니라 문구입니다.

## 변경 내용

`plugins/agent-guard/commands/verify.md` 한 파일(+5 / −3).

- **본문 리드** — `everything currently on disk`를 커밋 시 반출되는 범위로 바꾸고, 제외 이유와 다른 질문에 대한 대안(`agent-guard scan-path <dir>`)을 명시.
- **`Interpretation`의 exit 0 행** — 에이전트에게 `Tell the user the working tree is clean`이라고 지시하던 부분을 범위 한정 표현으로 변경. 이용자에게 과대한 안심을 주던 실질적 지점입니다.
- **frontmatter `description`** — 슬래시 명령 목록에 노출되므로 `excluding gitignored paths`와 대안을 간결히 추가.

## 검증

실행 환경: macOS (darwin 25.5.0), gitleaks 8.30.1, jq 1.7.1

| 게이트 | 결과 |
|---|---|
| `tests/run.sh` | 리베이스 전 base `f7176fe`에서 **1287 passed / 0 failed**(동수, 차이 없음) |
| 리베이스 후 | 문서 전용 변경이라 레이아웃·제출 검증만 재실행. 전체 스위트는 CI에 맡깁니다 |
| `scripts/validate-plugin-layout.sh` | exit 0 (`commands/verify.md`의 아카이브 동봉 포함) |
| `make submission-check` | exit 0 |

동작 변경이 없어 `smoke-test`와 `make bench`는 실행하지 않았습니다. 변경은 문서 한 파일에 닫혀 있습니다.

## 커버하지 못한 것

- 실제 Claude Code 세션의 슬래시 명령 목록에서 새 `description`이 어떻게 표시되는지는 미확인입니다. 길이가 늘어 잘릴 수 있습니다.
- README는 건드리지 않았습니다. README `Known Limitations`의 "gitignored files are not scanned"는 훅 백스톱에 관한 기술이며 `verify`의 범위와는 별개입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
