### PR TITLE
fix(scan): 인덱스도 HEAD 기준으로 함께 스캔한다

### DIFF
--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -2004,22 +2004,39 @@ scan_working_tree() {
   repo_root=$(git rev-parse --show-toplevel 2>/dev/null) \
     || return "$SCAN_STATUS_UNAVAILABLE"
 
-  # Index (#224) + worktree, never `git diff HEAD`. That single diff compares
-  # the worktree to HEAD, so content staged and then reverted on disk vanished
-  # from the scan while the next commit still carried it. `--cached` (index vs
-  # HEAD) plus the plain diff (worktree vs index) covers both, works the same
-  # before the first commit, and reports unmerged paths through the combined
-  # diff the plain form emits.
-  cached=$(CDPATH= cd -- "$repo_root" && extract_git_diff_added --cached --unified=0 --no-ext-diff -- .)
-  status=$?
-  [ "$status" -eq 0 ] || return "$status"
-  unstaged=$(CDPATH= cd -- "$repo_root" && extract_git_diff_added --unified=0 --no-ext-diff -- .)
-  status=$?
-  [ "$status" -eq 0 ] || return "$status"
-  tracked=$cached
-  [ -n "$cached" ] && [ -n "$unstaged" ] && tracked="$tracked
-$unstaged"
-  [ -z "$cached" ] && tracked=$unstaged
+  # Two diffs, and with a HEAD both are taken AGAINST HEAD (#224). `git diff
+  # HEAD` alone compares only the worktree, so a secret staged and then reverted
+  # on disk left the scan while the next commit still carried it; `--cached`
+  # (index vs HEAD) closes that. Diffing the worktree against the INDEX instead
+  # would look symmetric but is not: a committed line whose removal is staged and
+  # then undone on disk reads as an addition there, re-reporting history that
+  # `git diff HEAD` correctly calls unchanged. Added lines only is the contract,
+  # so HEAD stays the base for both.
+  if git -C "$repo_root" rev-parse --verify HEAD >/dev/null 2>&1; then
+    first=$(CDPATH= cd -- "$repo_root" && extract_git_diff_added --unified=0 --no-ext-diff HEAD -- .)
+    status=$?
+    [ "$status" -eq 0 ] || return "$status"
+    second=$(CDPATH= cd -- "$repo_root" && extract_git_diff_added --cached --unified=0 --no-ext-diff -- .)
+    status=$?
+    [ "$status" -eq 0 ] || return "$status"
+  else
+    # No HEAD: `--cached` compares against the empty tree and the plain diff
+    # carries unstaged edits. Nothing is committed yet, so neither can re-report
+    # history and there is no HEAD to diff against.
+    first=$(CDPATH= cd -- "$repo_root" && extract_git_diff_added --cached --unified=0 --no-ext-diff -- .)
+    status=$?
+    [ "$status" -eq 0 ] || return "$status"
+    second=$(CDPATH= cd -- "$repo_root" && extract_git_diff_added --unified=0 --no-ext-diff -- .)
+    status=$?
+    [ "$status" -eq 0 ] || return "$status"
+  fi
+  # Content staged and left alone on disk appears in both. gitleaks reports the
+  # same finding either way and agent-guard emits one generic line, so the cost
+  # is duplicate scanner input, not duplicate output.
+  tracked=$first
+  [ -n "$first" ] && [ -n "$second" ] && tracked="$tracked
+$second"
+  [ -z "$first" ] && tracked=$second
 
   result=0
   if [ -n "$tracked" ]; then

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -2004,22 +2004,22 @@ scan_working_tree() {
   repo_root=$(git rev-parse --show-toplevel 2>/dev/null) \
     || return "$SCAN_STATUS_UNAVAILABLE"
 
-  if git -C "$repo_root" rev-parse --verify HEAD >/dev/null 2>&1; then
-    tracked=$(CDPATH= cd -- "$repo_root" && extract_git_diff_added --unified=0 --no-ext-diff HEAD -- .)
-    status=$?
-    [ "$status" -eq 0 ] || return "$status"
-  else
-    cached=$(CDPATH= cd -- "$repo_root" && extract_git_diff_added --cached --unified=0 --no-ext-diff -- .)
-    status=$?
-    [ "$status" -eq 0 ] || return "$status"
-    unstaged=$(CDPATH= cd -- "$repo_root" && extract_git_diff_added --unified=0 --no-ext-diff -- .)
-    status=$?
-    [ "$status" -eq 0 ] || return "$status"
-    tracked=$cached
-    [ -n "$cached" ] && [ -n "$unstaged" ] && tracked="$tracked
+  # Index (#224) + worktree, never `git diff HEAD`. That single diff compares
+  # the worktree to HEAD, so content staged and then reverted on disk vanished
+  # from the scan while the next commit still carried it. `--cached` (index vs
+  # HEAD) plus the plain diff (worktree vs index) covers both, works the same
+  # before the first commit, and reports unmerged paths through the combined
+  # diff the plain form emits.
+  cached=$(CDPATH= cd -- "$repo_root" && extract_git_diff_added --cached --unified=0 --no-ext-diff -- .)
+  status=$?
+  [ "$status" -eq 0 ] || return "$status"
+  unstaged=$(CDPATH= cd -- "$repo_root" && extract_git_diff_added --unified=0 --no-ext-diff -- .)
+  status=$?
+  [ "$status" -eq 0 ] || return "$status"
+  tracked=$cached
+  [ -n "$cached" ] && [ -n "$unstaged" ] && tracked="$tracked
 $unstaged"
-    [ -z "$cached" ] && tracked=$unstaged
-  fi
+  [ -z "$cached" ] && tracked=$unstaged
 
   result=0
   if [ -n "$tracked" ]; then

--- a/plugins/agent-guard/commands/verify.md
+++ b/plugins/agent-guard/commands/verify.md
@@ -5,9 +5,9 @@ description: Run a deterministic one-shot secret scan over the repository's pend
 
 # /agent-guard:verify
 
-One-shot secret scan over everything the repository has pending: staged content (`git diff --cached`, index vs `HEAD`), unstaged worktree edits (`git diff`, worktree vs index), and untracked files. Backed by the bundled gitleaks rule set the agent-guard hooks already use.
+One-shot secret scan over everything the repository has pending: the worktree (`git diff HEAD`) and the index (`git diff --cached`), **both compared against `HEAD`**, plus untracked files. Backed by the bundled gitleaks rule set the agent-guard hooks already use.
 
-The index is covered. Stage a secret and then restore the file on disk to its `HEAD` contents and the staged copy is still flagged, so the tracked input is a superset of what `agent-guard scan-staged` sees. It remains a snapshot of the moment it ran, not a gate: the pre-commit hook runs `scan-staged` at commit time and is what actually blocks a commit.
+The index is covered. Stage a secret and then restore the file on disk to its `HEAD` contents and the staged copy is still flagged, so the tracked input is a superset of what `agent-guard scan-staged` sees. Keeping `HEAD` as the base for both diffs is what makes that safe in the other direction too: stage the *removal* of a committed secret and then undo it on disk and nothing is reported, because relative to `HEAD` nothing was added. It remains a snapshot of the moment it ran, not a gate: the pre-commit hook runs `scan-staged` at commit time and is what actually blocks a commit.
 
 What it does **not** cover:
 

--- a/plugins/agent-guard/commands/verify.md
+++ b/plugins/agent-guard/commands/verify.md
@@ -1,16 +1,18 @@
 ---
 allowed-tools: Bash
-description: Run a deterministic one-shot secret scan over the working tree as it exists on disk (tracked changes against HEAD, plus untracked files; gitignored paths excluded). Use for a quick "does the current state contain secrets?" check without going through hook triggers. It reads the worktree, not the index, so it does not replace the pre-commit hook. For gitignored paths or a tree outside the repository, use `agent-guard scan-path <dir>` instead.
+description: Run a deterministic one-shot secret scan over the repository's pending changes (staged content, unstaged worktree edits, and untracked files; gitignored paths excluded). Use for a quick "does the current state contain secrets?" check without going through hook triggers. It is a point-in-time check, not a gate, so it does not replace the pre-commit hook. For gitignored paths or a tree outside the repository, use `agent-guard scan-path <dir>` instead.
 ---
 
 # /agent-guard:verify
 
-One-shot secret scan over the working tree as it exists on disk: tracked files diffed against `HEAD`, plus untracked files. Backed by the bundled gitleaks rule set the agent-guard hooks already use.
+One-shot secret scan over everything the repository has pending: staged content (`git diff --cached`, index vs `HEAD`), unstaged worktree edits (`git diff`, worktree vs index), and untracked files. Backed by the bundled gitleaks rule set the agent-guard hooks already use.
 
-Two things it does **not** cover:
+The index is covered. Stage a secret and then restore the file on disk to its `HEAD` contents and the staged copy is still flagged, so the tracked input is a superset of what `agent-guard scan-staged` sees. It remains a snapshot of the moment it ran, not a gate: the pre-commit hook runs `scan-staged` at commit time and is what actually blocks a commit.
+
+What it does **not** cover:
 
 - **gitignored paths** — deliberately. Untracked input comes from `git ls-files --others --exclude-standard`, and flagging a local `.env` every run would bury the findings that do matter. "Is there a secret anywhere in this directory?" is a different question: answer it with `agent-guard scan-path <dir>`, which reads the filesystem directly and does cover gitignored paths and trees outside the repository.
-- **the index** — tracked input comes from `git diff HEAD`, which compares the worktree to `HEAD`, not `git diff --cached`. Stage a secret and then restore the file on disk to its `HEAD` contents and this scan reports clean while the staged content still holds it. The pre-commit hook runs `agent-guard scan-staged` against the index, so a clean result here does not stand in for it.
+- **history** — only content that differs from `HEAD` is diffed. A secret already committed in `HEAD` or an earlier commit is not re-reported here.
 
 ## Run
 
@@ -18,7 +20,7 @@ Two things it does **not** cover:
 
 ## Interpretation
 
-- **Exit 0, no output beyond the gitleaks summary** → no secrets detected in what was scanned. Say that, not "the directory is clean" or "safe to commit" — gitignored paths and the index were not covered. Then stop.
+- **Exit 0, no output beyond the gitleaks summary** → no secrets detected in what was scanned. Say that, not "the directory is clean" or "safe to commit" — gitignored paths and committed history were not covered, and the result goes stale with the next edit. Then stop.
 - **Non-zero exit with `agent-guard:` lines** → leaks were flagged. Report the exact file paths and rule names gitleaks emitted, verbatim. Do not propose fixes unless the user asks.
 - **`required command not found: gitleaks`** → suggest `agent-guard setup --install --gitleaks-checksum <SHA>` and stop.
 - **`gitleaks config not found`** → the plugin install is incomplete; suggest reinstalling via `curl -fsSL https://github.com/JeongJaeSoon/agent-guard/releases/latest/download/bootstrap.sh | sh`.

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -7459,6 +7459,32 @@ if [ -n "$REAL_GITLEAKS" ]; then
     sed 's/^/  stderr: /' "$ERR"
   fi
 
+  # MUST-PASS control: a committed secret whose removal is staged and then undone
+  # on disk. Nothing differs from HEAD, so nothing may be reported — that is what
+  # "added lines only" means. Diffing the worktree against the INDEX instead of
+  # against HEAD reads the restored line as an addition and re-reports a secret
+  # that is already committed, so this pins the diff bases, not just the verdict.
+  (
+    cd "$INDEX224_REPO" || exit 2
+    git reset -q --hard
+    printf 'AGDEMO_VAR=%s\nkeep\n' "$INDEX224_TOKEN" >app.txt
+    git add app.txt
+    git commit -q -m "commit the secret"
+    printf 'keep\n' >app.txt
+    git add app.txt
+    printf 'AGDEMO_VAR=%s\nkeep\n' "$INDEX224_TOKEN" >app.txt
+    PATH="$(dirname "$REAL_GITLEAKS"):$ORIGINAL_PATH" \
+      "$PLUGIN_ROOT/bin/agent-guard" scan-working-tree
+  ) >"$OUT" 2>"$ERR"
+  status=$?
+  if [ "$status" -eq 0 ]; then
+    ok "#224 control: a staged removal undone on disk re-reports nothing"
+  else
+    not_ok "#224 control: staged removal undone on disk stays clean (expected 0, got $status)"
+    sed 's/^/  stderr: /' "$ERR"
+  fi
+  ( cd "$INDEX224_REPO" && git reset -q --hard HEAD~1 ) >/dev/null 2>&1
+
   # MUST-PASS control: the same repo with nothing staged and nothing on disk.
   (
     cd "$INDEX224_REPO" || exit 2

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -7422,6 +7422,128 @@ if [ -n "$REAL_GITLEAKS" ]; then
     not_ok "apply_patch allows a go.sum checksum (expected 0, got $status)"
   fi
 
+  # --- #224: scan-working-tree must cover the index, not just the worktree ---
+  # Tracked input used to come from `git diff HEAD` alone, so content that lived
+  # only in the index was never scanned: stage a secret, restore the file on
+  # disk to its HEAD contents, and the scan reported clean while the next commit
+  # still carried the secret. Tokens are generated at runtime, so this file
+  # never holds a credential; the bundled vendor-token-shape rule matches on
+  # shape alone, which keeps the verdicts deterministic.
+  INDEX224_REPO="$TMP_ROOT/index-224-repo"
+  INDEX224_TOKEN="ghp_$(od -An -N18 -tx1 /dev/urandom | LC_ALL=C tr -d ' \n')"
+  mkdir -p "$INDEX224_REPO"
+  (
+    cd "$INDEX224_REPO" || exit 2
+    git init -q
+    git config user.email test@example.com
+    git config user.name "Agent Guard Tests"
+    printf '%s\n' clean >app.txt
+    git add app.txt
+    git commit -q -m init
+  ) >/dev/null 2>&1
+
+  # MUST-FAIL: index-only secret, worktree restored to its HEAD contents.
+  (
+    cd "$INDEX224_REPO" || exit 2
+    printf 'AGDEMO_VAR=%s\n' "$INDEX224_TOKEN" >app.txt
+    git add app.txt
+    printf '%s\n' clean >app.txt
+    PATH="$(dirname "$REAL_GITLEAKS"):$ORIGINAL_PATH" \
+      "$PLUGIN_ROOT/bin/agent-guard" scan-working-tree
+  ) >"$OUT" 2>"$ERR"
+  status=$?
+  if [ "$status" -eq 1 ]; then
+    ok "#224 scan-working-tree detects a secret that exists only in the index"
+  else
+    not_ok "#224 scan-working-tree detects an index-only secret (expected 1, got $status)"
+    sed 's/^/  stderr: /' "$ERR"
+  fi
+
+  # MUST-PASS control: the same repo with nothing staged and nothing on disk.
+  (
+    cd "$INDEX224_REPO" || exit 2
+    git reset -q --hard
+    PATH="$(dirname "$REAL_GITLEAKS"):$ORIGINAL_PATH" \
+      "$PLUGIN_ROOT/bin/agent-guard" scan-working-tree
+  ) >"$OUT" 2>"$ERR"
+  status=$?
+  if [ "$status" -eq 0 ]; then
+    ok "#224 control: scan-working-tree allows a repo with a clean index and tree"
+  else
+    not_ok "#224 control: clean index and tree stay clean (expected 0, got $status)"
+    sed 's/^/  stderr: /' "$ERR"
+  fi
+
+  # MUST-FAIL control: the pre-existing worktree-only path keeps its verdict.
+  (
+    cd "$INDEX224_REPO" || exit 2
+    printf 'AGDEMO_VAR=%s\n' "$INDEX224_TOKEN" >app.txt
+    PATH="$(dirname "$REAL_GITLEAKS"):$ORIGINAL_PATH" \
+      "$PLUGIN_ROOT/bin/agent-guard" scan-working-tree
+  ) >"$OUT" 2>"$ERR"
+  status=$?
+  if [ "$status" -eq 1 ]; then
+    ok "#224 control: scan-working-tree still detects an unstaged worktree secret"
+  else
+    not_ok "#224 control: unstaged worktree secret stays detected (expected 1, got $status)"
+    sed 's/^/  stderr: /' "$ERR"
+  fi
+
+  # A repo before its first commit has no HEAD to diff against. That branch
+  # already combined the index and the worktree; its verdicts must not move.
+  NOHEAD224_REPO="$TMP_ROOT/nohead-224-repo"
+  mkdir -p "$NOHEAD224_REPO"
+  (
+    cd "$NOHEAD224_REPO" || exit 2
+    git init -q
+    git config user.email test@example.com
+    git config user.name "Agent Guard Tests"
+    printf '%s\n' clean >app.txt
+    git add app.txt
+    PATH="$(dirname "$REAL_GITLEAKS"):$ORIGINAL_PATH" \
+      "$PLUGIN_ROOT/bin/agent-guard" scan-working-tree
+  ) >"$OUT" 2>"$ERR"
+  status=$?
+  if [ "$status" -eq 0 ]; then
+    ok "#224 control: pre-first-commit repo with clean staged content stays clean"
+  else
+    not_ok "#224 control: pre-first-commit clean repo (expected 0, got $status)"
+    sed 's/^/  stderr: /' "$ERR"
+  fi
+
+  (
+    cd "$NOHEAD224_REPO" || exit 2
+    printf 'AGDEMO_VAR=%s\n' "$INDEX224_TOKEN" >app.txt
+    git add app.txt
+    printf '%s\n' clean >app.txt
+    PATH="$(dirname "$REAL_GITLEAKS"):$ORIGINAL_PATH" \
+      "$PLUGIN_ROOT/bin/agent-guard" scan-working-tree
+  ) >"$OUT" 2>"$ERR"
+  status=$?
+  if [ "$status" -eq 1 ]; then
+    ok "#224 control: pre-first-commit repo still detects an index-only secret"
+  else
+    not_ok "#224 control: pre-first-commit index-only secret (expected 1, got $status)"
+    sed 's/^/  stderr: /' "$ERR"
+  fi
+
+  (
+    cd "$NOHEAD224_REPO" || exit 2
+    git rm -q --cached app.txt
+    printf '%s\n' clean >app.txt
+    git add app.txt
+    printf 'AGDEMO_VAR=%s\n' "$INDEX224_TOKEN" >app.txt
+    PATH="$(dirname "$REAL_GITLEAKS"):$ORIGINAL_PATH" \
+      "$PLUGIN_ROOT/bin/agent-guard" scan-working-tree
+  ) >"$OUT" 2>"$ERR"
+  status=$?
+  if [ "$status" -eq 1 ]; then
+    ok "#224 control: pre-first-commit repo still detects an unstaged secret"
+  else
+    not_ok "#224 control: pre-first-commit unstaged secret (expected 1, got $status)"
+    sed 's/^/  stderr: /' "$ERR"
+  fi
+
 else
   say "real gitleaks not available; skipped real-gitleaks integration tests"
 fi


### PR DESCRIPTION
`scan-working-tree`가 인덱스를 읽지 않아 스테이징된 시크릿을 놓치던 문제를 고칩니다. `Closes #224`.

## 문제

HEAD가 있으면 추적 입력을 `git diff HEAD`(워킹트리 vs HEAD)로만 만들었습니다. 인덱스에만 존재하는 내용이 스캔에서 빠집니다.

실측(런타임 생성 합성 토큰, 실제 gitleaks 8.30.1):

| 시나리오 | 수정 전 | 수정 후 |
|---|---|---|
| 인덱스에만 시크릿 (원 이슈) | **0** | 1 |
| `git add` 후 디스크에서 삭제 | **0** | 1 |
| 워킹트리에만 시크릿 | 1 | 1 |
| 깨끗함 | 0 | 0 |
| HEAD 없음 + 스테이징된 시크릿 | 1 | 1 |
| HEAD 없음 + 깨끗함 | 0 | 0 |
| 이미 커밋된 시크릿 | 0 | 0 |
| 스테이징된 삭제 | 0 | 0 |

두 번째 행은 이슈에 없던 변종입니다.

## 설계: 두 안을 두고 갈렸고, 실측으로 갈랐습니다

**A안** — `if/else`를 없애고 `--cached`(인덱스 vs HEAD) ∪ `git diff`(워킹트리 vs 인덱스). 더 작은 diff, 중복 스캔 없음.
**B안** — 분기를 유지하고 `git diff HEAD` 옆에 `--cached`를 추가. 두 diff 모두 HEAD 기준.

구현은 A안을 택했습니다. 12개 시나리오에서 A와 B가 동일했기 때문입니다. 그런데 **Codex 교차 검토가 A안의 새 오탐을 지목**했고, 실측으로 확인됐습니다.

**커밋된 시크릿의 삭제를 스테이징한 뒤 디스크에서 되돌린 경우:**

```
H->W (git diff HEAD)      0 줄 추가     ← HEAD 대비 변한 것 없음
H->I (git diff --cached)  0 줄 추가     ← 삭제뿐
I->W (git diff)           1 줄 추가     ← A안이 이걸 스캔

수정 전  exit=0   정상
A안      exit=1   오탐 — 이미 커밋된 시크릿을 재보고
B안      exit=0   정상
```

**"추가된 라인만 본다"가 이 스캐너의 계약입니다.** README도 "Removing an existing leaked value is allowed"라고 명시합니다. 워킹트리를 인덱스와 비교하면 그 계약이 깨집니다. 그래서 **B안**을 택했습니다 — 두 diff 모두 HEAD를 기준으로 둡니다.

HEAD 없는 저장소는 기존 경로를 그대로 씁니다. 아직 커밋된 것이 없어 과거를 재보고할 수 없고, 기준으로 삼을 HEAD도 없습니다.

## 변경 내용

`plugins/agent-guard/bin/agent-guard` — `scan_working_tree`의 HEAD 분기가 `git diff HEAD`와 `git diff --cached`를 함께 돌립니다. 결합 로직은 기존 no-HEAD 분기와 동일한 형태입니다.

`plugins/agent-guard/commands/verify.md` — 이전 PR #218에서 "인덱스는 보지 않는다"고 명시했는데 이제 사실이 아니라 갱신했습니다. 두 diff 모두 HEAD 기준이라는 점과, 그래서 스테이징된 삭제를 되돌려도 재보고하지 않는다는 점을 함께 적었습니다. gitignore 제외는 그대로라 그 서술은 유지했습니다.

## 테스트 (TDD, 7건)

red를 먼저 확인했습니다. 구현 전 must-fail 1건만 실패(`expected 1, got 0`), 대조군은 통과 — 기존 동작이 움직이지 않았다는 뒷받침입니다. B안 전환 시에도 회귀 테스트가 먼저 실패하는 것(`expected 0, got 1`)을 확인한 뒤 고쳤습니다.

- **must-fail**: 인덱스에만 있는 시크릿, `git add` 후 디스크 삭제
- **must-pass**: **스테이징한 삭제를 디스크에서 되돌린 경우**(회귀 잠금 — diff 기준을 고정합니다), 워킹트리 전용 시크릿, 깨끗한 상태, 첫 커밋 전 저장소, 이미 커밋된 시크릿

토큰은 런타임 생성이라 이 파일에 크리덴셜이 남지 않습니다.

## 검증

실행 환경: macOS (darwin 25.5.0), gitleaks 8.30.1, jq 1.7.1

| 게이트 | 결과 |
|---|---|
| `tests/run.sh` | **1372 passed / 0 failed** (base `67c6591`의 1365 + 신규 7) |
| `make smoke-test` | exit 0 |
| `agent-guard scan-path .` | exit 0 |

비교 기준 바이너리의 `scan_working_tree`가 `f7176fe`와 `67c6591` 사이에 **바이트 동일**(md5 일치)임을 확인하고 대조했습니다.

## 남은 것

- **중복 스캐너 입력.** 스테이징 후 손대지 않은 내용은 두 diff에 모두 나타납니다. gitleaks 판정은 같고 agent-guard는 일반 메시지 한 줄만 내므로 출력은 변하지 않습니다. 비용은 스캐너 입력 중복뿐입니다.
- **git 호출 1회 추가.** `scan-working-tree`는 `Stop` 백스톱과 `/agent-guard:verify`에서 호출됩니다. 작지만 매번 붙는 지연입니다.
- **병합 충돌 시 결합 diff 형식.** `extract_added_lines`가 첫 글자 `+`만 받으므로 ` +`(한쪽 부모에만 추가) 줄은 놓칩니다. 이 PR 이전과 동일한 기존 성질이며, 이 변경이 만든 것이 아닙니다.
- **`skip-worktree` / `assume-unchanged`.** `git diff HEAD`도 `--cached`도 워킹트리 전용 편집을 복구하지 못합니다. `PostToolUse` 경로 스캐너(#221)가 방금 쓴 파일만 보완합니다. `scan-working-tree`는 여전히 이 경우를 보지 못합니다.
- shellcheck는 로컬 미설치라 CI 확인이 필요합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
