### PR TITLE
feat(pii): Tier-1 PII 타입을 개별로 끌 수 있게 한다

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,18 @@ In **mask** mode, PII is masked in a tool's *output* (`PostToolUse`, the same pa
 
 The regex provider recognizes email, phone (including Korean mobile), IPv4, credit card, US SSN, and Korean resident registration number.
 
+`AGENT_GUARD_PII_SKIP` turns individual **Tier-1** types off, so masking stops hiding what you actually need to read — an IPv4 during network debugging, or the 10-digit runs inside hashes and hex tokens that the generic phone shape matches. It takes a comma- (or space-) separated list of the names that appear in the placeholders, so what to write is readable straight off the masked output:
+
+```sh
+AGENT_GUARD_PII_SKIP=IP_ADDRESS          # keep IPv4 addresses in tool output
+AGENT_GUARD_PII_SKIP=IP_ADDRESS,PHONE    # …and stop masking phone-shaped digits
+```
+
+Only `EMAIL`, `PHONE`, and `IP_ADDRESS` are accepted. A Tier-2 name (`CREDIT_CARD`, `SSN`, `KR_RRN`) or an unknown name is **refused with exit 2** rather than ignored: the mask-mode input hard-block is derived from Tier-2 masking, and a fail-closed gate must not be switchable from the environment. Two consequences worth knowing:
+
+- A skipped type is no longer treated as PII **at all**, so `AGENT_GUARD_PII_HOOK_MODE=block` also stops blocking inputs that contain it. That is the point of the switch, not a leak — but it does mean the setting is not "output-only" in `block` mode.
+- Skipping never affects Tier-2. Credit card, US SSN, and Korean resident registration number stay masked on output and hard-blocked on input in `mask` mode regardless of what is skipped.
+
 ## Native Git Hook
 
 Install from a clone or direct CLI install:
@@ -654,7 +666,7 @@ environment-family defaults, its entries are not relaxed for template-shaped
 filenames; explicitly listing `sample.env` or `secrets/*` therefore blocks those
 paths.
 
-Output masking is on unless `AGENT_GUARD_OUTPUT_REDACT` is set to `off`; the variable is a switch, not a mode name, so any other value leaves masking enabled. Set `AGENT_GUARD_PII_HOOK_MODE` to `block` (block PII in tool inputs), `mask` (mask PII in tool outputs + hard-block Tier-2 PII inputs), or `off` (default). Set `AGENT_GUARD_PROMPT_GUARD_MODE` to `block` (default), `mask` (reserved; degrades to block — no host supports prompt rewriting yet), `warn`, or `off` for secrets pasted into the user prompt.
+Output masking is on unless `AGENT_GUARD_OUTPUT_REDACT` is set to `off`; the variable is a switch, not a mode name, so any other value leaves masking enabled. Set `AGENT_GUARD_PII_HOOK_MODE` to `block` (block PII in tool inputs), `mask` (mask PII in tool outputs + hard-block Tier-2 PII inputs), or `off` (default); `AGENT_GUARD_PII_SKIP` turns individual Tier-1 types (`EMAIL`, `PHONE`, `IP_ADDRESS`) off and refuses Tier-2 names. Set `AGENT_GUARD_PROMPT_GUARD_MODE` to `block` (default), `mask` (reserved; degrades to block — no host supports prompt rewriting yet), `warn`, or `off` for secrets pasted into the user prompt.
 
 Set `AGENT_GUARD_INFRA_FAILURE_MODE=closed` when a host hook or shell wrapper
 must refuse execution if the scanner cannot run. The default is `open`, with a

