### PR TITLE
docs(deploy): 정책값 배포 수단과 Codex 관리 경로를 정확히 쓴다

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,46 @@ release, so copy it from the matching release or tag.
 Marketplace sources accept a branch or tag in `ref` but not an exact commit;
 do not add `sha` beside `ref` and describe the result as commit-pinned.
 
+Agent Guard reads no configuration file — every setting in
+[Configuration](#configuration) is an environment variable. To apply one
+fleet-wide, add it to the managed settings `env` key, which Claude Code
+applies to the session and its subprocesses:
+
+```json
+{ "env": { "AGENT_GUARD_INFRA_FAILURE_MODE": "open" } }
+```
+
+The example file deliberately ships without an `env` block: every default is
+already the recommended value, so an organization that keeps the defaults needs
+none. Add only the keys you are deliberately choosing, and do not force an
+opt-in feature such as `AGENT_GUARD_PII_HOOK_MODE` on developers who did not
+ask for it.
+
+Verify on one machine before the fleet rollout, and verify by behavior rather
+than by source. `/status`'s `Setting sources` line names the managed sources
+Claude Code read — not which source supplied a key, what value took effect, or
+whether the developer has approved it yet — and `claude doctor` reports the
+fetch outcome, not the value. On the claude.ai console path a delivered `env`
+change can wait for each developer to accept an approval dialog while the
+managed source keeps showing as active, so the source line can certify a policy
+that has not landed.
+
+Agent Guard's infrastructure diagnostic names the mode it actually read, so
+induce a failure on the pilot machine and read it back. In a Claude Code
+session there, run the plugin-local binary with the scanner pointed at nothing:
+
+```sh
+printf '%s' '{"tool_name":"Write","tool_input":{"content":"x"}}' \
+  | AGENT_GUARD_GITLEAKS_BIN=/nonexistent agent-guard hook-pre-tool
+echo "exit=$?"
+```
+
+`closed` has landed when the hook exits `2` and says `Blocking because
+AGENT_GUARD_INFRA_FAILURE_MODE=closed`; an exit of `0` with `continuing because
+AGENT_GUARD_INFRA_FAILURE_MODE=open (the default)` means the delivered value is
+not in effect there, whatever `/status` shows. For any other policy variable,
+exercise the behavior it controls the same way.
+
 ### 2. Run the setup commands (each developer, once per machine)
 
 Once the managed settings land, Claude Code loads the plugin automatically.
@@ -315,8 +355,18 @@ session message with the exact command to run:
 No fleet-side enforcement is required for these reminders; they ship with the
 force-enabled plugin.
 
-Codex has no separate managed path: Codex users install the plugin through
-the standard install described in the README.
+Codex has enterprise managed configuration of its own — `requirements.toml`
+for enforced constraints, `managed_config.toml` for defaults, delivered by
+file or macOS MDM — and an administrator can restrict which marketplace
+sources are allowed. It offers neither of the two things this Claude path
+relies on: there is no equivalent of `enabledPlugins` that force-enables a
+specific plugin, and managed configuration does not distribute environment
+variables. So Codex users install the plugin through the standard install
+described above, trust its hooks themselves, and set any policy variable in
+their own environment. Codex `requirements.toml` can also declare managed
+hooks against a `managed_dir` that your MDM populates; Agent Guard does not
+ship or support that integration, so treat it as a custom one you re-verify
+on every upgrade.
 
 ## PII Filtering
 


### PR DESCRIPTION
Managed deployment 절의 두 곳을 고칩니다. **동작 변경은 없습니다.** README만 (+27 / −2).

## 1. 정책값을 어떻게 배포하는지가 없었다

[Configuration](https://github.com/JeongJaeSoon/agent-guard#configuration)은 환경변수를 나열하지만, **조직 전체에 어떻게 적용하는지**를 어디에도 쓰지 않습니다. Agent Guard는 설정 파일을 읽지 않고 환경변수만 보므로, 관리 설정의 `env` 키가 유일한 수단입니다. 관리자는 이 도선이 없으면 변수 목록을 봐도 배포 방법에 도달하지 못합니다.

추가한 내용:

- 관리 설정의 `env` 키에 넣는다 (Claude Code가 세션과 그 서브프로세스에 적용)
- **예시 파일이 `env` 없이 배포되는 이유** — 모든 기본값이 이미 권장값이므로, 기본을 그대로 쓰는 조직에는 불필요
- **옵트인 기능을 강제하지 않는다** — `AGENT_GUARD_PII_HOOK_MODE`를 예시에 넣지 않는 계약은 `tests/run.sh:132`가 이미 검증합니다(`managed Claude settings do not force the opt-in PII hook mode`). 그 의도를 산문에도 남겼습니다
- claude.ai 콘솔 경유 배포에서는 `env` 변경이 개발자의 승인 대화상자를 기다린다는 점
- 전개 전 1대에서 `/status`의 `Setting sources` 줄로 확인할 것

`deployment/claude-managed-settings.example.json`은 **의도적으로 건드리지 않았습니다.** 위 테스트가 보여주듯, 예시에 정책 선택을 싣지 않는 것은 기존 설계 판단입니다.

## 2. Codex에 대한 기술이 사실과 다르다

현행:

> Codex has no separate managed path

사실이 아닙니다. Codex에는 `requirements.toml`(강제 제약)과 `managed_config.toml`(기본값)이 있고, 파일 또는 macOS MDM(`com.openai.codex`)으로 배포할 수 있습니다. 관리자는 마켓플레이스 허용 소스도 제한할 수 있습니다.

없는 것은 **이 Claude용 절차가 의존하는 두 가지**입니다.

| | Claude Code | Codex |
|---|---|---|
| 특정 플러그인 강제 활성화 | `enabledPlugins` | **상당하는 것이 없음** |
| 환경변수 배포 | `env` | **관리 설정으로 배포 불가** |

결론(표준 설치를 쓴다)은 기존과 같지만, 전제가 틀리면 도입을 검토하는 조직이 잘못된 판단을 합니다. "관리 경로가 없다"와 "관리 경로는 있으나 필요한 두 가지를 결여한다"는 평가의 의미가 전혀 다릅니다.

아울러 Codex의 `requirements.toml`이 `managed_dir`를 가리키는 관리 훅을 선언할 수 있다는 점, 다만 **Agent Guard가 그 통합을 출하하지도 지원하지도 않으므로** 채택한다면 업그레이드마다 재검증하는 커스텀 통합으로 다뤄야 한다는 점을 한 문장으로 명시했습니다. 이 경로는 플러그인 신뢰와 환경변수 양쪽 제약을 우회할 수 있어서, 모르고 재발명되는 것보다 존재와 미지원을 동시에 알리는 편이 안전하다고 판단했습니다.

출처: [Codex — Managed configuration](https://developers.openai.com/codex/enterprise/managed-configuration), [Claude Code — Deploy managed settings](https://code.claude.com/docs/en/managed-settings)

## 검증

| 게이트 | 결과 |
|---|---|
| `tests/run.sh` | 리베이스 전 base `f7176fe`에서 **1287 passed / 0 failed**(동수, 차이 없음) |
| 리베이스 후 | 문서 전용 변경이라 레이아웃·제출 검증만 재실행. 전체 스위트는 CI에 맡깁니다 |
| `scripts/validate-plugin-layout.sh` | exit 0 |
| `make submission-check` | exit 0 |

동작 변경이 없어 `smoke-test`와 `make bench`는 실행하지 않았습니다.

## 커버하지 못한 것

- Codex 관리 설정에 대한 기술은 공식 문서에 근거한 것으로, 실제 Codex 엔터프라이즈 환경에서 검증하지 않았습니다. 특히 `managed_dir` 경로는 동작 확인을 하지 않았습니다.
- `env`가 플러그인의 훅 서브프로세스까지 전파되는지는 공식 문서의 기술(세션과 그 서브프로세스에 적용)에 의존하며, 실측하지 않았습니다. README에도 단정적 보증은 쓰지 않았습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