--- a/README.md
+++ b/README.md
@@ -413,6 +413,7 @@ Only `EMAIL`, `PHONE`, and `IP_ADDRESS` are accepted. A Tier-2 name (`CREDIT_CAR
 
 - A skipped type is no longer treated as PII **at all**, so `AGENT_GUARD_PII_HOOK_MODE=block` also stops blocking inputs that contain it. That is the point of the switch, not a leak — but it does mean the setting is not "output-only" in `block` mode.
 - Skipping never affects Tier-2. Credit card, US SSN, and Korean resident registration number stay masked on output and hard-blocked on input in `mask` mode regardless of what is skipped.
+- It requires the built-in `regex` provider. An endpoint provider (`http`, `pleno`) redacts server-side and never receives the skip set, so combining the two is **refused with exit 2** rather than left as a switch that silently does nothing.
 
 ## Native Git Hook
 

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -776,6 +776,17 @@ pii_skip_set() {
     esac
     skip_out="$skip_out$skip_name,"
   done
+  # An endpoint provider redacts server-side and never receives the skip set, so
+  # accepting one would leave a switch that silently does nothing on every path
+  # that goes through the provider. An unknown provider value is left alone here
+  # so pii_provider still reports it as the provider error it is.
+  if [ "$skip_out" != , ]; then
+    case "${AGENT_GUARD_PII_PROVIDER:-regex}" in
+      http|pleno)
+        die "AGENT_GUARD_PII_SKIP is only supported with AGENT_GUARD_PII_PROVIDER=regex (got ${AGENT_GUARD_PII_PROVIDER})"
+        ;;
+    esac
+  fi
   printf '%s' "$skip_out"
 }
 

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -739,6 +739,46 @@ pii_provider() {
   esac
 }
 
+# Tier-1 types AGENT_GUARD_PII_SKIP may turn off. Tier-2 (credit card, US SSN,
+# KR resident reg. no.) is deliberately absent: masking those is what the
+# mask-mode input hard-block is derived from, and a fail-closed gate must not be
+# switchable from the environment. The names are the output placeholders
+# (`[PII:IP_ADDRESS]`), so what to write is readable off the masked output.
+PII_SKIPPABLE=',EMAIL,PHONE,IP_ADDRESS,'
+
+# Prints the skip set normalized to `,A,B,` so a substring test is an exact name
+# test. Separators are commas and/or spaces. An unknown or Tier-2 name dies
+# rather than being ignored: someone who wrote AGENT_GUARD_PII_SKIP=CREDIT_CARD
+# expects cards to pass and has to be told the knob cannot do that. Callers that
+# read it through $( ) validate it once in the main shell first — otherwise the
+# subshell swallows the die and the misconfiguration runs on silently.
+pii_skip_set() {
+  # skip_-prefixed names throughout: sh has no locals, and this runs in the main
+  # shell of callers that hold their own `out` / `name` / `raw`.
+  skip_raw=${AGENT_GUARD_PII_SKIP:-}
+  [ -n "$skip_raw" ] || { printf ','; return 0; }
+  case $- in *f*) skip_had_noglob=1 ;; *) skip_had_noglob=0 ;; esac
+  skip_oifs=$IFS
+  IFS=', '
+  set -f
+  # Intentional word splitting: this is the list parse.
+  set -- $skip_raw
+  IFS=$skip_oifs
+  [ "$skip_had_noglob" -eq 1 ] || set +f
+  skip_out=,
+  for skip_name in "$@"; do
+    case "$PII_SKIPPABLE" in
+      *",$skip_name,"*) ;;
+      *) die "AGENT_GUARD_PII_SKIP: unsupported type: $skip_name (expected EMAIL, PHONE, or IP_ADDRESS)" ;;
+    esac
+    case $skip_out in
+      *",$skip_name,"*) continue ;;
+    esac
+    skip_out="$skip_out$skip_name,"
+  done
+  printf '%s' "$skip_out"
+}
+
 # Held here so the CLI masker and the hook input gate below read the SAME
 # Tier-2 patterns instead of two hand-kept copies. They contain no backslashes,
 # so `awk -v` passes them through unchanged. mask_pii_response_json is a jq
@@ -845,9 +885,10 @@ function mask_tier2(s) {
 
 pii_regex_adapter_filter() {
   need_cmd awk
+  skip=$(pii_skip_set) || exit 2
   awk -v CC16_RE="$PII_CREDIT_CARD_RE" -v CC19_RE="$PII_CREDIT_CARD19_RE" \
       -v AMEX_RE="$PII_AMEX_RE" -v SSN_RE="$PII_SSN_RE" \
-      -v KR_RRN_RE="$PII_KR_RRN_RE" -v IPV4_RE="$PII_IPV4_RE" \
+      -v KR_RRN_RE="$PII_KR_RRN_RE" -v IPV4_RE="$PII_IPV4_RE" -v SKIP="$skip" \
       "$PII_AWK_LIB"'
     BEGIN {
       email = "[[:alnum:]_%+.-]+@[[:alnum:].-]+[.][[:alpha:]][[:alpha:]][[:alpha:]]*"
@@ -858,14 +899,22 @@ pii_regex_adapter_filter() {
       if (NR > 1) {
         printf "%s", ORS
       }
+      # Tier-2 first so a Tier-1 pattern cannot shadow it, and it is never
+      # skippable — that ordering premise holds whatever SKIP contains.
       line = mask_tier2($0)
-      line = mask_re(line, IPV4_RE, "[PII:IP_ADDRESS]", "ipv4")
-      gsub(email, "[PII:EMAIL]", line)
+      if (!index(SKIP, ",IP_ADDRESS,")) {
+        line = mask_re(line, IPV4_RE, "[PII:IP_ADDRESS]", "ipv4")
+      }
+      if (!index(SKIP, ",EMAIL,")) {
+        gsub(email, "[PII:EMAIL]", line)
+      }
       # Phone needs the same digit boundary: without it the generic 3-3-4 shape
       # matches the first 10 digits of any long numeric id, which the credit
       # card false positive used to hide.
-      line = mask_re(line, kr_mobile, "[PII:PHONE]", "digits")
-      line = mask_re(line, phone, "[PII:PHONE]", "digits")
+      if (!index(SKIP, ",PHONE,")) {
+        line = mask_re(line, kr_mobile, "[PII:PHONE]", "digits")
+        line = mask_re(line, phone, "[PII:PHONE]", "digits")
+      }
       printf "%s", line
     }
   '
@@ -986,6 +1035,9 @@ pii_filter() {
   done
 
   provider=$(pii_provider) || exit 2
+  # Validate here, not only inside the adapter: --check never reaches the adapter
+  # and would otherwise report "ok" for a skip set every real run refuses.
+  pii_skip_set >/dev/null
   if [ "$check" -eq 1 ]; then
     pii_adapter_check "$provider"
     return 0
@@ -1067,6 +1119,7 @@ check_pii_hook_input() {
   # unsupported value, but the $(...) reads below would swallow that exit and
   # silently disable the gate. Running it here (no subshell) fails closed.
   pii_hook_mode >/dev/null
+  pii_skip_set >/dev/null
   [ "$(pii_hook_mode)" = off ] && return 0
   need_cmd jq
 
@@ -4420,7 +4473,9 @@ redact_response_whole_leaf_fail_closed() {
 # gate is the awk path, which needs no regex features beyond POSIX ERE.
 mask_pii_response_json() {
   resp=$1
-  printf '%s' "$resp" | jq -c "$JQ_WALK"'
+  skip=$(pii_skip_set) || exit 2
+  printf '%s' "$resp" | jq -c --arg pii_skip "$skip" "$JQ_WALK"'
+    def keep($type): ($pii_skip | contains(",\($type),")) | not;
     def luhn:
       ([gsub("[^0-9]"; "") | explode | .[] | . - 48] | reverse
        | to_entries
@@ -4437,10 +4492,16 @@ mask_pii_response_json() {
       | mask_card("(?<![0-9])(?<pan>3[47][0-9]{2}[ -]?[0-9]{6}[ -]?[0-9]{5})(?![0-9])")
       | gsub("(?<![0-9])[0-9]{6}-[0-9]{7}(?![0-9])"; "[PII:KR_RRN]")
       | gsub("(?<![0-9])[0-9]{3}-[0-9]{2}-[0-9]{4}(?![0-9])"; "[PII:SSN]")
-      | gsub("(?<![0-9])(?<![0-9]\\.)(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(\\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])){3}(?![0-9])(?!\\.[0-9])"; "[PII:IP_ADDRESS]")
-      | gsub("[A-Za-z0-9_%+.-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}"; "[PII:EMAIL]")
-      | gsub("(?<![0-9])01[0-9][ -]?[0-9]{4}[ -]?[0-9]{4}(?![0-9])"; "[PII:PHONE]")
-      | gsub("(?<![0-9])(\\+?[0-9][ .-]?)?(\\([0-9]{3}\\)|[0-9]{3})[ .-]?[0-9]{3}[ .-]?[0-9]{4}(?![0-9])"; "[PII:PHONE]");
+      | (if keep("IP_ADDRESS")
+         then gsub("(?<![0-9])(?<![0-9]\\.)(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(\\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])){3}(?![0-9])(?!\\.[0-9])"; "[PII:IP_ADDRESS]")
+         else . end)
+      | (if keep("EMAIL")
+         then gsub("[A-Za-z0-9_%+.-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}"; "[PII:EMAIL]")
+         else . end)
+      | (if keep("PHONE")
+         then gsub("(?<![0-9])01[0-9][ -]?[0-9]{4}[ -]?[0-9]{4}(?![0-9])"; "[PII:PHONE]")
+           | gsub("(?<![0-9])(\\+?[0-9][ .-]?)?(\\([0-9]{3}\\)|[0-9]{3})[ .-]?[0-9]{3}[ .-]?[0-9]{4}(?![0-9])"; "[PII:PHONE]")
+         else . end);
     walk(if type == "string" then mask_pii else . end)
   ' 2>/dev/null
 }
@@ -4457,6 +4518,7 @@ redact_tool_output() {
   # value; the $(...) read below would otherwise swallow the exit and silently
   # leave PII unmasked). A misconfigured mode fails loud instead of fail-open.
   pii_hook_mode >/dev/null
+  pii_skip_set >/dev/null
   secrets_on=0; pii_on=0
   output_redact_enabled && secrets_on=1
   [ "$(pii_hook_mode)" = mask ] && pii_on=1
@@ -4690,6 +4752,7 @@ hook_user_prompt() {
   # and redact_tool_output guard against).
   prompt_guard_mode >/dev/null
   pii_hook_mode >/dev/null
+  pii_skip_set >/dev/null
   prompt_mode=$(prompt_guard_mode)
   if ! hook_dependencies_ready; then
     emit_degraded_hook_warning UserPromptSubmit "$input"
@@ -5085,6 +5148,7 @@ do_exec() {
   # Validate the PII mode up front so a misconfiguration fails loud (pii_hook_mode
   # dies on an unsupported value) instead of silently leaving PII unmasked.
   pii_hook_mode >/dev/null
+  pii_skip_set >/dev/null
   if output_redact_enabled; then
     need_cmd jq
     need_gitleaks

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -9431,6 +9431,185 @@ else
   sed 's/^/  stderr: /' "$ERR"
 fi
 
+# --- AGENT_GUARD_PII_SKIP (per-type Tier-1 opt-out) --------------------------
+# Tier-1 masking is output-only and never hard-blocks an input, so switching a
+# type off cannot weaken the input gate. Tier-2 names are refused outright: that
+# gate is fail-closed and must not be turned off from the environment.
+pii_skip_cli() { # $1 skip set, $2 text
+  printf '%s' "$2" \
+    | env AGENT_GUARD_PII_SKIP="$1" "$PLUGIN_ROOT/bin/agent-guard" pii-filter 2>/dev/null
+}
+
+pii_skip_hook() { # $1 skip set, $2 text
+  printf '{"tool_name":"Read","tool_input":{"file_path":"m"},"tool_response":%s}' \
+    "$(printf '%s' "$2" | jq -Rs .)" \
+    | (cd "$TMP_ROOT" && env AGENT_GUARD_PII_SKIP="$1" AGENT_GUARD_PII_HOOK_MODE=mask \
+        "$PLUGIN_ROOT/bin/agent-guard" hook-post-tool 2>/dev/null) \
+    | jq -r '.hookSpecificOutput.updatedToolOutput // empty'
+}
+
+pii_skip_gate() { # $1 skip set, $2 hook mode, $3 content
+  printf '{"tool_name":"Write","tool_input":{"file_path":"a.ts","content":%s}}' \
+    "$(printf '%s' "$3" | jq -Rs .)" \
+    | env AGENT_GUARD_PII_SKIP="$1" AGENT_GUARD_PII_HOOK_MODE="$2" \
+      "$PLUGIN_ROOT/bin/agent-guard" hook-pre-tool >/dev/null 2>"$ERR"
+}
+
+SKIP_SAMPLE='mail x@y.io ip 8.8.8.8 mob 010-1234-5678'
+
+# One type off: that type survives, the other Tier-1 types still mask, and the
+# CLI adapter and the hook output masker still agree character for character.
+skip_cli=$(pii_skip_cli IP_ADDRESS "$SKIP_SAMPLE")
+skip_hook=$(pii_skip_hook IP_ADDRESS "$SKIP_SAMPLE")
+if [ "$skip_cli" = 'mail [PII:EMAIL] ip 8.8.8.8 mob [PII:PHONE]' ] \
+   && [ "$skip_cli" = "$skip_hook" ]; then
+  ok "PII skip IP_ADDRESS keeps IPv4 and both maskers stay in sync"
+else
+  not_ok "PII skip IP_ADDRESS keeps IPv4 and both maskers stay in sync"
+  printf '%s\n' "  cli : $skip_cli" "  hook: $skip_hook"
+fi
+
+skip_cli=$(pii_skip_cli 'IP_ADDRESS,PHONE' "$SKIP_SAMPLE")
+skip_hook=$(pii_skip_hook 'IP_ADDRESS,PHONE' "$SKIP_SAMPLE")
+if [ "$skip_cli" = 'mail [PII:EMAIL] ip 8.8.8.8 mob 010-1234-5678' ] \
+   && [ "$skip_cli" = "$skip_hook" ]; then
+  ok "PII skip accepts a comma-separated list"
+else
+  not_ok "PII skip accepts a comma-separated list"
+  printf '%s\n' "  cli : $skip_cli" "  hook: $skip_hook"
+fi
+
+# Unset and empty are the same thing: mask everything.
+skip_cli=$(pii_skip_cli '' "$SKIP_SAMPLE")
+if [ "$skip_cli" = 'mail [PII:EMAIL] ip [PII:IP_ADDRESS] mob [PII:PHONE]' ]; then
+  ok "PII skip empty masks every type"
+else
+  not_ok "PII skip empty masks every type"
+  printf '%s\n' "  cli : $skip_cli"
+fi
+
+# Skipping a Tier-1 type must not touch Tier-2 masking or the input gate.
+skip_cli=$(pii_skip_cli 'IP_ADDRESS,PHONE,EMAIL' 'ssn 123-45-6789 rrn 900101-1234567')
+if [ "$skip_cli" = 'ssn [PII:SSN] rrn [PII:KR_RRN]' ]; then
+  ok "PII skip leaves Tier-2 masking untouched"
+else
+  not_ok "PII skip leaves Tier-2 masking untouched"
+  printf '%s\n' "  cli : $skip_cli"
+fi
+
+pii_skip_gate 'IP_ADDRESS,PHONE,EMAIL' mask 'ssn 123-45-6789'
+status=$?
+if [ "$status" -eq 2 ] && grep -q 'high-sensitivity PII' "$ERR"; then
+  ok "PII skip cannot disable the Tier-2 input hard-block"
+else
+  not_ok "PII skip cannot disable the Tier-2 input hard-block (expected 2, got $status)"
+  sed 's/^/  stderr: /' "$ERR"
+fi
+
+# block mode blocks ANY PII, and it derives that from the masker — so a skipped
+# type stops blocking there too. That is the documented consequence, not a leak:
+# the type is no longer treated as PII at all.
+pii_skip_gate IP_ADDRESS block 'ip 8.8.8.8'
+status=$?
+if [ "$status" -eq 0 ]; then
+  ok "PII skip IP_ADDRESS also stops block mode from blocking an IPv4 input"
+else
+  not_ok "PII skip IP_ADDRESS also stops block mode from blocking an IPv4 input (expected 0, got $status)"
+  sed 's/^/  stderr: /' "$ERR"
+fi
+
+pii_skip_gate IP_ADDRESS block 'mail x@y.io'
+status=$?
+if [ "$status" -eq 2 ]; then
+  ok "PII skip IP_ADDRESS leaves block mode blocking other Tier-1 PII"
+else
+  not_ok "PII skip IP_ADDRESS leaves block mode blocking other Tier-1 PII (expected 2, got $status)"
+  sed 's/^/  stderr: /' "$ERR"
+fi
+
+# A Tier-2 name is refused loudly rather than silently ignored: a user who wrote
+# it is expecting cards to pass, and must be told the knob does not do that.
+for skip_bad in CREDIT_CARD SSN KR_RRN BOGUS ip_address; do
+  printf '%s' 'x' \
+    | env AGENT_GUARD_PII_SKIP="$skip_bad" "$PLUGIN_ROOT/bin/agent-guard" pii-filter \
+      >/dev/null 2>"$ERR"
+  status=$?
+  if [ "$status" -eq 2 ] && grep -q 'AGENT_GUARD_PII_SKIP' "$ERR"; then
+    ok "PII skip rejects $skip_bad"
+  else
+    not_ok "PII skip rejects $skip_bad (expected 2, got $status)"
+    sed 's/^/  stderr: /' "$ERR"
+  fi
+done
+
+# The same refusal must reach every hook, not just the CLI — a hook that
+# swallowed it would silently mask (or not mask) against the user's intent.
+pii_skip_gate CREDIT_CARD mask 'const n = 42;'
+status=$?
+if [ "$status" -eq 2 ] && grep -q 'AGENT_GUARD_PII_SKIP' "$ERR"; then
+  ok "PII skip rejection reaches hook-pre-tool"
+else
+  not_ok "PII skip rejection reaches hook-pre-tool (expected 2, got $status)"
+  sed 's/^/  stderr: /' "$ERR"
+fi
+
+printf '%s' '{"tool_name":"Read","tool_input":{"file_path":"m"},"tool_response":"x"}' \
+  | env AGENT_GUARD_PII_SKIP=CREDIT_CARD AGENT_GUARD_PII_HOOK_MODE=mask \
+    "$PLUGIN_ROOT/bin/agent-guard" hook-post-tool >/dev/null 2>"$ERR"
+status=$?
+if [ "$status" -eq 2 ] && grep -q 'AGENT_GUARD_PII_SKIP' "$ERR"; then
+  ok "PII skip rejection reaches hook-post-tool"
+else
+  not_ok "PII skip rejection reaches hook-post-tool (expected 2, got $status)"
+  sed 's/^/  stderr: /' "$ERR"
+fi
+
+printf '{"session_id":"t","prompt":"hello"}' \
+  | env AGENT_GUARD_PII_SKIP=CREDIT_CARD AGENT_GUARD_PII_HOOK_MODE=mask \
+    "$PLUGIN_ROOT/bin/agent-guard" hook-user-prompt >/dev/null 2>"$ERR"
+status=$?
+if [ "$status" -eq 2 ] && grep -q 'AGENT_GUARD_PII_SKIP' "$ERR"; then
+  ok "PII skip rejection reaches hook-user-prompt"
+else
+  not_ok "PII skip rejection reaches hook-user-prompt (expected 2, got $status)"
+  sed 's/^/  stderr: /' "$ERR"
+fi
+
+# --check is the health check people run to validate their configuration, so it
+# must refuse a skip set that every real run would refuse.
+env AGENT_GUARD_PII_SKIP=CREDIT_CARD "$PLUGIN_ROOT/bin/agent-guard" pii-filter --check \
+  >/dev/null 2>"$ERR"
+status=$?
+if [ "$status" -eq 2 ] && grep -q 'AGENT_GUARD_PII_SKIP' "$ERR"; then
+  ok "PII skip rejection reaches pii-filter --check"
+else
+  not_ok "PII skip rejection reaches pii-filter --check (expected 2, got $status)"
+  sed 's/^/  stderr: /' "$ERR"
+fi
+
+# exec pipes the masker with stderr suppressed, so only the up-front validation
+# in its main shell can surface a bad skip set — without it the run would just
+# quietly leave the output unmasked.
+env AGENT_GUARD_PII_SKIP=CREDIT_CARD AGENT_GUARD_PII_HOOK_MODE=mask \
+  "$PLUGIN_ROOT/bin/agent-guard" exec -- printf 'x\n' >/dev/null 2>"$ERR"
+status=$?
+if [ "$status" -eq 2 ] && grep -q 'AGENT_GUARD_PII_SKIP' "$ERR"; then
+  ok "PII skip rejection reaches agent-guard exec"
+else
+  not_ok "PII skip rejection reaches agent-guard exec (expected 2, got $status)"
+  sed 's/^/  stderr: /' "$ERR"
+fi
+
+# exec masks through the same adapter, so a skipped type must survive there too.
+skip_exec=$(env AGENT_GUARD_PII_SKIP=IP_ADDRESS AGENT_GUARD_PII_HOOK_MODE=mask \
+  "$PLUGIN_ROOT/bin/agent-guard" exec -- printf 'ip 8.8.8.8 mail x@y.io\n' 2>/dev/null)
+if [ "$skip_exec" = 'ip 8.8.8.8 mail [PII:EMAIL]' ]; then
+  ok "PII skip applies to agent-guard exec output"
+else
+  not_ok "PII skip applies to agent-guard exec output"
+  printf '%s\n' "  out : $skip_exec"
+fi
+
 # --- agent-guard exec (shell-escape output masking) --------------------------
 # `agent-guard exec` runs a command and masks secret-like values in its captured
 # output before printing. Secret VALUE assembled at runtime from fragments so this

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -9575,6 +9575,37 @@ else
   sed 's/^/  stderr: /' "$ERR"
 fi
 
+# An endpoint provider redacts server-side and never receives the skip set, so
+# accepting one would leave a switch that silently does nothing on every path
+# that goes through the provider (CLI, exec, and block-mode input gating).
+for skip_prov in http pleno; do
+  printf '%s' 'x' \
+    | env AGENT_GUARD_PII_SKIP=IP_ADDRESS AGENT_GUARD_PII_PROVIDER="$skip_prov" \
+      AGENT_GUARD_PII_REDACT_URL=http://127.0.0.1:1 \
+      "$PLUGIN_ROOT/bin/agent-guard" pii-filter >/dev/null 2>"$ERR"
+  status=$?
+  if [ "$status" -eq 2 ] && grep -q 'AGENT_GUARD_PII_SKIP' "$ERR"; then
+    ok "PII skip is refused with the $skip_prov provider"
+  else
+    not_ok "PII skip is refused with the $skip_prov provider (want exit 2 naming AGENT_GUARD_PII_SKIP, got $status)"
+    sed 's/^/  stderr: /' "$ERR"
+  fi
+done
+
+# …and an empty skip set must leave endpoint providers exactly as they were:
+# reaching the request (and failing on the unreachable URL) proves the new
+# validation did not start rejecting a configuration that used to work.
+printf '%s' 'x' \
+  | env AGENT_GUARD_PII_PROVIDER=http AGENT_GUARD_PII_REDACT_URL=http://127.0.0.1:1 \
+    "$PLUGIN_ROOT/bin/agent-guard" pii-filter >/dev/null 2>"$ERR"
+status=$?
+if [ "$status" -eq 2 ] && grep -q 'provider request failed' "$ERR"; then
+  ok "an empty PII skip set leaves endpoint providers untouched"
+else
+  not_ok "an empty PII skip set leaves endpoint providers untouched (expected 2, got $status)"
+  sed 's/^/  stderr: /' "$ERR"
+fi
+
 # --check is the health check people run to validate their configuration, so it
 # must refuse a skip set that every real run would refuse.
 env AGENT_GUARD_PII_SKIP=CREDIT_CARD "$PLUGIN_ROOT/bin/agent-guard" pii-filter --check \


### PR DESCRIPTION
> **스택 PR** — base는 `fix/pii-regex-false-positives`(#217). 공유 awk 라이브러리와 `mask_re()` 구조에 의존하므로 #217 머지 후에 보는 편이 읽기 쉽다.

## 동기

#217로 정규식 쪽 오탐은 크게 줄었지만, **형태만으로는 원리적으로 구별할 수 없는 Tier-1 잔여 오탐**이 남는다.

- 유효한 IPv4는 빌드 버전과 형태가 같다 (`1.2.3.4`)
- 경계에 둘러싸인 10~11자리 숫자열은 실제 전화번호와 형태가 같다. 해시나 16진 토큰 안에서 생기기 때문에 랜덤 24자 16진 값의 약 4%가 `[PII:PHONE]`이 된다

휴리스틱으로 깎는 건 위험하다(#217에 적었듯 실제 IP 마스킹을 우회하는 통로가 된다). 한편 네트워크 디버깅이나 로그 분석에서는 이 값들이 사라지는 것 자체가 작업을 막는다. **탐지 로직을 약화시키지 않으면서 사용자가 타입 단위로 내려올 수 있게** 하는 것이 이 PR이다.

## 변경 내용

```sh
AGENT_GUARD_PII_SKIP=IP_ADDRESS          # IPv4를 출력에 남긴다
AGENT_GUARD_PII_SKIP=IP_ADDRESS,PHONE    # 전화 형태 숫자열도 남긴다
```

- 값은 **출력 플레이스홀더와 같은 이름**(`[PII:IP_ADDRESS]` → `IP_ADDRESS`). 마스킹된 출력을 보면 무엇을 쓸지 바로 알 수 있다. 구분자는 쉼표 또는 공백.
- 대상은 **Tier-1만** (`EMAIL` / `PHONE` / `IP_ADDRESS`).
- **Tier-2(`CREDIT_CARD` / `SSN` / `KR_RRN`)와 알 수 없는 이름은 exit 2로 거부.** mask 모드의 입력 하드블록은 Tier-2 마스킹에서 파생되므로, fail-closed 게이트를 환경변수로 끌 수 있는 상태로 두지 않는다. 조용히 무시하지 않고 소리내어 거부하는 이유는, `CREDIT_CARD`라고 쓴 사람은 카드가 통과할 것으로 기대하고 있고 그렇지 않다는 사실을 알아야 하기 때문이다.

### 설계 판단

| 논점 | 채택 | 이유 |
| --- | --- | --- |
| 입도 | 플레이스홀더 단위 | `PHONE`은 `kr_mobile`과 generic phone을 모두 덮는다. 1 이름 = 1 플레이스홀더로 어중간한 상태를 만들지 않는다 |
| 위치 | 환경변수 | 기존 PII 설정은 전부 환경변수. 정책 파일은 deny-list 전용이고 새 포맷 추가는 과설계 |
| 잘못된 값 | loud하게 die | 리포지토리의 기존 방식(`pii_hook_mode` / provider / language)과 일치 |
| 검증 위치 | `$( )` 밖 메인 셸에서 한 번 | 서브셸 안의 `die`는 종료가 삼켜져 오설정이 조용히 계속 동작한다 |

### 건드리지 않은 것

`pii_tier2_present`(입력 하드블록 게이트)는 Tier-2 전용이라 무변경. "Tier-2를 먼저 마스킹해 Tier-1 패턴에 가려지지 않게 한다"는 순서 전제도 SKIP 내용과 무관하게 유지된다.

## 명시하는 부수효과

**`block` 모드에서는 끈 타입이 입력 블록 대상에서도 빠진다.** `pii_text_has_match()`가 "마스커가 문자열을 바꿨는가"로 PII 유무를 판정하기 때문이다. 그 타입을 PII로 보지 않겠다는 선언이므로 의도된 동작이지만, 이 설정이 "출력 전용"이 아니라는 점은 README와 테스트 양쪽에 명시했다.

## 동작 확인

실바이너리로 전 입구를 확인한 실출력 전문은 sticky comment(`<!-- test-results -->`)에 있다. 요약:

| 입구 | 확인 |
| --- | --- |
| CLI 마스커 | 4가지 SKIP 값, 공백 구분 포함 |
| PostToolUse 출력 마스커 | CLI와 문자 단위 일치 |
| Tier-2 | SKIP에 전 Tier-1을 넣어도 마스킹·하드블록 모두 불변 |
| `block` 모드 | 끈 타입은 통과, 다른 Tier-1은 차단 |
| 잘못된 값 | `pii-filter` / `--check` / `exec` / 3개 훅 전부 exit 2 |

```
make test         passed: 1325 / failed: 0
make smoke-test   exit 0
agent-guard scan-path .   exit 0
```

## 리뷰 대응

### Codex P2 — 엔드포인트 프로바이더에서 무효한 skip 설정

`AGENT_GUARD_PII_PROVIDER`가 `http` / `pleno`일 때 `pii_endpoint_adapter_filter`는 텍스트(pleno는 언어까지)만 전송하고 skip 집합은 전달하지 않는다. 그래서 `EMAIL` 같은 값을 받아들여도 엔드포인트는 해당 타입을 그대로 마스킹하고 block 모드는 그것을 포함한 입력을 계속 차단하는데, 명령은 성공으로 끝난다.

**exit 2로 거부**하도록 고쳤다. 요청 컨트랙트를 확장하는 쪽은 외부 API 규약 변경이라 범위 밖이고 검증할 수도 없다. 알 수 없는 프로바이더 값은 여기서 건드리지 않고 `pii_provider`가 프로바이더 오류로 보고하게 둔다.

절충점을 하나 명시한다. 출력 마스킹(`mask_pii_response_json`)은 프로바이더와 무관하게 항상 내장 regex를 쓰므로 엔드포인트 프로바이더에서도 skip이 동작할 여지는 있었다. 하지만 그러면 "출력에는 먹고 입력 게이트에는 안 먹는" 반쪽 상태가 되므로, 전면 거부 쪽을 택했다. 조용히 반만 동작하는 것보다 낫다.

### 자체 리뷰 (`/code-review high`) 2건

1. **`pii-filter --check`가 검증을 우회했다.** `AGENT_GUARD_PII_SKIP=CREDIT_CARD`에서 `--check`는 "ok" + exit 0인데 실행 계열은 전부 exit 2였다. 설정 건전성을 확인하려고 쓰는 명령이, 모든 툴 호출이 깨지기 직전까지 "문제없음"이라고 답하는 상태. `pii_filter` 쪽에서 검증하도록 고치고 회귀 테스트를 추가했다.
2. **skip 파서가 `raw` / `out` / `name`이라는 범용 전역을 썼다.** sh에 지역 변수는 없고 이 함수는 호출자의 메인 셸에서 돈다. `skip_` 접두사로 개명했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
