### PR TITLE
Add CLI-managed Claude and Codex plugin lifecycle

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -26,20 +26,39 @@ agent-guard plugin install --host codex
 Use `--host all` to install both in one command. If `--host` is omitted,
 exactly one of `claude` or `codex` must be available. Claude Code supports
 `--scope user|project|local` and defaults to `user`; Codex supports user scope
-only. Repeating `install` is a no-op when the plugin is already installed and
-enabled, and never updates it implicitly. If an installed plugin is disabled,
-`status` reports that state and `install` asks you to enable it through the
-host manager. Updates and removals remain explicit:
+only. Each marketplace is pinned to the release tag matching the CLI that
+performs the installation (`v<CLI version>`). Repeating `install` is a
+no-op when the pinned marketplace and installed plugin already match that CLI,
+and never updates them implicitly. If an installed plugin is disabled, `status`
+reports that state and `install` asks you to enable it through the host manager.
+Updates and removals remain explicit:
 
 ```sh
 agent-guard plugin update --host all
 agent-guard plugin uninstall --host claude
 ```
 
-These commands use the remote `JeongJaeSoon/agent-guard` marketplace and call
-the host CLIs directly. They do not write plugin caches or host configuration
-files themselves, do not invoke `sudo`, and do not bypass host confirmation
-prompts. Restart each changed host before verifying its hooks.
+These commands use the remote `JeongJaeSoon/agent-guard@v<CLI version>` marketplace
+and call the host CLIs directly. They do not write plugin caches or host
+configuration files themselves, do not invoke `sudo`, and do not bypass host
+confirmation prompts. Restart each changed host before verifying its hooks.
+
+`status` reports installed plugin version drift separately from marketplace
+state. Claude Code exposes the configured marketplace ref in its JSON status;
+Codex 0.153.4 does not, so Codex status conservatively labels the pin
+unverified. Before `install` or `update` reuses an existing Codex marketplace,
+the CLI asks Codex to add the same pinned source again. Codex treats that as an
+idempotent no-op only for the same ref and rejects an unpinned or different ref
+without changing state.
+
+The CLI will not silently replace an unpinned marketplace, a marketplace pinned
+to another release, or a same-name marketplace from another source. Remove the
+marketplace with the official host manager, then rerun `agent-guard plugin
+install --host HOST`. Marketplace removal also removes plugins installed from
+that marketplace, so treat those two commands as one recovery operation. If
+marketplace registration or plugin installation fails partway through, the CLI
+reports which host-managed state remains and the exact command that is safe to
+retry.
 
 The CLI plugin lifecycle is for self-managed installations. It detects an
 installed Claude plugin with `managed` scope and also reads Agent Guard entries

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -41,12 +41,20 @@ the host CLIs directly. They do not write plugin caches or host configuration
 files themselves, do not invoke `sudo`, and do not bypass host confirmation
 prompts. Restart each changed host before verifying its hooks.
 
-The CLI plugin lifecycle is for self-managed installations. If Claude Code
-reports an Agent Guard plugin or marketplace with `managed` scope, `status`
-identifies it as managed and `install`, `update`, and `uninstall` refuse to
-change it. On Jamf or another managed deployment, change the reviewed release
-tag in the administrator-owned managed settings instead; do not add a user or
-project installation over the managed policy. See [Operations](operations.md#managed-claude-code-rollout).
+The CLI plugin lifecycle is for self-managed installations. It detects an
+installed Claude plugin with `managed` scope and also reads Agent Guard entries
+from the administrator-owned `managed-settings.json` and
+`managed-settings.d/*.json` files on macOS and Linux. This covers the initial
+state where the managed marketplace is declared but its plugin has not yet been
+downloaded. `status` identifies that state as managed; `install`, `update`, and
+`uninstall` refuse to change it. An unreadable, non-regular, or malformed managed
+settings file makes these commands fail closed because ownership cannot be
+determined safely. Valid files that contain only unrelated settings do not block
+self-managed use. This CLI check helps prevent accidental lifecycle changes; the
+Claude managed-settings deployment remains the administrative enforcement
+boundary. On Jamf or another managed deployment, change the reviewed release tag
+in managed settings instead; do not add a user or project installation over the
+managed policy. See [Operations](operations.md#managed-claude-code-rollout).
 
 ## Standalone CLI
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -41,6 +41,13 @@ the host CLIs directly. They do not write plugin caches or host configuration
 files themselves, do not invoke `sudo`, and do not bypass host confirmation
 prompts. Restart each changed host before verifying its hooks.
 
+The CLI plugin lifecycle is for self-managed installations. If Claude Code
+reports an Agent Guard plugin or marketplace with `managed` scope, `status`
+identifies it as managed and `install`, `update`, and `uninstall` refuse to
+change it. On Jamf or another managed deployment, change the reviewed release
+tag in the administrator-owned managed settings instead; do not add a user or
+project installation over the managed policy. See [Operations](operations.md#managed-claude-code-rollout).
+
 ## Standalone CLI
 
 Install the current release:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -14,6 +14,33 @@ The plugins are not replaceable by a PATH CLI: they translate Claude Code and
 Codex events into the same CLI contract. A standalone installation adds the
 CLI and optional shell integration; it does not register host hooks.
 
+If `agent-guard` is already installed as a standalone or Homebrew command, it
+can delegate plugin installation to the official host managers:
+
+```sh
+agent-guard plugin status --host all
+agent-guard plugin install --host claude
+agent-guard plugin install --host codex
+```
+
+Use `--host all` to install both in one command. If `--host` is omitted,
+exactly one of `claude` or `codex` must be available. Claude Code supports
+`--scope user|project|local` and defaults to `user`; Codex supports user scope
+only. Repeating `install` is a no-op when the plugin is already installed and
+enabled, and never updates it implicitly. If an installed plugin is disabled,
+`status` reports that state and `install` asks you to enable it through the
+host manager. Updates and removals remain explicit:
+
+```sh
+agent-guard plugin update --host all
+agent-guard plugin uninstall --host claude
+```
+
+These commands use the remote `JeongJaeSoon/agent-guard` marketplace and call
+the host CLIs directly. They do not write plugin caches or host configuration
+files themselves, do not invoke `sudo`, and do not bypass host confirmation
+prompts. Restart each changed host before verifying its hooks.
+
 ## Standalone CLI
 
 Install the current release:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -47,10 +47,14 @@ from the administrator-owned `managed-settings.json` and
 `managed-settings.d/*.json` files on macOS and Linux. This covers the initial
 state where the managed marketplace is declared but its plugin has not yet been
 downloaded. `status` identifies that state as managed; `install`, `update`, and
-`uninstall` refuse to change it. An unreadable, non-regular, or malformed managed
-settings file makes these commands fail closed because ownership cannot be
-determined safely. Valid files that contain only unrelated settings do not block
-self-managed use. This CLI check helps prevent accidental lifecycle changes; the
+`uninstall` refuse to change it. Files are merged in Claude's base-then-sorted-
+drop-in order before the Agent Guard keys are evaluated. An unreadable or
+malformed file, or a path that does not resolve to a regular file, makes these
+commands fail closed because ownership cannot be determined safely. Empty files
+and valid files that contain only unrelated settings do not block self-managed
+use. If a valid `policyHelper` is declared, its result replaces the file-based
+settings at runtime; the CLI does not execute the helper and therefore also
+fails closed. This CLI check helps prevent accidental lifecycle changes; the
 Claude managed-settings deployment remains the administrative enforcement
 boundary. On Jamf or another managed deployment, change the reviewed release tag
 in managed settings instead; do not add a user or project installation over the

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -152,6 +152,22 @@ agent-guard version
 The formula pins the release tarball’s SHA-256. Homebrew owns this installation;
 do not run `agent-guard update` over it.
 
+If this CLI also installed a Claude Code or Codex plugin, upgrading the CLI does
+not silently move that host marketplace to a new release. After `agent-guard
+update` or `brew upgrade`, synchronize each self-managed host explicitly:
+
+```sh
+agent-guard plugin status --host all
+agent-guard plugin update --host all
+```
+
+When the existing marketplace is pinned to the previous release, `plugin
+update` stops before mutation and prints the exact official host-manager remove
+and reinstall commands. Follow that recovery sequence, restart the host, rerun
+the plugin-local setup and acceptance checks, and re-trust changed Codex hooks.
+Use only the hosts installed on that machine. For Jamf-managed Claude Code,
+advance the managed marketplace tag through the administrator rollout instead.
+
 ## Removing an installation
 
 Remove each route through the manager that owns it: use the Claude Code or

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -256,6 +256,36 @@ plugin_enabled() {
   esac
 }
 
+claude_managed_plugin_present() {
+  jq -e '.[] | select((.id // .pluginId // "") == "agent-guard@agent-guard" and .scope == "managed")' "$1" >/dev/null 2>&1
+}
+
+claude_managed_marketplace_present() {
+  jq -e '.[] | select(.name == "agent-guard"
+    and (.scope == "managed" or .managed == true or .isManaged == true))' "$1" >/dev/null 2>&1
+}
+
+claude_managed_status() {
+  plugin_marketplaces=$1
+  plugin_plugins=$2
+  if claude_managed_plugin_present "$plugin_plugins"; then
+    managed_version=$(jq -r '.[]
+      | select((.id // .pluginId // "") == "agent-guard@agent-guard" and .scope == "managed")
+      | .version // "unknown"' "$plugin_plugins" | head -n 1)
+    if jq -e '.[]
+      | select((.id // .pluginId // "") == "agent-guard@agent-guard" and .scope == "managed")
+      | .enabled == true' "$plugin_plugins" >/dev/null 2>&1; then
+      managed_enabled=enabled
+    else
+      managed_enabled=disabled
+    fi
+    printf 'claude: managed by Jamf/managed settings (plugin installed, %s, version %s)\n' \
+      "$managed_enabled" "$managed_version"
+  else
+    printf '%s\n' 'claude: managed by Jamf/managed settings (marketplace configured, plugin not installed)'
+  fi
+}
+
 plugin_read_state() {
   plugin_host=$1
   plugin_marketplaces=$2
@@ -291,6 +321,19 @@ plugin_for_host() {
     rm -rf "$plugin_tmp"
     printf '%s\n' "$PROGRAM: $plugin_host plugin manager could not report its state" >&2
     return 1
+  fi
+
+  if [ "$plugin_host" = claude ] \
+      && { claude_managed_plugin_present "$plugin_plugins" \
+           || claude_managed_marketplace_present "$plugin_marketplaces"; }; then
+    if [ "$plugin_action" = status ]; then
+      claude_managed_status "$plugin_marketplaces" "$plugin_plugins"
+      rm -rf "$plugin_tmp"
+      return 0
+    fi
+    rm -rf "$plugin_tmp"
+    printf '%s\n' "$PROGRAM: Claude Agent Guard is managed by Jamf/managed settings; ask the administrator to change the pinned marketplace ref instead of using '$PROGRAM plugin $plugin_action'" >&2
+    return 2
   fi
 
   if plugin_marketplace_present "$plugin_host" "$plugin_marketplaces"; then

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -294,12 +294,15 @@ claude_managed_settings_state() (
       || return 2
   fi
 
-  # Keep only merge keys and Agent Guard source classifications in this file;
-  # raw marketplace URLs, policy-helper paths, and unrelated settings never
-  # enter it. The subshell trap also removes a mktemp_file fallback outside the
-  # invocation rundir on every normal return, including parse failures.
+  # Marketplace names remain as merge keys. Raw marketplace values,
+  # policy-helper paths, and unrelated settings never enter this file; only
+  # Agent Guard ownership classifications do. The subshell traps also remove a
+  # mktemp_file fallback outside the invocation rundir on returns and signals.
   managed_summary=$(mktemp_file) || return 2
   trap 'rm -f "$managed_summary"' 0
+  trap 'exit 129' HUP
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
   for managed_file in \
     "$managed_root/managed-settings.json" \
     "$managed_fragments"/*.json; do
@@ -472,6 +475,11 @@ plugin_for_host() {
     fi
     rm -rf "$plugin_tmp"
     printf '%s\n' "$PROGRAM: Claude Agent Guard is managed by Jamf/managed settings; ask the administrator to change the pinned marketplace ref instead of using '$PROGRAM plugin $plugin_action'" >&2
+    return 2
+  fi
+  if [ "$plugin_managed_state" -ne 1 ]; then
+    rm -rf "$plugin_tmp"
+    printf '%s\n' "$PROGRAM: Claude managed settings inspection was interrupted; refusing plugin lifecycle changes" >&2
     return 2
   fi
 

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -585,7 +585,11 @@ plugin_for_host() {
 
 do_plugin() {
   plugin_action=${1:-}
-  case "$plugin_action" in status|install|update|uninstall) shift ;; *) plugin_usage; return 2 ;; esac
+  case "$plugin_action" in
+    status|install|update|uninstall) shift ;;
+    -h|--help|help) plugin_usage; return 0 ;;
+    *) plugin_usage; return 2 ;;
+  esac
   plugin_host=
   plugin_scope=user
   while [ "$#" -gt 0 ]; do

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -174,11 +174,298 @@ Usage:
   agent-guard setup [--install --gitleaks-checksum SHA [--gitleaks-version X.Y.Z]]
   agent-guard doctor
   agent-guard logs [status|export]
+  agent-guard plugin status|install|update|uninstall [--host claude|codex|all] [--scope user|project|local]
   agent-guard update
   agent-guard smoke-test
   agent-guard checksum [VERSION]
   agent-guard version
 EOF
+}
+
+plugin_usage() {
+  cat >&2 <<'EOF'
+Usage:
+  agent-guard plugin status|install|update|uninstall [--host claude|codex|all] [--scope user|project|local]
+
+If --host is omitted, exactly one of claude or codex must be available. Claude
+Code defaults to user scope. Codex supports user scope only.
+EOF
+}
+
+plugin_marketplace_source_ok() {
+  plugin_host=$1
+  plugin_json=$2
+  case "$plugin_host" in
+    claude)
+      jq -e '.[] | select(.name == "agent-guard")
+        | ((.repo // "") == "JeongJaeSoon/agent-guard")' "$plugin_json" >/dev/null 2>&1
+      ;;
+    codex)
+      jq -e '.marketplaces[] | select(.name == "agent-guard")
+        | (.marketplaceSource.source // "") as $source
+        | ($source == "JeongJaeSoon/agent-guard"
+           or $source == "https://github.com/JeongJaeSoon/agent-guard"
+           or $source == "https://github.com/JeongJaeSoon/agent-guard.git")' "$plugin_json" >/dev/null 2>&1
+      ;;
+  esac
+}
+
+plugin_marketplace_present() {
+  plugin_host=$1
+  plugin_json=$2
+  case "$plugin_host" in
+    claude) jq -e '.[] | select(.name == "agent-guard")' "$plugin_json" >/dev/null 2>&1 ;;
+    codex) jq -e '.marketplaces[] | select(.name == "agent-guard")' "$plugin_json" >/dev/null 2>&1 ;;
+  esac
+}
+
+plugin_installed() {
+  plugin_host=$1
+  plugin_json=$2
+  plugin_scope=$3
+  case "$plugin_host" in
+    claude) jq -e --arg scope "$plugin_scope" '.[]
+      | select((.id // .pluginId // "") == "agent-guard@agent-guard" and (.scope // "user") == $scope)' "$plugin_json" >/dev/null 2>&1 ;;
+    codex) jq -e '.installed[] | select(.pluginId == "agent-guard@agent-guard" and .installed == true)' "$plugin_json" >/dev/null 2>&1 ;;
+  esac
+}
+
+plugin_version() {
+  plugin_host=$1
+  plugin_json=$2
+  plugin_scope=$3
+  case "$plugin_host" in
+    claude) jq -r --arg scope "$plugin_scope" '.[]
+      | select((.id // .pluginId // "") == "agent-guard@agent-guard" and (.scope // "user") == $scope)
+      | .version // "unknown"' "$plugin_json" | head -n 1 ;;
+    codex) jq -r '.installed[] | select(.pluginId == "agent-guard@agent-guard") | .version // "unknown"' "$plugin_json" | head -n 1 ;;
+  esac
+}
+
+plugin_enabled() {
+  plugin_host=$1
+  plugin_json=$2
+  plugin_scope=$3
+  case "$plugin_host" in
+    claude) jq -e --arg scope "$plugin_scope" '.[]
+      | select((.id // .pluginId // "") == "agent-guard@agent-guard" and (.scope // "user") == $scope)
+      | .enabled == true' "$plugin_json" >/dev/null 2>&1 ;;
+    codex) jq -e '.installed[]
+      | select(.pluginId == "agent-guard@agent-guard" and .installed == true)
+      | .enabled == true' "$plugin_json" >/dev/null 2>&1 ;;
+  esac
+}
+
+plugin_read_state() {
+  plugin_host=$1
+  plugin_marketplaces=$2
+  plugin_plugins=$3
+  case "$plugin_host" in
+    claude)
+      claude plugin marketplace list --json >"$plugin_marketplaces" \
+        && claude plugin list --json >"$plugin_plugins" \
+        && jq -e 'type == "array"' "$plugin_marketplaces" >/dev/null 2>&1 \
+        && jq -e 'type == "array"' "$plugin_plugins" >/dev/null 2>&1
+      ;;
+    codex)
+      codex plugin marketplace list --json >"$plugin_marketplaces" \
+        && codex plugin list --json >"$plugin_plugins" \
+        && jq -e 'type == "object" and (.marketplaces | type == "array")' "$plugin_marketplaces" >/dev/null 2>&1 \
+        && jq -e 'type == "object" and (.installed | type == "array")' "$plugin_plugins" >/dev/null 2>&1
+      ;;
+  esac
+}
+
+plugin_for_host() {
+  plugin_action=$1
+  plugin_host=$2
+  plugin_scope=$3
+  plugin_tmp=$(mktemp -d "${TMPDIR:-/tmp}/agent-guard-plugin.XXXXXX") || {
+    printf '%s\n' "$PROGRAM: could not create plugin status directory" >&2
+    return 2
+  }
+  plugin_marketplaces="$plugin_tmp/marketplaces.json"
+  plugin_plugins="$plugin_tmp/plugins.json"
+
+  if ! plugin_read_state "$plugin_host" "$plugin_marketplaces" "$plugin_plugins"; then
+    rm -rf "$plugin_tmp"
+    printf '%s\n' "$PROGRAM: $plugin_host plugin manager could not report its state" >&2
+    return 1
+  fi
+
+  if plugin_marketplace_present "$plugin_host" "$plugin_marketplaces"; then
+    if ! plugin_marketplace_source_ok "$plugin_host" "$plugin_marketplaces"; then
+      rm -rf "$plugin_tmp"
+      printf '%s\n' "$PROGRAM: $plugin_host marketplace 'agent-guard' has a different source; refusing to replace it" >&2
+      return 2
+    fi
+    plugin_has_marketplace=1
+  else
+    plugin_has_marketplace=0
+  fi
+  if plugin_installed "$plugin_host" "$plugin_plugins" "$plugin_scope"; then
+    plugin_has_install=1
+    if plugin_enabled "$plugin_host" "$plugin_plugins" "$plugin_scope"; then
+      plugin_is_enabled=1
+    else
+      plugin_is_enabled=0
+    fi
+  else
+    plugin_has_install=0
+    plugin_is_enabled=0
+  fi
+
+  case "$plugin_action" in
+    status)
+      if [ "$plugin_has_install" -eq 1 ]; then
+        printf '%s: installed, %s (version %s, marketplace %s)\n' \
+          "$plugin_host" "$([ "$plugin_is_enabled" -eq 1 ] && printf enabled || printf disabled)" \
+          "$(plugin_version "$plugin_host" "$plugin_plugins" "$plugin_scope")" \
+          "$([ "$plugin_has_marketplace" -eq 1 ] && printf configured || printf missing)"
+      else
+        printf '%s: not installed (marketplace %s)\n' \
+          "$plugin_host" "$([ "$plugin_has_marketplace" -eq 1 ] && printf configured || printf missing)"
+      fi
+      ;;
+    install)
+      if [ "$plugin_has_install" -eq 1 ]; then
+        if [ "$plugin_is_enabled" -eq 0 ]; then
+          printf '%s\n' "$PROGRAM: $plugin_host agent-guard plugin is installed but disabled; enable it with the $plugin_host plugin manager" >&2
+          rm -rf "$plugin_tmp"
+          return 1
+        fi
+        printf '%s: agent-guard plugin is already installed and enabled (version %s)\n' \
+          "$plugin_host" "$(plugin_version "$plugin_host" "$plugin_plugins" "$plugin_scope")"
+      else
+        plugin_marketplace_added=0
+        if [ "$plugin_has_marketplace" -eq 0 ]; then
+          case "$plugin_host" in
+            claude) claude plugin marketplace add JeongJaeSoon/agent-guard --scope "$plugin_scope" || { rm -rf "$plugin_tmp"; return 1; } ;;
+            codex) codex plugin marketplace add JeongJaeSoon/agent-guard || { rm -rf "$plugin_tmp"; return 1; } ;;
+          esac
+          plugin_marketplace_added=1
+        fi
+        case "$plugin_host" in
+          claude) claude plugin install agent-guard@agent-guard --scope "$plugin_scope" ;;
+          codex) codex plugin add agent-guard@agent-guard ;;
+        esac
+        plugin_install_status=$?
+        if [ "$plugin_install_status" -ne 0 ] && [ "$plugin_marketplace_added" -eq 1 ]; then
+          plugin_retry="$PROGRAM plugin install --host $plugin_host"
+          if [ "$plugin_host" = claude ] && [ "$plugin_scope" != user ]; then
+            plugin_retry="$plugin_retry --scope $plugin_scope"
+          fi
+          printf '%s\n' "$PROGRAM: $plugin_host marketplace 'agent-guard' was added, but plugin installation failed; the marketplace remains configured and it is safe to retry '$plugin_retry'" >&2
+        fi
+        [ "$plugin_install_status" -eq 0 ]
+      fi
+      ;;
+    update)
+      if [ "$plugin_has_marketplace" -eq 0 ] || [ "$plugin_has_install" -eq 0 ]; then
+        printf '%s\n' "$PROGRAM: $plugin_host plugin is not installed; run '$PROGRAM plugin install --host $plugin_host' first" >&2
+        rm -rf "$plugin_tmp"
+        return 1
+      fi
+      if [ "$plugin_is_enabled" -eq 0 ]; then
+        printf '%s\n' "$PROGRAM: $plugin_host agent-guard plugin is installed but disabled; update will keep it disabled" >&2
+      fi
+      case "$plugin_host" in
+        claude)
+          claude plugin marketplace update agent-guard \
+            && claude plugin update agent-guard@agent-guard --scope "$plugin_scope"
+          ;;
+        codex) codex plugin marketplace upgrade agent-guard ;;
+      esac
+      ;;
+    uninstall)
+      if [ "$plugin_has_install" -eq 0 ]; then
+        printf '%s\n' "$plugin_host: agent-guard plugin is not installed"
+      else
+        case "$plugin_host" in
+          claude) claude plugin uninstall agent-guard@agent-guard --scope "$plugin_scope" ;;
+          codex) codex plugin remove agent-guard@agent-guard ;;
+        esac
+      fi
+      ;;
+  esac
+  plugin_status=$?
+  rm -rf "$plugin_tmp"
+  return "$plugin_status"
+}
+
+do_plugin() {
+  plugin_action=${1:-}
+  case "$plugin_action" in status|install|update|uninstall) shift ;; *) plugin_usage; return 2 ;; esac
+  plugin_host=
+  plugin_scope=user
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --host)
+        [ "$#" -ge 2 ] || { plugin_usage; return 2; }
+        plugin_host=$2
+        shift 2
+        ;;
+      --scope)
+        [ "$#" -ge 2 ] || { plugin_usage; return 2; }
+        plugin_scope=$2
+        shift 2
+        ;;
+      -h|--help) plugin_usage; return 0 ;;
+      *) plugin_usage; return 2 ;;
+    esac
+  done
+  case "$plugin_host" in ''|claude|codex|all) ;; *) plugin_usage; return 2 ;; esac
+  case "$plugin_scope" in user|project|local) ;; *) plugin_usage; return 2 ;; esac
+  command -v jq >/dev/null 2>&1 || {
+    printf '%s\n' "$PROGRAM: jq is required to inspect plugin-manager state" >&2
+    return 1
+  }
+
+  plugin_has_claude=0
+  plugin_has_codex=0
+  command -v claude >/dev/null 2>&1 && plugin_has_claude=1
+  command -v codex >/dev/null 2>&1 && plugin_has_codex=1
+  if [ -z "$plugin_host" ]; then
+    if [ "$plugin_has_claude" -eq 1 ] && [ "$plugin_has_codex" -eq 0 ]; then
+      plugin_host=claude
+    elif [ "$plugin_has_codex" -eq 1 ] && [ "$plugin_has_claude" -eq 0 ]; then
+      plugin_host=codex
+    else
+      printf '%s\n' "$PROGRAM: omit --host only when exactly one of claude or codex is available" >&2
+      return 2
+    fi
+  fi
+  if { [ "$plugin_host" = codex ] || [ "$plugin_host" = all ]; } && [ "$plugin_scope" != user ]; then
+    printf '%s\n' "$PROGRAM: Codex plugin management supports user scope only" >&2
+    return 2
+  fi
+
+  plugin_result=0
+  case "$plugin_host" in
+    claude)
+      [ "$plugin_has_claude" -eq 1 ] || { printf '%s\n' "$PROGRAM: claude command not found" >&2; return 1; }
+      plugin_for_host "$plugin_action" claude "$plugin_scope"
+      ;;
+    codex)
+      [ "$plugin_has_codex" -eq 1 ] || { printf '%s\n' "$PROGRAM: codex command not found" >&2; return 1; }
+      plugin_for_host "$plugin_action" codex "$plugin_scope"
+      ;;
+    all)
+      if [ "$plugin_has_claude" -eq 1 ]; then
+        plugin_for_host "$plugin_action" claude "$plugin_scope" || plugin_result=1
+      else
+        printf '%s\n' "$PROGRAM: claude command not found" >&2
+        plugin_result=1
+      fi
+      if [ "$plugin_has_codex" -eq 1 ]; then
+        plugin_for_host "$plugin_action" codex "$plugin_scope" || plugin_result=1
+      else
+        printf '%s\n' "$PROGRAM: codex command not found" >&2
+        plugin_result=1
+      fi
+      return "$plugin_result"
+      ;;
+  esac
 }
 
 info() {
@@ -6549,6 +6836,7 @@ case "$cmd" in
   scan-path) shift; scan_path "$@" ;;
   filter-lockfile-hashes) shift; filter_lockfile_hashes "$@" ;;
   logs) shift; audit_logs "$@" ;;
+  plugin) shift; do_plugin "$@" ;;
   check) check_deps ;;
   doctor) shift; do_setup "$@" ;;
   update) shift; do_update "$@" ;;

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -265,7 +265,8 @@ claude_managed_plugin_present() {
 # so a first-sync/download failure cannot make a managed declaration look like a
 # self-managed marketplace. Return 0 for an Agent Guard declaration, 1 when all
 # available files are valid but unrelated, and 2 when their state is unsafe to
-# determine. Mutations fail closed on 2; status reports the configuration error.
+# determine. Return 3 when policyHelper replaces their values dynamically.
+# Mutations fail closed on 2 or 3; status reports the configuration limitation.
 claude_managed_settings_state() (
   # Path injection exists only for isolated tests. It is deliberately gated and
   # does not turn this user-run helper into an OS policy enforcement boundary.
@@ -293,40 +294,62 @@ claude_managed_settings_state() (
       || return 2
   fi
 
-  managed_found=1
+  managed_summary=$(mktemp_file) || return 2
   for managed_file in \
     "$managed_root/managed-settings.json" \
     "$managed_fragments"/*.json; do
     [ -e "$managed_file" ] || [ -L "$managed_file" ] || continue
     [ -f "$managed_file" ] && [ -r "$managed_file" ] || return 2
-    jq -e '
+    jq -c -s '
+      def valid_policy_helper:
+        type == "object" and
+        (.path | type == "string" and startswith("/")) and
+        ((has("timeoutMs") | not) or (.timeoutMs | type == "number")) and
+        ((has("refreshIntervalMs") | not) or
+         (.refreshIntervalMs | type == "number"));
+      if length == 0 then {}
+      elif length == 1 and (.[0] | type == "object") then .[0]
+      else error("managed settings must contain one object")
+      end
+      | if (has("extraKnownMarketplaces") and
+            (.extraKnownMarketplaces | type) != "object") then
+        error("extraKnownMarketplaces must be an object")
+      elif (has("enabledPlugins") and (.enabledPlugins | type) != "object") then
+        error("enabledPlugins must be an object")
+      elif (has("policyHelper") and
+            ((.policyHelper | valid_policy_helper) | not)) then
+        error("policyHelper must name an absolute executable path")
+      else
+        with_entries(select(
+          .key == "extraKnownMarketplaces" or
+          .key == "enabledPlugins" or
+          .key == "policyHelper"))
+      end
+    ' "$managed_file" >>"$managed_summary" 2>/dev/null || return 2
+  done
+
+  managed_state=$(jq -r -s '
       def agent_guard_source:
         type == "object" and
         ((.source == "github" and .repo == "JeongJaeSoon/agent-guard") or
          (.source == "git" and
           (.url == "https://github.com/JeongJaeSoon/agent-guard" or
            .url == "https://github.com/JeongJaeSoon/agent-guard.git")));
-      if type != "object" then error("managed settings must be an object")
-      elif (has("extraKnownMarketplaces") and
-            (.extraKnownMarketplaces | type) != "object") then
-        error("extraKnownMarketplaces must be an object")
-      elif (has("enabledPlugins") and (.enabledPlugins | type) != "object") then
-        error("enabledPlugins must be an object")
-      else
-        ((.extraKnownMarketplaces // {}) as $marketplaces
-         | ($marketplaces | has("agent-guard")) or
-           ($marketplaces | any(.[]; (.source? | agent_guard_source)))) or
-        ((.enabledPlugins // {}) | has("agent-guard@agent-guard"))
-      end
-    ' "$managed_file" >/dev/null 2>&1
-    managed_status=$?
-    case "$managed_status" in
-      0) managed_found=0 ;;
-      1) ;;
-      *) return 2 ;;
-    esac
-  done
-  return "$managed_found"
+      reduce .[] as $document ({}; . * $document)
+      | if has("policyHelper") then "dynamic"
+        elif (((.extraKnownMarketplaces // {})
+               | any(.[]; (.source? | agent_guard_source))) or
+              ((.enabledPlugins // {}) | has("agent-guard@agent-guard"))) then
+          "managed"
+        else "unrelated"
+        end
+    ' "$managed_summary" 2>/dev/null) || return 2
+  case "$managed_state" in
+    managed) return 0 ;;
+    unrelated) return 1 ;;
+    dynamic) return 3 ;;
+    *) return 2 ;;
+  esac
 )
 
 claude_managed_status() {
@@ -402,6 +425,11 @@ plugin_for_host() {
     else
       printf '%s\n' "$PROGRAM: Claude managed settings could not be read or safely parsed; refusing plugin lifecycle changes" >&2
     fi
+    return 2
+  fi
+  if [ "$plugin_managed_state" -eq 3 ]; then
+    rm -rf "$plugin_tmp"
+    printf '%s\n' "$PROGRAM: Claude policyHelper replaces file-based managed settings; plugin ownership cannot be determined, so lifecycle changes are refused" >&2
     return 2
   fi
   if [ "$plugin_managed_state" -eq 0 ]; then

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -293,6 +293,7 @@ claude_managed_settings_state() (
       || return 2
   fi
 
+  managed_found=1
   for managed_file in \
     "$managed_root/managed-settings.json" \
     "$managed_fragments"/*.json; do
@@ -320,12 +321,12 @@ claude_managed_settings_state() (
     ' "$managed_file" >/dev/null 2>&1
     managed_status=$?
     case "$managed_status" in
-      0) return 0 ;;
+      0) managed_found=0 ;;
       1) ;;
       *) return 2 ;;
     esac
   done
-  return 1
+  return "$managed_found"
 )
 
 claude_managed_status() {

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -294,7 +294,12 @@ claude_managed_settings_state() (
       || return 2
   fi
 
+  # Keep only merge keys and Agent Guard source classifications in this file;
+  # raw marketplace URLs, policy-helper paths, and unrelated settings never
+  # enter it. The subshell trap also removes a mktemp_file fallback outside the
+  # invocation rundir on every normal return, including parse failures.
   managed_summary=$(mktemp_file) || return 2
+  trap 'rm -f "$managed_summary"' 0
   for managed_file in \
     "$managed_root/managed-settings.json" \
     "$managed_fragments"/*.json; do
@@ -307,6 +312,28 @@ claude_managed_settings_state() (
         ((has("timeoutMs") | not) or (.timeoutMs | type == "number")) and
         ((has("refreshIntervalMs") | not) or
          (.refreshIntervalMs | type == "number"));
+      def compact_source:
+        {} +
+        (if has("source") then
+           {source: (if .source == "github" or .source == "git"
+                     then .source else "other" end)}
+         else {} end) +
+        (if has("repo") then
+           {repo: (if .repo == "JeongJaeSoon/agent-guard"
+                   then "agent-guard" else "other" end)}
+         else {} end) +
+        (if has("url") then
+           {url: (if .url == "https://github.com/JeongJaeSoon/agent-guard" or
+                       .url == "https://github.com/JeongJaeSoon/agent-guard.git"
+                  then "agent-guard" else "other" end)}
+         else {} end);
+      def compact_marketplace:
+        if type != "object" then "other"
+        elif has("source") and (.source | type) != "object" then
+          {source: "other"}
+        elif has("source") then {source: (.source | compact_source)}
+        else {}
+        end;
       if length == 0 then {}
       elif length == 1 and (.[0] | type == "object") then .[0]
       else error("managed settings must contain one object")
@@ -320,10 +347,16 @@ claude_managed_settings_state() (
             ((.policyHelper | valid_policy_helper) | not)) then
         error("policyHelper must name an absolute executable path")
       else
-        with_entries(select(
-          .key == "extraKnownMarketplaces" or
-          .key == "enabledPlugins" or
-          .key == "policyHelper"))
+        ({
+          extraKnownMarketplaces:
+            ((.extraKnownMarketplaces // {})
+             | with_entries(.value |= compact_marketplace)),
+          enabledPlugins:
+            (if ((.enabledPlugins // {}) | has("agent-guard@agent-guard"))
+             then {"agent-guard@agent-guard": true}
+             else {}
+             end)
+        } + if has("policyHelper") then {policyHelper: true} else {} end)
       end
     ' "$managed_file" >>"$managed_summary" 2>/dev/null || return 2
   done
@@ -331,10 +364,9 @@ claude_managed_settings_state() (
   managed_state=$(jq -r -s '
       def agent_guard_source:
         type == "object" and
-        ((.source == "github" and .repo == "JeongJaeSoon/agent-guard") or
+        ((.source == "github" and .repo == "agent-guard") or
          (.source == "git" and
-          (.url == "https://github.com/JeongJaeSoon/agent-guard" or
-           .url == "https://github.com/JeongJaeSoon/agent-guard.git")));
+          .url == "agent-guard"));
       reduce .[] as $document ({}; . * $document)
       | if has("policyHelper") then "dynamic"
         elif (((.extraKnownMarketplaces // {})

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -260,14 +260,76 @@ claude_managed_plugin_present() {
   jq -e '.[] | select((.id // .pluginId // "") == "agent-guard@agent-guard" and .scope == "managed")' "$1" >/dev/null 2>&1
 }
 
-claude_managed_marketplace_present() {
-  jq -e '.[] | select(.name == "agent-guard"
-    and (.scope == "managed" or .managed == true or .isManaged == true))' "$1" >/dev/null 2>&1
-}
+# Claude's marketplace-list JSON intentionally omits settings provenance for
+# ordinary Git/GitHub marketplaces. Read the administrator-owned source instead
+# so a first-sync/download failure cannot make a managed declaration look like a
+# self-managed marketplace. Return 0 for an Agent Guard declaration, 1 when all
+# available files are valid but unrelated, and 2 when their state is unsafe to
+# determine. Mutations fail closed on 2; status reports the configuration error.
+claude_managed_settings_state() (
+  # Path injection exists only for isolated tests. It is deliberately gated and
+  # does not turn this user-run helper into an OS policy enforcement boundary.
+  if [ "${AG_PLUGIN_TEST_MODE:-0}" = 1 ] \
+      && [ -n "${AG_PLUGIN_TEST_CLAUDE_MANAGED_SETTINGS_ROOT:-}" ]; then
+    managed_root=$AG_PLUGIN_TEST_CLAUDE_MANAGED_SETTINGS_ROOT
+  elif [ -n "${AG_PLUGIN_TEST_CLAUDE_MANAGED_SETTINGS_ROOT:-}" ]; then
+    return 2
+  else
+    case "$(uname -s)" in
+      Darwin) managed_root='/Library/Application Support/ClaudeCode' ;;
+      Linux) managed_root='/etc/claude-code' ;;
+      *) return 1 ;;
+    esac
+  fi
+  case "$managed_root" in /*) ;; *) return 2 ;; esac
+
+  if [ -e "$managed_root" ] || [ -L "$managed_root" ]; then
+    [ -d "$managed_root" ] && [ -r "$managed_root" ] && [ -x "$managed_root" ] \
+      || return 2
+  fi
+  managed_fragments="$managed_root/managed-settings.d"
+  if [ -e "$managed_fragments" ] || [ -L "$managed_fragments" ]; then
+    [ -d "$managed_fragments" ] && [ -r "$managed_fragments" ] && [ -x "$managed_fragments" ] \
+      || return 2
+  fi
+
+  for managed_file in \
+    "$managed_root/managed-settings.json" \
+    "$managed_fragments"/*.json; do
+    [ -e "$managed_file" ] || [ -L "$managed_file" ] || continue
+    [ -f "$managed_file" ] && [ -r "$managed_file" ] || return 2
+    jq -e '
+      def agent_guard_source:
+        type == "object" and
+        ((.source == "github" and .repo == "JeongJaeSoon/agent-guard") or
+         (.source == "git" and
+          (.url == "https://github.com/JeongJaeSoon/agent-guard" or
+           .url == "https://github.com/JeongJaeSoon/agent-guard.git")));
+      if type != "object" then error("managed settings must be an object")
+      elif (has("extraKnownMarketplaces") and
+            (.extraKnownMarketplaces | type) != "object") then
+        error("extraKnownMarketplaces must be an object")
+      elif (has("enabledPlugins") and (.enabledPlugins | type) != "object") then
+        error("enabledPlugins must be an object")
+      else
+        ((.extraKnownMarketplaces // {}) as $marketplaces
+         | ($marketplaces | has("agent-guard")) or
+           ($marketplaces | any(.[]; (.source? | agent_guard_source)))) or
+        ((.enabledPlugins // {}) | has("agent-guard@agent-guard"))
+      end
+    ' "$managed_file" >/dev/null 2>&1
+    managed_status=$?
+    case "$managed_status" in
+      0) return 0 ;;
+      1) ;;
+      *) return 2 ;;
+    esac
+  done
+  return 1
+)
 
 claude_managed_status() {
-  plugin_marketplaces=$1
-  plugin_plugins=$2
+  plugin_plugins=$1
   if claude_managed_plugin_present "$plugin_plugins"; then
     managed_version=$(jq -r '.[]
       | select((.id // .pluginId // "") == "agent-guard@agent-guard" and .scope == "managed")
@@ -282,7 +344,7 @@ claude_managed_status() {
     printf 'claude: managed by Jamf/managed settings (plugin installed, %s, version %s)\n' \
       "$managed_enabled" "$managed_version"
   else
-    printf '%s\n' 'claude: managed by Jamf/managed settings (marketplace configured, plugin not installed)'
+    printf '%s\n' 'claude: managed by Jamf/managed settings (Agent Guard configured, plugin not installed)'
   fi
 }
 
@@ -323,11 +385,27 @@ plugin_for_host() {
     return 1
   fi
 
-  if [ "$plugin_host" = claude ] \
-      && { claude_managed_plugin_present "$plugin_plugins" \
-           || claude_managed_marketplace_present "$plugin_marketplaces"; }; then
+  plugin_managed_state=1
+  if [ "$plugin_host" = claude ]; then
+    if claude_managed_plugin_present "$plugin_plugins"; then
+      plugin_managed_state=0
+    else
+      claude_managed_settings_state
+      plugin_managed_state=$?
+    fi
+  fi
+  if [ "$plugin_managed_state" -eq 2 ]; then
+    rm -rf "$plugin_tmp"
     if [ "$plugin_action" = status ]; then
-      claude_managed_status "$plugin_marketplaces" "$plugin_plugins"
+      printf '%s\n' "$PROGRAM: Claude managed settings could not be read or safely parsed; plugin ownership cannot be determined" >&2
+    else
+      printf '%s\n' "$PROGRAM: Claude managed settings could not be read or safely parsed; refusing plugin lifecycle changes" >&2
+    fi
+    return 2
+  fi
+  if [ "$plugin_managed_state" -eq 0 ]; then
+    if [ "$plugin_action" = status ]; then
+      claude_managed_status "$plugin_plugins"
       rm -rf "$plugin_tmp"
       return 0
     fi

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -189,25 +189,49 @@ Usage:
 
 If --host is omitted, exactly one of claude or codex must be available. Claude
 Code defaults to user scope. Codex supports user scope only.
+
+Marketplaces are pinned to the release tag matching this CLI. If status reports
+marketplace drift, remove that marketplace with the host manager and run install
+again. Host marketplace removal also removes plugins installed from it.
 EOF
 }
 
-plugin_marketplace_source_ok() {
+plugin_marketplace_source_is_agent_guard() {
   plugin_host=$1
   plugin_json=$2
   case "$plugin_host" in
     claude)
       jq -e '.[] | select(.name == "agent-guard")
-        | ((.repo // "") == "JeongJaeSoon/agent-guard")' "$plugin_json" >/dev/null 2>&1
+        | (((.source // "") == "github" and
+            (.repo // "") == "JeongJaeSoon/agent-guard") or
+           ((.source // "") == "git" and
+            ((.url // "") == "https://github.com/JeongJaeSoon/agent-guard" or
+             (.url // "") == "https://github.com/JeongJaeSoon/agent-guard.git")))' \
+        "$plugin_json" >/dev/null 2>&1
       ;;
     codex)
       jq -e '.marketplaces[] | select(.name == "agent-guard")
         | (.marketplaceSource.source // "") as $source
-        | ($source == "JeongJaeSoon/agent-guard"
-           or $source == "https://github.com/JeongJaeSoon/agent-guard"
-           or $source == "https://github.com/JeongJaeSoon/agent-guard.git")' "$plugin_json" >/dev/null 2>&1
+        | ((.marketplaceSource.sourceType // "") == "git") and
+          ($source == "JeongJaeSoon/agent-guard" or
+           $source == "https://github.com/JeongJaeSoon/agent-guard" or
+           $source == "https://github.com/JeongJaeSoon/agent-guard.git")' \
+        "$plugin_json" >/dev/null 2>&1
       ;;
   esac
+}
+
+# Claude exposes the configured Git ref in marketplace-list JSON. Codex 0.153.4
+# does not; for mutating actions we use `marketplace add owner/repo@ref` as the
+# official manager's idempotence probe. It succeeds for the same ref and rejects
+# an existing unpinned or different ref without changing host state.
+claude_marketplace_matches_release() {
+  jq -e --arg ref "v$VERSION" '.[] | select(.name == "agent-guard")
+    | (.ref // "") == $ref' "$1" >/dev/null 2>&1
+}
+
+claude_marketplace_ref() {
+  jq -r '.[] | select(.name == "agent-guard") | .ref // "unpinned"' "$1" | head -n 1
 }
 
 plugin_marketplace_present() {
@@ -400,8 +424,13 @@ claude_managed_status() {
     else
       managed_enabled=disabled
     fi
-    printf 'claude: managed by Jamf/managed settings (plugin installed, %s, version %s)\n' \
-      "$managed_enabled" "$managed_version"
+    if [ "$managed_version" = "$VERSION" ]; then
+      managed_version_status="version $managed_version"
+    else
+      managed_version_status="version $managed_version, expected $VERSION"
+    fi
+    printf 'claude: managed by Jamf/managed settings (plugin installed, %s, %s)\n' \
+      "$managed_enabled" "$managed_version_status"
   else
     printf '%s\n' 'claude: managed by Jamf/managed settings (Agent Guard configured, plugin not installed)'
   fi
@@ -484,14 +513,15 @@ plugin_for_host() {
   fi
 
   if plugin_marketplace_present "$plugin_host" "$plugin_marketplaces"; then
-    if ! plugin_marketplace_source_ok "$plugin_host" "$plugin_marketplaces"; then
-      rm -rf "$plugin_tmp"
-      printf '%s\n' "$PROGRAM: $plugin_host marketplace 'agent-guard' has a different source; refusing to replace it" >&2
-      return 2
-    fi
     plugin_has_marketplace=1
+    if plugin_marketplace_source_is_agent_guard "$plugin_host" "$plugin_marketplaces"; then
+      plugin_marketplace_source=agent-guard
+    else
+      plugin_marketplace_source=conflict
+    fi
   else
     plugin_has_marketplace=0
+    plugin_marketplace_source=missing
   fi
   if plugin_installed "$plugin_host" "$plugin_plugins" "$plugin_scope"; then
     plugin_has_install=1
@@ -507,32 +537,107 @@ plugin_for_host() {
 
   case "$plugin_action" in
     status)
+      case "$plugin_marketplace_source" in
+        agent-guard)
+          if [ "$plugin_host" = claude ]; then
+            if claude_marketplace_matches_release "$plugin_marketplaces"; then
+              plugin_marketplace_status="configured at v$VERSION"
+            else
+              plugin_marketplace_status="drift: $(claude_marketplace_ref "$plugin_marketplaces"), expected v$VERSION"
+            fi
+          else
+            plugin_marketplace_status='configured, pin unverified by Codex'
+          fi
+          ;;
+        conflict) plugin_marketplace_status='conflict: different source' ;;
+        missing) plugin_marketplace_status=missing ;;
+      esac
       if [ "$plugin_has_install" -eq 1 ]; then
-        printf '%s: installed, %s (version %s, marketplace %s)\n' \
+        plugin_installed_version=$(plugin_version "$plugin_host" "$plugin_plugins" "$plugin_scope")
+        if [ "$plugin_installed_version" = "$VERSION" ]; then
+          plugin_version_status="version $plugin_installed_version"
+        else
+          plugin_version_status="version $plugin_installed_version, expected $VERSION"
+        fi
+        printf '%s: installed, %s (%s, marketplace %s)\n' \
           "$plugin_host" "$([ "$plugin_is_enabled" -eq 1 ] && printf enabled || printf disabled)" \
-          "$(plugin_version "$plugin_host" "$plugin_plugins" "$plugin_scope")" \
-          "$([ "$plugin_has_marketplace" -eq 1 ] && printf configured || printf missing)"
+          "$plugin_version_status" "$plugin_marketplace_status"
       else
         printf '%s: not installed (marketplace %s)\n' \
-          "$plugin_host" "$([ "$plugin_has_marketplace" -eq 1 ] && printf configured || printf missing)"
+          "$plugin_host" "$plugin_marketplace_status"
       fi
       ;;
     install)
+      if [ "$plugin_marketplace_source" = conflict ]; then
+        rm -rf "$plugin_tmp"
+        printf '%s\n' "$PROGRAM: $plugin_host marketplace 'agent-guard' has a different source; refusing to replace it" >&2
+        return 2
+      fi
+      if [ "$plugin_marketplace_source" = agent-guard ]; then
+        plugin_marketplace_matches=0
+        case "$plugin_host" in
+          claude)
+            claude_marketplace_matches_release "$plugin_marketplaces" \
+              && plugin_marketplace_matches=1
+            ;;
+          codex)
+            codex plugin marketplace add "JeongJaeSoon/agent-guard@v$VERSION" \
+              && plugin_marketplace_matches=1
+            ;;
+        esac
+        if [ "$plugin_marketplace_matches" -eq 0 ]; then
+          if [ "$plugin_host" = claude ]; then
+            plugin_actual_ref=$(claude_marketplace_ref "$plugin_marketplaces")
+            plugin_remove="claude plugin marketplace remove agent-guard --scope $plugin_scope"
+          else
+            plugin_actual_ref='unverified or different ref'
+            plugin_remove='codex plugin marketplace remove agent-guard'
+          fi
+          plugin_retry="$PROGRAM plugin install --host $plugin_host"
+          if [ "$plugin_host" = claude ] && [ "$plugin_scope" != user ]; then
+            plugin_retry="$plugin_retry --scope $plugin_scope"
+          fi
+          rm -rf "$plugin_tmp"
+          printf '%s\n' "$PROGRAM: $plugin_host marketplace 'agent-guard' is '$plugin_actual_ref', expected 'v$VERSION'; refusing to reuse it" >&2
+          printf '%s\n' "$PROGRAM: run '$plugin_remove', then '$plugin_retry'; marketplace removal also removes its installed plugin" >&2
+          return 2
+        fi
+      fi
       if [ "$plugin_has_install" -eq 1 ]; then
         if [ "$plugin_is_enabled" -eq 0 ]; then
           printf '%s\n' "$PROGRAM: $plugin_host agent-guard plugin is installed but disabled; enable it with the $plugin_host plugin manager" >&2
           rm -rf "$plugin_tmp"
           return 1
         fi
-        printf '%s: agent-guard plugin is already installed and enabled (version %s)\n' \
-          "$plugin_host" "$(plugin_version "$plugin_host" "$plugin_plugins" "$plugin_scope")"
+        plugin_installed_version=$(plugin_version "$plugin_host" "$plugin_plugins" "$plugin_scope")
+        if [ "$plugin_installed_version" != "$VERSION" ]; then
+          plugin_retry="$PROGRAM plugin update --host $plugin_host"
+          if [ "$plugin_host" = claude ] && [ "$plugin_scope" != user ]; then
+            plugin_retry="$plugin_retry --scope $plugin_scope"
+          fi
+          rm -rf "$plugin_tmp"
+          printf '%s\n' "$PROGRAM: $plugin_host agent-guard plugin version is $plugin_installed_version, expected $VERSION; run '$plugin_retry'" >&2
+          return 1
+        fi
+        printf '%s: agent-guard plugin is already installed and enabled (version %s, marketplace v%s)\n' \
+          "$plugin_host" "$plugin_installed_version" "$VERSION"
       else
         plugin_marketplace_added=0
         if [ "$plugin_has_marketplace" -eq 0 ]; then
           case "$plugin_host" in
-            claude) claude plugin marketplace add JeongJaeSoon/agent-guard --scope "$plugin_scope" || { rm -rf "$plugin_tmp"; return 1; } ;;
-            codex) codex plugin marketplace add JeongJaeSoon/agent-guard || { rm -rf "$plugin_tmp"; return 1; } ;;
+            claude) claude plugin marketplace add "JeongJaeSoon/agent-guard@v$VERSION" --scope "$plugin_scope" ;;
+            codex) codex plugin marketplace add "JeongJaeSoon/agent-guard@v$VERSION" ;;
           esac
+          plugin_add_status=$?
+          if [ "$plugin_add_status" -ne 0 ]; then
+            plugin_retry="$PROGRAM plugin install --host $plugin_host"
+            if [ "$plugin_host" = claude ] && [ "$plugin_scope" != user ]; then
+              plugin_retry="$plugin_retry --scope $plugin_scope"
+            fi
+            rm -rf "$plugin_tmp"
+            printf '%s\n' "$PROGRAM: $plugin_host could not add marketplace 'agent-guard' pinned to v$VERSION; no plugin installation was attempted and it is safe to retry '$plugin_retry'" >&2
+            return 1
+          fi
           plugin_marketplace_added=1
         fi
         case "$plugin_host" in
@@ -551,13 +656,53 @@ plugin_for_host() {
       fi
       ;;
     update)
+      if [ "$plugin_marketplace_source" = conflict ]; then
+        rm -rf "$plugin_tmp"
+        printf '%s\n' "$PROGRAM: $plugin_host marketplace 'agent-guard' has a different source; refusing to replace it" >&2
+        return 2
+      fi
       if [ "$plugin_has_marketplace" -eq 0 ] || [ "$plugin_has_install" -eq 0 ]; then
         printf '%s\n' "$PROGRAM: $plugin_host plugin is not installed; run '$PROGRAM plugin install --host $plugin_host' first" >&2
         rm -rf "$plugin_tmp"
         return 1
       fi
+      plugin_marketplace_matches=0
+      case "$plugin_host" in
+        claude)
+          claude_marketplace_matches_release "$plugin_marketplaces" \
+            && plugin_marketplace_matches=1
+          ;;
+        codex)
+          codex plugin marketplace add "JeongJaeSoon/agent-guard@v$VERSION" \
+            && plugin_marketplace_matches=1
+          ;;
+      esac
+      if [ "$plugin_marketplace_matches" -eq 0 ]; then
+        if [ "$plugin_host" = claude ]; then
+          plugin_actual_ref=$(claude_marketplace_ref "$plugin_marketplaces")
+          plugin_remove="claude plugin marketplace remove agent-guard --scope $plugin_scope"
+        else
+          plugin_actual_ref='unverified or different ref'
+          plugin_remove='codex plugin marketplace remove agent-guard'
+        fi
+        plugin_retry="$PROGRAM plugin install --host $plugin_host"
+        if [ "$plugin_host" = claude ] && [ "$plugin_scope" != user ]; then
+          plugin_retry="$plugin_retry --scope $plugin_scope"
+        fi
+        rm -rf "$plugin_tmp"
+        printf '%s\n' "$PROGRAM: $plugin_host marketplace 'agent-guard' is '$plugin_actual_ref', expected 'v$VERSION'; refusing to update through it" >&2
+        printf '%s\n' "$PROGRAM: run '$plugin_remove', then '$plugin_retry'; marketplace removal also removes its installed plugin" >&2
+        return 2
+      fi
       if [ "$plugin_is_enabled" -eq 0 ]; then
         printf '%s\n' "$PROGRAM: $plugin_host agent-guard plugin is installed but disabled; update will keep it disabled" >&2
+      fi
+      plugin_installed_version=$(plugin_version "$plugin_host" "$plugin_plugins" "$plugin_scope")
+      if [ "$plugin_installed_version" = "$VERSION" ]; then
+        printf '%s: agent-guard plugin already matches this CLI (version %s, marketplace v%s)\n' \
+          "$plugin_host" "$VERSION" "$VERSION"
+        rm -rf "$plugin_tmp"
+        return 0
       fi
       case "$plugin_host" in
         claude)
@@ -566,8 +711,22 @@ plugin_for_host() {
           ;;
         codex) codex plugin marketplace upgrade agent-guard ;;
       esac
+      plugin_update_status=$?
+      if [ "$plugin_update_status" -ne 0 ]; then
+        plugin_retry="$PROGRAM plugin update --host $plugin_host"
+        if [ "$plugin_host" = claude ] && [ "$plugin_scope" != user ]; then
+          plugin_retry="$plugin_retry --scope $plugin_scope"
+        fi
+        printf '%s\n' "$PROGRAM: $plugin_host update did not complete; the marketplace remains pinned to v$VERSION and it is safe to retry '$plugin_retry'" >&2
+      fi
+      [ "$plugin_update_status" -eq 0 ]
       ;;
     uninstall)
+      if [ "$plugin_marketplace_source" = conflict ]; then
+        rm -rf "$plugin_tmp"
+        printf '%s\n' "$PROGRAM: $plugin_host marketplace 'agent-guard' has a different source; refusing plugin lifecycle changes" >&2
+        return 2
+      fi
       if [ "$plugin_has_install" -eq 0 ]; then
         printf '%s\n' "$plugin_host: agent-guard plugin is not installed"
       else

--- a/tests/fixtures/mock-plugin-manager
+++ b/tests/fixtures/mock-plugin-manager
@@ -2,6 +2,10 @@
 set -u
 
 host=${0##*/}
+expected_version=${AG_PLUGIN_TEST_EXPECTED_VERSION:?}
+expected_tag=${AG_PLUGIN_TEST_EXPECTED_TAG:?}
+old_version=${AG_PLUGIN_TEST_OLD_VERSION:?}
+old_tag=${AG_PLUGIN_TEST_OLD_TAG:?}
 printf '%s %s\n' "$host" "$*" >>"$AG_PLUGIN_TEST_LOG"
 
 case "$host:$*" in
@@ -11,7 +15,7 @@ esac
 # Codex 0.153.4 omits Git refs from marketplace-list JSON. Its add command is
 # the read-safe identity probe: the same ref succeeds idempotently, while an
 # existing unpinned or different ref fails without changing manager state.
-if [ "$host:$*" = "codex:plugin marketplace add JeongJaeSoon/agent-guard@v3.4.0" ]; then
+if [ "$host:$*" = "codex:plugin marketplace add JeongJaeSoon/agent-guard@$expected_tag" ]; then
   case "${AG_PLUGIN_TEST_MARKETPLACE:-absent}" in
     unpinned|old) exit 1 ;;
   esac
@@ -33,9 +37,9 @@ fi
 if [ "$1 $2 $3" = 'plugin marketplace list' ]; then
   case "$host:${AG_PLUGIN_TEST_MARKETPLACE:-absent}" in
     claude:absent) printf '%s\n' '[]' ;;
-    claude:ok) printf '%s\n' '[{"name":"agent-guard","source":"github","repo":"JeongJaeSoon/agent-guard","ref":"v3.4.0","installLocation":"/fixture/agent-guard"}]' ;;
+    claude:ok) printf '[{"name":"agent-guard","source":"github","repo":"JeongJaeSoon/agent-guard","ref":"%s","installLocation":"/fixture/agent-guard"}]\n' "$expected_tag" ;;
     claude:unpinned) printf '%s\n' '[{"name":"agent-guard","source":"github","repo":"JeongJaeSoon/agent-guard","installLocation":"/fixture/agent-guard"}]' ;;
-    claude:old) printf '%s\n' '[{"name":"agent-guard","source":"github","repo":"JeongJaeSoon/agent-guard","ref":"v3.3.0","installLocation":"/fixture/agent-guard"}]' ;;
+    claude:old) printf '[{"name":"agent-guard","source":"github","repo":"JeongJaeSoon/agent-guard","ref":"%s","installLocation":"/fixture/agent-guard"}]\n' "$old_tag" ;;
     claude:conflict) printf '%s\n' '[{"name":"agent-guard","repo":"someone/else"}]' ;;
     codex:absent) printf '%s\n' '{"marketplaces":[]}' ;;
     codex:ok) printf '%s\n' '{"marketplaces":[{"name":"agent-guard","marketplaceSource":{"sourceType":"git","source":"https://github.com/JeongJaeSoon/agent-guard.git"}}]}' ;;
@@ -49,17 +53,17 @@ fi
 if [ "$1 $2" = 'plugin list' ]; then
   case "$host:${AG_PLUGIN_TEST_INSTALLED:-0}" in
     claude:0) printf '%s\n' '[]' ;;
-    claude:1) printf '%s\n' '[{"id":"agent-guard@agent-guard","version":"3.4.0","scope":"user","enabled":true}]' ;;
-    claude:project) printf '%s\n' '[{"id":"agent-guard@agent-guard","version":"3.4.0","scope":"project","enabled":true}]' ;;
-    claude:project_old) printf '%s\n' '[{"id":"agent-guard@agent-guard","version":"3.3.0","scope":"project","enabled":true}]' ;;
-    claude:disabled) printf '%s\n' '[{"id":"agent-guard@agent-guard","version":"3.4.0","scope":"user","enabled":false}]' ;;
-    claude:old) printf '%s\n' '[{"id":"agent-guard@agent-guard","version":"3.3.0","scope":"user","enabled":true}]' ;;
-    claude:managed) printf '%s\n' '[{"id":"agent-guard@agent-guard","version":"3.4.0","scope":"managed","enabled":true}]' ;;
-    claude:managed_disabled) printf '%s\n' '[{"id":"agent-guard@agent-guard","version":"3.4.0","scope":"managed","enabled":false}]' ;;
+    claude:1) printf '[{"id":"agent-guard@agent-guard","version":"%s","scope":"user","enabled":true}]\n' "$expected_version" ;;
+    claude:project) printf '[{"id":"agent-guard@agent-guard","version":"%s","scope":"project","enabled":true}]\n' "$expected_version" ;;
+    claude:project_old) printf '[{"id":"agent-guard@agent-guard","version":"%s","scope":"project","enabled":true}]\n' "$old_version" ;;
+    claude:disabled) printf '[{"id":"agent-guard@agent-guard","version":"%s","scope":"user","enabled":false}]\n' "$expected_version" ;;
+    claude:old) printf '[{"id":"agent-guard@agent-guard","version":"%s","scope":"user","enabled":true}]\n' "$old_version" ;;
+    claude:managed) printf '[{"id":"agent-guard@agent-guard","version":"%s","scope":"managed","enabled":true}]\n' "$expected_version" ;;
+    claude:managed_disabled) printf '[{"id":"agent-guard@agent-guard","version":"%s","scope":"managed","enabled":false}]\n' "$expected_version" ;;
     codex:0) printf '%s\n' '{"installed":[]}' ;;
-    codex:1) printf '%s\n' '{"installed":[{"pluginId":"agent-guard@agent-guard","version":"3.4.0","installed":true,"enabled":true}]}' ;;
-    codex:disabled) printf '%s\n' '{"installed":[{"pluginId":"agent-guard@agent-guard","version":"3.4.0","installed":true,"enabled":false}]}' ;;
-    codex:old) printf '%s\n' '{"installed":[{"pluginId":"agent-guard@agent-guard","version":"3.3.0","installed":true,"enabled":true}]}' ;;
+    codex:1) printf '{"installed":[{"pluginId":"agent-guard@agent-guard","version":"%s","installed":true,"enabled":true}]}\n' "$expected_version" ;;
+    codex:disabled) printf '{"installed":[{"pluginId":"agent-guard@agent-guard","version":"%s","installed":true,"enabled":false}]}\n' "$expected_version" ;;
+    codex:old) printf '{"installed":[{"pluginId":"agent-guard@agent-guard","version":"%s","installed":true,"enabled":true}]}\n' "$old_version" ;;
   esac
 fi
 

--- a/tests/fixtures/mock-plugin-manager
+++ b/tests/fixtures/mock-plugin-manager
@@ -24,9 +24,8 @@ fi
 if [ "$1 $2 $3" = 'plugin marketplace list' ]; then
   case "$host:${AG_PLUGIN_TEST_MARKETPLACE:-absent}" in
     claude:absent) printf '%s\n' '[]' ;;
-    claude:ok) printf '%s\n' '[{"name":"agent-guard","repo":"JeongJaeSoon/agent-guard"}]' ;;
+    claude:ok) printf '%s\n' '[{"name":"agent-guard","source":"github","repo":"JeongJaeSoon/agent-guard","ref":"v3.4.0","installLocation":"/fixture/agent-guard"}]' ;;
     claude:conflict) printf '%s\n' '[{"name":"agent-guard","repo":"someone/else"}]' ;;
-    claude:managed) printf '%s\n' '[{"name":"agent-guard","repo":"JeongJaeSoon/agent-guard","scope":"managed"}]' ;;
     codex:absent) printf '%s\n' '{"marketplaces":[]}' ;;
     codex:ok) printf '%s\n' '{"marketplaces":[{"name":"agent-guard","marketplaceSource":{"sourceType":"git","source":"https://github.com/JeongJaeSoon/agent-guard.git"}}]}' ;;
     codex:conflict) printf '%s\n' '{"marketplaces":[{"name":"agent-guard","marketplaceSource":{"sourceType":"local","source":"/another/source"}}]}' ;;

--- a/tests/fixtures/mock-plugin-manager
+++ b/tests/fixtures/mock-plugin-manager
@@ -26,6 +26,7 @@ if [ "$1 $2 $3" = 'plugin marketplace list' ]; then
     claude:absent) printf '%s\n' '[]' ;;
     claude:ok) printf '%s\n' '[{"name":"agent-guard","repo":"JeongJaeSoon/agent-guard"}]' ;;
     claude:conflict) printf '%s\n' '[{"name":"agent-guard","repo":"someone/else"}]' ;;
+    claude:managed) printf '%s\n' '[{"name":"agent-guard","repo":"JeongJaeSoon/agent-guard","scope":"managed"}]' ;;
     codex:absent) printf '%s\n' '{"marketplaces":[]}' ;;
     codex:ok) printf '%s\n' '{"marketplaces":[{"name":"agent-guard","marketplaceSource":{"sourceType":"git","source":"https://github.com/JeongJaeSoon/agent-guard.git"}}]}' ;;
     codex:conflict) printf '%s\n' '{"marketplaces":[{"name":"agent-guard","marketplaceSource":{"sourceType":"local","source":"/another/source"}}]}' ;;
@@ -39,6 +40,8 @@ if [ "$1 $2" = 'plugin list' ]; then
     claude:1) printf '%s\n' '[{"id":"agent-guard@agent-guard","version":"3.4.0","scope":"user","enabled":true}]' ;;
     claude:project) printf '%s\n' '[{"id":"agent-guard@agent-guard","version":"3.4.0","scope":"project","enabled":true}]' ;;
     claude:disabled) printf '%s\n' '[{"id":"agent-guard@agent-guard","version":"3.4.0","scope":"user","enabled":false}]' ;;
+    claude:managed) printf '%s\n' '[{"id":"agent-guard@agent-guard","version":"3.4.0","scope":"managed","enabled":true}]' ;;
+    claude:managed_disabled) printf '%s\n' '[{"id":"agent-guard@agent-guard","version":"3.4.0","scope":"managed","enabled":false}]' ;;
     codex:0) printf '%s\n' '{"installed":[]}' ;;
     codex:1) printf '%s\n' '{"installed":[{"pluginId":"agent-guard@agent-guard","version":"3.4.0","installed":true,"enabled":true}]}' ;;
     codex:disabled) printf '%s\n' '{"installed":[{"pluginId":"agent-guard@agent-guard","version":"3.4.0","installed":true,"enabled":false}]}' ;;

--- a/tests/fixtures/mock-plugin-manager
+++ b/tests/fixtures/mock-plugin-manager
@@ -1,0 +1,48 @@
+#!/usr/bin/env sh
+set -u
+
+host=${0##*/}
+printf '%s %s\n' "$host" "$*" >>"$AG_PLUGIN_TEST_LOG"
+
+case "$host:$*" in
+  "${AG_PLUGIN_TEST_FAIL:-__never__}"*) exit 1 ;;
+esac
+
+if [ "${AG_PLUGIN_TEST_SCHEMA:-normal}" = malformed ]; then
+  printf '%s\n' '{not-json'
+  exit 0
+fi
+
+if [ "${AG_PLUGIN_TEST_SCHEMA:-normal}" = drift ]; then
+  case "$1 $2 $3" in
+    'plugin marketplace list') printf '%s\n' '{"sources":[]}' ;;
+    *) printf '%s\n' '{"plugins":[]}' ;;
+  esac
+  exit 0
+fi
+
+if [ "$1 $2 $3" = 'plugin marketplace list' ]; then
+  case "$host:${AG_PLUGIN_TEST_MARKETPLACE:-absent}" in
+    claude:absent) printf '%s\n' '[]' ;;
+    claude:ok) printf '%s\n' '[{"name":"agent-guard","repo":"JeongJaeSoon/agent-guard"}]' ;;
+    claude:conflict) printf '%s\n' '[{"name":"agent-guard","repo":"someone/else"}]' ;;
+    codex:absent) printf '%s\n' '{"marketplaces":[]}' ;;
+    codex:ok) printf '%s\n' '{"marketplaces":[{"name":"agent-guard","marketplaceSource":{"sourceType":"git","source":"https://github.com/JeongJaeSoon/agent-guard.git"}}]}' ;;
+    codex:conflict) printf '%s\n' '{"marketplaces":[{"name":"agent-guard","marketplaceSource":{"sourceType":"local","source":"/another/source"}}]}' ;;
+  esac
+  exit 0
+fi
+
+if [ "$1 $2" = 'plugin list' ]; then
+  case "$host:${AG_PLUGIN_TEST_INSTALLED:-0}" in
+    claude:0) printf '%s\n' '[]' ;;
+    claude:1) printf '%s\n' '[{"id":"agent-guard@agent-guard","version":"3.4.0","scope":"user","enabled":true}]' ;;
+    claude:project) printf '%s\n' '[{"id":"agent-guard@agent-guard","version":"3.4.0","scope":"project","enabled":true}]' ;;
+    claude:disabled) printf '%s\n' '[{"id":"agent-guard@agent-guard","version":"3.4.0","scope":"user","enabled":false}]' ;;
+    codex:0) printf '%s\n' '{"installed":[]}' ;;
+    codex:1) printf '%s\n' '{"installed":[{"pluginId":"agent-guard@agent-guard","version":"3.4.0","installed":true,"enabled":true}]}' ;;
+    codex:disabled) printf '%s\n' '{"installed":[{"pluginId":"agent-guard@agent-guard","version":"3.4.0","installed":true,"enabled":false}]}' ;;
+  esac
+fi
+
+exit 0

--- a/tests/fixtures/mock-plugin-manager
+++ b/tests/fixtures/mock-plugin-manager
@@ -8,6 +8,15 @@ case "$host:$*" in
   "${AG_PLUGIN_TEST_FAIL:-__never__}"*) exit 1 ;;
 esac
 
+# Codex 0.153.4 omits Git refs from marketplace-list JSON. Its add command is
+# the read-safe identity probe: the same ref succeeds idempotently, while an
+# existing unpinned or different ref fails without changing manager state.
+if [ "$host:$*" = "codex:plugin marketplace add JeongJaeSoon/agent-guard@v3.4.0" ]; then
+  case "${AG_PLUGIN_TEST_MARKETPLACE:-absent}" in
+    unpinned|old) exit 1 ;;
+  esac
+fi
+
 if [ "${AG_PLUGIN_TEST_SCHEMA:-normal}" = malformed ]; then
   printf '%s\n' '{not-json'
   exit 0
@@ -25,9 +34,13 @@ if [ "$1 $2 $3" = 'plugin marketplace list' ]; then
   case "$host:${AG_PLUGIN_TEST_MARKETPLACE:-absent}" in
     claude:absent) printf '%s\n' '[]' ;;
     claude:ok) printf '%s\n' '[{"name":"agent-guard","source":"github","repo":"JeongJaeSoon/agent-guard","ref":"v3.4.0","installLocation":"/fixture/agent-guard"}]' ;;
+    claude:unpinned) printf '%s\n' '[{"name":"agent-guard","source":"github","repo":"JeongJaeSoon/agent-guard","installLocation":"/fixture/agent-guard"}]' ;;
+    claude:old) printf '%s\n' '[{"name":"agent-guard","source":"github","repo":"JeongJaeSoon/agent-guard","ref":"v3.3.0","installLocation":"/fixture/agent-guard"}]' ;;
     claude:conflict) printf '%s\n' '[{"name":"agent-guard","repo":"someone/else"}]' ;;
     codex:absent) printf '%s\n' '{"marketplaces":[]}' ;;
     codex:ok) printf '%s\n' '{"marketplaces":[{"name":"agent-guard","marketplaceSource":{"sourceType":"git","source":"https://github.com/JeongJaeSoon/agent-guard.git"}}]}' ;;
+    codex:unpinned) printf '%s\n' '{"marketplaces":[{"name":"agent-guard","marketplaceSource":{"sourceType":"git","source":"https://github.com/JeongJaeSoon/agent-guard.git"}}]}' ;;
+    codex:old) printf '%s\n' '{"marketplaces":[{"name":"agent-guard","marketplaceSource":{"sourceType":"git","source":"https://github.com/JeongJaeSoon/agent-guard.git"}}]}' ;;
     codex:conflict) printf '%s\n' '{"marketplaces":[{"name":"agent-guard","marketplaceSource":{"sourceType":"local","source":"/another/source"}}]}' ;;
   esac
   exit 0
@@ -38,12 +51,15 @@ if [ "$1 $2" = 'plugin list' ]; then
     claude:0) printf '%s\n' '[]' ;;
     claude:1) printf '%s\n' '[{"id":"agent-guard@agent-guard","version":"3.4.0","scope":"user","enabled":true}]' ;;
     claude:project) printf '%s\n' '[{"id":"agent-guard@agent-guard","version":"3.4.0","scope":"project","enabled":true}]' ;;
+    claude:project_old) printf '%s\n' '[{"id":"agent-guard@agent-guard","version":"3.3.0","scope":"project","enabled":true}]' ;;
     claude:disabled) printf '%s\n' '[{"id":"agent-guard@agent-guard","version":"3.4.0","scope":"user","enabled":false}]' ;;
+    claude:old) printf '%s\n' '[{"id":"agent-guard@agent-guard","version":"3.3.0","scope":"user","enabled":true}]' ;;
     claude:managed) printf '%s\n' '[{"id":"agent-guard@agent-guard","version":"3.4.0","scope":"managed","enabled":true}]' ;;
     claude:managed_disabled) printf '%s\n' '[{"id":"agent-guard@agent-guard","version":"3.4.0","scope":"managed","enabled":false}]' ;;
     codex:0) printf '%s\n' '{"installed":[]}' ;;
     codex:1) printf '%s\n' '{"installed":[{"pluginId":"agent-guard@agent-guard","version":"3.4.0","installed":true,"enabled":true}]}' ;;
     codex:disabled) printf '%s\n' '{"installed":[{"pluginId":"agent-guard@agent-guard","version":"3.4.0","installed":true,"enabled":false}]}' ;;
+    codex:old) printf '%s\n' '{"installed":[{"pluginId":"agent-guard@agent-guard","version":"3.3.0","installed":true,"enabled":true}]}' ;;
   esac
 fi
 

--- a/tests/plugin-management.sh
+++ b/tests/plugin-management.sh
@@ -279,6 +279,23 @@ else
   not_ok 'unreadable or non-regular managed fragments block before mutation'
 fi
 
+for invalid_trailing_action in status install; do
+  new_case "claude_managed_base_trailing_malformed_${invalid_trailing_action}"
+  add_host claude
+  export AG_PLUGIN_TEST_MARKETPLACE=ok AG_PLUGIN_TEST_INSTALLED=0
+  write_managed_base '{"enabledPlugins":{"agent-guard@agent-guard":true}}'
+  write_managed_fragment trailing '{not-json'
+  if run_guard plugin "$invalid_trailing_action" --host claude; then
+    not_ok "Claude $invalid_trailing_action validates fragments after a managed base match"
+  elif [ "$?" -eq 2 ] \
+     && grep -q 'could not be read or safely parsed' "$case_dir/err" \
+     && ! grep -Eq 'marketplace (add|update)|plugin (install|update|uninstall)' "$case_log"; then
+    ok "Claude $invalid_trailing_action fails closed on a malformed trailing managed fragment"
+  else
+    not_ok "Claude $invalid_trailing_action fails closed on a malformed trailing managed fragment"
+  fi
+done
+
 new_case claude_update
 add_host claude
 export AG_PLUGIN_TEST_MARKETPLACE=ok AG_PLUGIN_TEST_INSTALLED=project

--- a/tests/plugin-management.sh
+++ b/tests/plugin-management.sh
@@ -167,6 +167,46 @@ else
   not_ok 'install refuses a same-name marketplace from another source'
 fi
 
+new_case claude_managed_plugin_status
+add_host claude
+export AG_PLUGIN_TEST_MARKETPLACE=ok AG_PLUGIN_TEST_INSTALLED=managed_disabled
+if run_guard plugin status --host claude \
+   && grep -q 'managed by Jamf/managed settings (plugin installed, disabled, version 3.4.0)' "$case_dir/out"; then
+  ok 'Claude status identifies a managed disabled plugin and its version'
+else
+  not_ok 'Claude status identifies a managed disabled plugin and its version'
+fi
+
+new_case claude_managed_marketplace_status
+add_host claude
+export AG_PLUGIN_TEST_MARKETPLACE=managed AG_PLUGIN_TEST_INSTALLED=0
+if run_guard plugin status --host claude \
+   && grep -q 'managed by Jamf/managed settings (marketplace configured, plugin not installed)' "$case_dir/out"; then
+  ok 'Claude status identifies a managed marketplace without a plugin'
+else
+  not_ok 'Claude status identifies a managed marketplace without a plugin'
+fi
+
+for managed_state in plugin marketplace; do
+  for managed_action in install update uninstall; do
+    new_case "claude_managed_${managed_state}_${managed_action}"
+    add_host claude
+    case "$managed_state" in
+      plugin) export AG_PLUGIN_TEST_MARKETPLACE=ok AG_PLUGIN_TEST_INSTALLED=managed ;;
+      marketplace) export AG_PLUGIN_TEST_MARKETPLACE=managed AG_PLUGIN_TEST_INSTALLED=0 ;;
+    esac
+    if run_guard plugin "$managed_action" --host claude; then
+      not_ok "Claude $managed_action refuses a managed $managed_state"
+    elif [ "$?" -eq 2 ] \
+       && grep -q 'ask the administrator to change the pinned marketplace ref' "$case_dir/err" \
+       && ! grep -Eq 'marketplace (add|update)|plugin (install|update|uninstall)' "$case_log"; then
+      ok "Claude $managed_action refuses a managed $managed_state before mutation"
+    else
+      not_ok "Claude $managed_action refuses a managed $managed_state before mutation"
+    fi
+  done
+done
+
 new_case claude_update
 add_host claude
 export AG_PLUGIN_TEST_MARKETPLACE=ok AG_PLUGIN_TEST_INSTALLED=project

--- a/tests/plugin-management.sh
+++ b/tests/plugin-management.sh
@@ -99,6 +99,15 @@ run_guard() {
   PATH="$case_bin:/usr/bin:/bin" "$GUARD" "$@" >"$case_dir/out" 2>"$case_dir/err"
 }
 
+new_case plugin_help
+if run_guard plugin --help \
+   && grep -Fq 'agent-guard plugin status|install|update|uninstall' "$case_dir/err" \
+   && [ ! -s "$case_log" ]; then
+  ok 'plugin help exits successfully without calling a host manager'
+else
+  not_ok 'plugin help exits successfully without calling a host manager'
+fi
+
 new_case no_host
 if run_guard plugin status; then
   not_ok 'plugin host auto-detection rejects no host'

--- a/tests/plugin-management.sh
+++ b/tests/plugin-management.sh
@@ -251,6 +251,67 @@ else
   not_ok 'unrelated managed settings do not block self-managed installation'
 fi
 
+new_case claude_unarmed_test_root_override
+add_host claude
+export AG_PLUGIN_TEST_MODE=0
+if run_guard plugin install --host claude; then
+  not_ok 'a managed-settings test root requires explicit test mode'
+elif [ "$?" -eq 2 ] \
+   && grep -q 'could not be read or safely parsed' "$case_dir/err" \
+   && ! grep -Eq 'marketplace (add|update)|plugin (install|update|uninstall)' "$case_log"; then
+  ok 'a managed-settings test root is rejected outside explicit test mode'
+else
+  not_ok 'a managed-settings test root is rejected outside explicit test mode'
+fi
+
+new_case claude_empty_managed_settings
+add_host claude
+: >"$case_managed/managed-settings.json"
+if run_guard plugin install --host claude \
+   && grep -Fxq 'claude plugin marketplace add JeongJaeSoon/agent-guard --scope user' "$case_log" \
+   && grep -Fxq 'claude plugin install agent-guard@agent-guard --scope user' "$case_log"; then
+  ok 'an empty managed settings file is treated as an unrelated empty object'
+else
+  not_ok 'an empty managed settings file is treated as an unrelated empty object'
+fi
+
+new_case claude_marketplace_override_unrelated
+add_host claude
+write_managed_base '{"extraKnownMarketplaces":{"agent-guard":{"source":{"source":"github","repo":"JeongJaeSoon/agent-guard"}}}}'
+write_managed_fragment override '{"extraKnownMarketplaces":{"agent-guard":{"source":{"repo":"example/other"}}}}'
+if run_guard plugin status --host claude \
+   && grep -q '^claude: not installed (marketplace missing)$' "$case_dir/out"; then
+  ok 'a later drop-in marketplace override determines the final managed state'
+else
+  not_ok 'a later drop-in marketplace override determines the final managed state'
+fi
+
+new_case claude_marketplace_override_managed
+add_host claude
+write_managed_base '{"extraKnownMarketplaces":{"security":{"source":{"source":"github","repo":"example/other"}}}}'
+write_managed_fragment override '{"extraKnownMarketplaces":{"security":{"source":{"repo":"JeongJaeSoon/agent-guard"}}}}'
+if run_guard plugin status --host claude \
+   && grep -q 'managed by Jamf/managed settings (Agent Guard configured, plugin not installed)' "$case_dir/out"; then
+  ok 'a later drop-in can make the final merged marketplace managed'
+else
+  not_ok 'a later drop-in can make the final merged marketplace managed'
+fi
+
+for policy_helper_action in status install; do
+  new_case "claude_policy_helper_${policy_helper_action}"
+  add_host claude
+  write_managed_base '{"policyHelper":{"path":"/usr/local/bin/claude-policy","timeoutMs":5000},"extraKnownMarketplaces":{"agent-guard":{"source":{"source":"github","repo":"JeongJaeSoon/agent-guard"}}}}'
+  if run_guard plugin "$policy_helper_action" --host claude; then
+    not_ok "Claude $policy_helper_action rejects dynamic managed settings ownership"
+  elif [ "$?" -eq 2 ] \
+     && grep -q 'policyHelper replaces file-based managed settings' "$case_dir/err" \
+     && ! grep -Eq 'marketplace (add|update)|plugin (install|update|uninstall)' "$case_log"; then
+    ok "Claude $policy_helper_action fails closed when policyHelper replaces file settings"
+  else
+    not_ok "Claude $policy_helper_action fails closed when policyHelper replaces file settings"
+  fi
+done
+
 new_case claude_malformed_managed_settings
 add_host claude
 export AG_PLUGIN_TEST_MARKETPLACE=ok AG_PLUGIN_TEST_INSTALLED=0

--- a/tests/plugin-management.sh
+++ b/tests/plugin-management.sh
@@ -1,0 +1,270 @@
+#!/usr/bin/env sh
+set -u
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd -P)
+GUARD="$ROOT/plugins/agent-guard/bin/agent-guard"
+CASE_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/agent-guard-plugin-test.XXXXXX")
+trap 'rm -rf "$CASE_ROOT"' EXIT INT TERM
+REAL_JQ=$(command -v jq)
+pass=0
+fail=0
+
+ok() { pass=$((pass + 1)); printf 'ok - %s\n' "$1"; }
+not_ok() { fail=$((fail + 1)); printf 'not ok - %s\n' "$1"; }
+
+new_case() {
+  case_name=$1
+  case_dir="$CASE_ROOT/$case_name"
+  case_bin="$case_dir/bin"
+  case_log="$case_dir/calls"
+  mkdir -p "$case_bin"
+  : >"$case_log"
+  ln -s "$REAL_JQ" "$case_bin/jq"
+  export AG_PLUGIN_TEST_LOG="$case_log"
+  export AG_PLUGIN_TEST_MARKETPLACE=absent
+  export AG_PLUGIN_TEST_INSTALLED=0
+  export AG_PLUGIN_TEST_FAIL=
+  export AG_PLUGIN_TEST_SCHEMA=normal
+}
+
+add_host() {
+  host=$1
+  cp "$ROOT/tests/fixtures/mock-plugin-manager" "$case_bin/$host"
+  chmod +x "$case_bin/$host"
+}
+
+run_guard() {
+  PATH="$case_bin:/usr/bin:/bin" "$GUARD" "$@" >"$case_dir/out" 2>"$case_dir/err"
+}
+
+new_case no_host
+if run_guard plugin status; then
+  not_ok 'plugin host auto-detection rejects no host'
+elif [ "$?" -eq 2 ] && grep -q 'exactly one' "$case_dir/err"; then
+  ok 'plugin host auto-detection rejects no host'
+else
+  not_ok 'plugin host auto-detection rejects no host'
+fi
+
+new_case both_hosts
+add_host claude
+add_host codex
+if run_guard plugin status; then
+  not_ok 'plugin host auto-detection rejects two hosts'
+elif [ "$?" -eq 2 ] && [ ! -s "$case_log" ]; then
+  ok 'plugin host auto-detection rejects two hosts before manager calls'
+else
+  not_ok 'plugin host auto-detection rejects two hosts before manager calls'
+fi
+
+new_case claude_install
+add_host claude
+if run_guard plugin install \
+   && grep -Fxq 'claude plugin marketplace add JeongJaeSoon/agent-guard --scope user' "$case_log" \
+   && grep -Fxq 'claude plugin install agent-guard@agent-guard --scope user' "$case_log" \
+   && ! grep -Eq '(^| )(sudo|-y)( |$)' "$case_log"; then
+  ok 'Claude install auto-detects, registers the remote marketplace, and retains prompts'
+else
+  not_ok 'Claude install auto-detects, registers the remote marketplace, and retains prompts'
+fi
+
+new_case installed_noop
+add_host claude
+export AG_PLUGIN_TEST_MARKETPLACE=ok AG_PLUGIN_TEST_INSTALLED=1
+if run_guard plugin install --host claude \
+   && grep -q 'already installed' "$case_dir/out" \
+   && ! grep -Eq 'marketplace add|plugin install|plugin update' "$case_log"; then
+  ok 'install is idempotent and never updates an installed plugin'
+else
+  not_ok 'install is idempotent and never updates an installed plugin'
+fi
+
+for disabled_host in claude codex; do
+  new_case "${disabled_host}_disabled_status"
+  add_host "$disabled_host"
+  export AG_PLUGIN_TEST_MARKETPLACE=ok AG_PLUGIN_TEST_INSTALLED=disabled
+  if run_guard plugin status --host "$disabled_host" \
+     && grep -q '^'"$disabled_host"': installed, disabled' "$case_dir/out"; then
+    ok "$disabled_host status distinguishes an installed disabled plugin"
+  else
+    not_ok "$disabled_host status distinguishes an installed disabled plugin"
+  fi
+
+  new_case "${disabled_host}_disabled_install"
+  add_host "$disabled_host"
+  export AG_PLUGIN_TEST_MARKETPLACE=ok AG_PLUGIN_TEST_INSTALLED=disabled
+  if run_guard plugin install --host "$disabled_host"; then
+    not_ok "$disabled_host install rejects an installed disabled plugin"
+  elif grep -q 'installed but disabled' "$case_dir/err" \
+     && ! grep -Eq 'plugin (install|add) agent-guard@agent-guard' "$case_log"; then
+    ok "$disabled_host install requires explicit host activation"
+  else
+    not_ok "$disabled_host install requires explicit host activation"
+  fi
+
+  new_case "${disabled_host}_disabled_update"
+  add_host "$disabled_host"
+  export AG_PLUGIN_TEST_MARKETPLACE=ok AG_PLUGIN_TEST_INSTALLED=disabled
+  if run_guard plugin update --host "$disabled_host" \
+     && grep -q 'installed but disabled; update will keep it disabled' "$case_dir/err"; then
+    ok "$disabled_host update preserves installed status without implying activation"
+  else
+    not_ok "$disabled_host update preserves installed status without implying activation"
+  fi
+done
+
+for failed_host in claude codex; do
+  new_case "${failed_host}_install_failure"
+  add_host "$failed_host"
+  case "$failed_host" in
+    claude) export AG_PLUGIN_TEST_FAIL='claude:plugin install' ;;
+    codex) export AG_PLUGIN_TEST_FAIL='codex:plugin add agent-guard@agent-guard' ;;
+  esac
+  if run_guard plugin install --host "$failed_host"; then
+    not_ok "$failed_host install reports retained marketplace after plugin failure"
+  elif grep -q "marketplace 'agent-guard' was added" "$case_dir/err" \
+     && grep -q "safe to retry 'agent-guard plugin install --host $failed_host'" "$case_dir/err"; then
+    ok "$failed_host install reports retained marketplace and safe retry"
+  else
+    not_ok "$failed_host install reports retained marketplace and safe retry"
+  fi
+done
+
+new_case claude_malformed_state
+add_host claude
+export AG_PLUGIN_TEST_SCHEMA=malformed
+if run_guard plugin install --host claude; then
+  not_ok 'Claude install rejects malformed manager state before mutation'
+elif grep -q 'could not report its state' "$case_dir/err" \
+   && ! grep -Eq 'marketplace add|plugin install' "$case_log"; then
+  ok 'Claude install rejects malformed manager state before mutation'
+else
+  not_ok 'Claude install rejects malformed manager state before mutation'
+fi
+
+new_case codex_schema_drift
+add_host codex
+export AG_PLUGIN_TEST_SCHEMA=drift
+if run_guard plugin install --host codex; then
+  not_ok 'Codex install rejects changed manager schema before mutation'
+elif grep -q 'could not report its state' "$case_dir/err" \
+   && ! grep -Eq 'marketplace add|plugin add agent-guard@agent-guard' "$case_log"; then
+  ok 'Codex install rejects changed manager schema before mutation'
+else
+  not_ok 'Codex install rejects changed manager schema before mutation'
+fi
+
+new_case source_conflict
+add_host codex
+export AG_PLUGIN_TEST_MARKETPLACE=conflict
+if run_guard plugin install --host codex; then
+  not_ok 'install refuses a same-name marketplace from another source'
+elif [ "$?" -eq 2 ] \
+   && grep -q 'different source' "$case_dir/err" \
+   && ! grep -Eq 'marketplace add|plugin add' "$case_log"; then
+  ok 'install refuses a same-name marketplace from another source'
+else
+  not_ok 'install refuses a same-name marketplace from another source'
+fi
+
+new_case claude_update
+add_host claude
+export AG_PLUGIN_TEST_MARKETPLACE=ok AG_PLUGIN_TEST_INSTALLED=project
+if run_guard plugin update --host claude --scope project \
+   && tail -n 2 "$case_log" | sed 's/^claude //' >"$case_dir/tail" \
+   && printf '%s\n' 'plugin marketplace update agent-guard' \
+      'plugin update agent-guard@agent-guard --scope project' >"$case_dir/expected" \
+   && cmp -s "$case_dir/expected" "$case_dir/tail"; then
+  ok 'Claude update refreshes the marketplace before the scoped plugin'
+else
+  not_ok 'Claude update refreshes the marketplace before the scoped plugin'
+fi
+
+new_case claude_project_status_absent
+add_host claude
+export AG_PLUGIN_TEST_MARKETPLACE=ok AG_PLUGIN_TEST_INSTALLED=1
+if run_guard plugin status --host claude --scope project \
+   && grep -q '^claude: not installed' "$case_dir/out"; then
+  ok 'Claude status reports the requested project scope absent when only user scope is installed'
+else
+  not_ok 'Claude status reports the requested project scope absent when only user scope is installed'
+fi
+
+new_case claude_project_install
+add_host claude
+export AG_PLUGIN_TEST_MARKETPLACE=ok AG_PLUGIN_TEST_INSTALLED=1
+if run_guard plugin install --host claude --scope project \
+   && grep -Fxq 'claude plugin install agent-guard@agent-guard --scope project' "$case_log" \
+   && ! grep -q 'already installed' "$case_dir/out"; then
+  ok 'a user-scoped Claude install does not suppress project-scoped installation'
+else
+  not_ok 'a user-scoped Claude install does not suppress project-scoped installation'
+fi
+
+new_case claude_project_update_absent
+add_host claude
+export AG_PLUGIN_TEST_MARKETPLACE=ok AG_PLUGIN_TEST_INSTALLED=1
+if run_guard plugin update --host claude --scope project; then
+  not_ok 'Claude project update rejects a user-only installation'
+elif grep -q 'plugin is not installed' "$case_dir/err" \
+   && ! grep -Eq 'marketplace update|plugin update' "$case_log"; then
+  ok 'Claude project update reports absent when only user scope is installed'
+else
+  not_ok 'Claude project update reports absent when only user scope is installed'
+fi
+
+new_case claude_project_uninstall_absent
+add_host claude
+export AG_PLUGIN_TEST_MARKETPLACE=ok AG_PLUGIN_TEST_INSTALLED=1
+if run_guard plugin uninstall --host claude --scope project \
+   && grep -q 'not installed' "$case_dir/out" \
+   && ! grep -q 'plugin uninstall' "$case_log"; then
+  ok 'Claude project uninstall is a no-op when only user scope is installed'
+else
+  not_ok 'Claude project uninstall is a no-op when only user scope is installed'
+fi
+
+new_case codex_update
+add_host codex
+export AG_PLUGIN_TEST_MARKETPLACE=ok AG_PLUGIN_TEST_INSTALLED=1
+if run_guard plugin update --host codex \
+   && grep -Fxq 'codex plugin marketplace upgrade agent-guard' "$case_log"; then
+  ok 'Codex update delegates to marketplace upgrade'
+else
+  not_ok 'Codex update delegates to marketplace upgrade'
+fi
+
+new_case codex_scope
+add_host codex
+if run_guard plugin install --host codex --scope project; then
+  not_ok 'Codex rejects non-user plugin scope'
+elif [ "$?" -eq 2 ] && [ ! -s "$case_log" ]; then
+  ok 'Codex rejects non-user plugin scope before manager calls'
+else
+  not_ok 'Codex rejects non-user plugin scope before manager calls'
+fi
+
+new_case all_partial
+add_host claude
+add_host codex
+export AG_PLUGIN_TEST_FAIL='claude:plugin install'
+if run_guard plugin install --host all; then
+  not_ok 'all-host install reports a partial failure'
+elif grep -Fxq 'codex plugin add agent-guard@agent-guard' "$case_log"; then
+  ok 'all-host install continues to Codex after a Claude failure and exits nonzero'
+else
+  not_ok 'all-host install continues to Codex after a Claude failure and exits nonzero'
+fi
+
+new_case uninstall_noop
+add_host codex
+if run_guard plugin uninstall --host codex \
+   && grep -q 'not installed' "$case_dir/out" \
+   && ! grep -q 'plugin remove' "$case_log"; then
+  ok 'uninstall is idempotent when the plugin is absent'
+else
+  not_ok 'uninstall is idempotent when the plugin is absent'
+fi
+
+printf 'plugin management: %s passed, %s failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/tests/plugin-management.sh
+++ b/tests/plugin-management.sh
@@ -73,6 +73,22 @@ EOF
   export AG_PLUGIN_TEST_SUMMARY_SNAPSHOT="$case_dir/summary-snapshot"
 }
 
+signal_during_managed_summary() {
+  rm -f "$case_bin/jq"
+  cat >"$case_bin/jq" <<'EOF'
+#!/usr/bin/env sh
+case "$*" in
+  *managed-settings.json)
+    kill "-$AG_PLUGIN_TEST_SUMMARY_SIGNAL" "$PPID"
+    exit 1
+    ;;
+esac
+exec "$AG_PLUGIN_TEST_REAL_JQ" "$@"
+EOF
+  chmod +x "$case_bin/jq"
+  export AG_PLUGIN_TEST_REAL_JQ="$REAL_JQ"
+}
+
 add_host() {
   host=$1
   cp "$ROOT/tests/fixtures/mock-plugin-manager" "$case_bin/$host"
@@ -358,6 +374,27 @@ elif [ "$?" -eq 2 ] \
 else
   not_ok 'managed settings summary stores only non-sensitive ownership classifications'
 fi
+
+for summary_signal in HUP INT TERM; do
+  new_case "claude_summary_cleanup_${summary_signal}"
+  add_host claude
+  force_rundir_fallback
+  signal_during_managed_summary
+  export AG_PLUGIN_TEST_SUMMARY_SIGNAL="$summary_signal"
+  write_managed_base '{"enabledPlugins":{"agent-guard@agent-guard":true}}'
+  if TMPDIR="$case_tmp" run_guard plugin install --host claude; then
+    not_ok "managed settings summary fallback is removed after $summary_signal"
+  else
+    find "$case_tmp" -mindepth 1 -print -quit >"$case_dir/residue"
+    if grep -Fq "$case_tmp/agent-guard.XXXXXX" "$case_dir/mktemp-calls" \
+       && [ ! -s "$case_dir/residue" ] \
+       && ! grep -Eq 'marketplace (add|update)|plugin (install|update|uninstall)' "$case_log"; then
+      ok "managed settings summary fallback is removed after $summary_signal"
+    else
+      not_ok "managed settings summary fallback is removed after $summary_signal"
+    fi
+  fi
+done
 
 new_case claude_marketplace_override_unrelated
 add_host claude

--- a/tests/plugin-management.sh
+++ b/tests/plugin-management.sh
@@ -6,6 +6,8 @@ GUARD="$ROOT/plugins/agent-guard/bin/agent-guard"
 CASE_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/agent-guard-plugin-test.XXXXXX")
 trap 'rm -rf "$CASE_ROOT"' EXIT INT TERM
 REAL_JQ=$(command -v jq)
+REAL_MKTEMP=$(command -v mktemp)
+REAL_RM=$(command -v rm)
 pass=0
 fail=0
 
@@ -38,6 +40,37 @@ write_managed_base() {
 write_managed_fragment() {
   mkdir -p "$case_managed/managed-settings.d"
   printf '%s\n' "$2" >"$case_managed/managed-settings.d/$1.json"
+}
+
+force_rundir_fallback() {
+  case_tmp="$case_dir/tmp"
+  mkdir -p "$case_tmp"
+  cat >"$case_bin/mktemp" <<'EOF'
+#!/usr/bin/env sh
+printf '%s\n' "$*" >>"$AG_PLUGIN_TEST_MKTEMP_LOG"
+case "$*" in
+  *agent-guard-run.*) exit 1 ;;
+esac
+exec "$AG_PLUGIN_TEST_REAL_MKTEMP" "$@"
+EOF
+  chmod +x "$case_bin/mktemp"
+  export AG_PLUGIN_TEST_REAL_MKTEMP="$REAL_MKTEMP"
+  export AG_PLUGIN_TEST_MKTEMP_LOG="$case_dir/mktemp-calls"
+}
+
+capture_summary_on_cleanup() {
+  cat >"$case_bin/rm" <<'EOF'
+#!/usr/bin/env sh
+if [ "${1:-}" = -f ] && [ "$#" -eq 2 ] && [ -f "$2" ]; then
+  case "$2" in
+    */agent-guard.*) cp "$2" "$AG_PLUGIN_TEST_SUMMARY_SNAPSHOT" ;;
+  esac
+fi
+exec "$AG_PLUGIN_TEST_REAL_RM" "$@"
+EOF
+  chmod +x "$case_bin/rm"
+  export AG_PLUGIN_TEST_REAL_RM="$REAL_RM"
+  export AG_PLUGIN_TEST_SUMMARY_SNAPSHOT="$case_dir/summary-snapshot"
 }
 
 add_host() {
@@ -273,6 +306,57 @@ if run_guard plugin install --host claude \
   ok 'an empty managed settings file is treated as an unrelated empty object'
 else
   not_ok 'an empty managed settings file is treated as an unrelated empty object'
+fi
+
+new_case claude_summary_fallback_cleanup_success
+add_host claude
+force_rundir_fallback
+: >"$case_managed/managed-settings.json"
+if TMPDIR="$case_tmp" run_guard plugin status --host claude; then
+  find "$case_tmp" -mindepth 1 -print -quit >"$case_dir/residue"
+  if grep -Fq "$case_tmp/agent-guard.XXXXXX" "$case_dir/mktemp-calls" \
+     && [ ! -s "$case_dir/residue" ]; then
+    ok 'managed settings summary fallback is removed after success'
+  else
+    not_ok 'managed settings summary fallback is removed after success'
+  fi
+else
+  not_ok 'managed settings summary fallback is removed after success'
+fi
+
+new_case claude_summary_fallback_cleanup_failure
+add_host claude
+force_rundir_fallback
+write_managed_base '{not-json'
+if TMPDIR="$case_tmp" run_guard plugin status --host claude; then
+  not_ok 'managed settings summary fallback is removed after parse failure'
+elif [ "$?" -eq 2 ]; then
+  find "$case_tmp" -mindepth 1 -print -quit >"$case_dir/residue"
+  if grep -Fq "$case_tmp/agent-guard.XXXXXX" "$case_dir/mktemp-calls" \
+     && [ ! -s "$case_dir/residue" ]; then
+    ok 'managed settings summary fallback is removed after parse failure'
+  else
+    not_ok 'managed settings summary fallback is removed after parse failure'
+  fi
+else
+  not_ok 'managed settings summary fallback is removed after parse failure'
+fi
+
+new_case claude_summary_excludes_raw_managed_values
+add_host claude
+capture_summary_on_cleanup
+write_managed_base '{"policyHelper":{"path":"/private/super-secret-helper"},"extraKnownMarketplaces":{"internal":{"source":{"source":"git","url":"https://token:super-secret@example.invalid/private.git","headers":{"Authorization":"Bearer super-secret"}}},"official":{"source":{"source":"github","repo":"JeongJaeSoon/agent-guard"}}},"enabledPlugins":{"agent-guard@agent-guard":true,"private@internal":true},"env":{"AGENT_GUARD_PRIVATE_VALUE":"super-secret-env"}}'
+if run_guard plugin status --host claude; then
+  not_ok 'managed settings summary excludes raw managed values'
+elif [ "$?" -eq 2 ] \
+   && [ -s "$AG_PLUGIN_TEST_SUMMARY_SNAPSHOT" ] \
+   && grep -Fq '"repo":"agent-guard"' "$AG_PLUGIN_TEST_SUMMARY_SNAPSHOT" \
+   && grep -Fq '"policyHelper":true' "$AG_PLUGIN_TEST_SUMMARY_SNAPSHOT" \
+   && ! grep -Eq 'super-secret|Authorization|private@internal|AGENT_GUARD_PRIVATE_VALUE' \
+        "$AG_PLUGIN_TEST_SUMMARY_SNAPSHOT"; then
+  ok 'managed settings summary stores only non-sensitive ownership classifications'
+else
+  not_ok 'managed settings summary stores only non-sensitive ownership classifications'
 fi
 
 new_case claude_marketplace_override_unrelated

--- a/tests/plugin-management.sh
+++ b/tests/plugin-management.sh
@@ -3,6 +3,16 @@ set -u
 
 ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd -P)
 GUARD="$ROOT/plugins/agent-guard/bin/agent-guard"
+CLI_VERSION=$("$GUARD" version | awk 'NR == 1 { print $2 }')
+[ -n "$CLI_VERSION" ] || { printf '%s\n' 'could not read CLI version' >&2; exit 2; }
+CLI_TAG="v$CLI_VERSION"
+OLD_VERSION=0.0.0
+[ "$CLI_VERSION" = "$OLD_VERSION" ] && OLD_VERSION=0.0.1
+OLD_TAG="v$OLD_VERSION"
+export AG_PLUGIN_TEST_EXPECTED_VERSION="$CLI_VERSION"
+export AG_PLUGIN_TEST_EXPECTED_TAG="$CLI_TAG"
+export AG_PLUGIN_TEST_OLD_VERSION="$OLD_VERSION"
+export AG_PLUGIN_TEST_OLD_TAG="$OLD_TAG"
 CASE_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/agent-guard-plugin-test.XXXXXX")
 trap 'rm -rf "$CASE_ROOT"' EXIT INT TERM
 REAL_JQ=$(command -v jq)
@@ -131,7 +141,7 @@ fi
 new_case claude_install
 add_host claude
 if run_guard plugin install \
-   && grep -Fxq 'claude plugin marketplace add JeongJaeSoon/agent-guard@v3.4.0 --scope user' "$case_log" \
+   && grep -Fxq "claude plugin marketplace add JeongJaeSoon/agent-guard@$CLI_TAG --scope user" "$case_log" \
    && grep -Fxq 'claude plugin install agent-guard@agent-guard --scope user' "$case_log" \
    && ! grep -Eq '(^| )(sudo|-y)( |$)' "$case_log"; then
   ok 'Claude install auto-detects, registers the remote marketplace, and retains prompts'
@@ -155,7 +165,7 @@ add_host codex
 export AG_PLUGIN_TEST_MARKETPLACE=ok AG_PLUGIN_TEST_INSTALLED=1
 if run_guard plugin install --host codex \
    && grep -q 'already installed' "$case_dir/out" \
-   && grep -Fxq 'codex plugin marketplace add JeongJaeSoon/agent-guard@v3.4.0' "$case_log" \
+   && grep -Fxq "codex plugin marketplace add JeongJaeSoon/agent-guard@$CLI_TAG" "$case_log" \
    && ! grep -Eq 'plugin add agent-guard@agent-guard|marketplace (upgrade|remove)' "$case_log"; then
   ok 'Codex install uses the manager same-ref probe and remains idempotent'
 else
@@ -202,7 +212,7 @@ for failed_host in claude codex; do
   export AG_PLUGIN_TEST_FAIL="$failed_host:plugin marketplace add"
   if run_guard plugin install --host "$failed_host"; then
     not_ok "$failed_host install reports marketplace registration failure"
-  elif grep -q "pinned to v3.4.0" "$case_dir/err" \
+  elif grep -q "pinned to $CLI_TAG" "$case_dir/err" \
      && grep -q "safe to retry 'agent-guard plugin install --host $failed_host'" "$case_dir/err" \
      && ! grep -Eq 'plugin (install|add) agent-guard@agent-guard' "$case_log"; then
     ok "$failed_host install stops before plugin installation when marketplace registration fails"
@@ -271,9 +281,9 @@ for drift_host in claude codex; do
     add_host "$drift_host"
     export AG_PLUGIN_TEST_MARKETPLACE="$drift_marketplace" AG_PLUGIN_TEST_INSTALLED=old
     if run_guard plugin status --host "$drift_host" \
-       && grep -q 'version 3.3.0, expected 3.4.0' "$case_dir/out"; then
+       && grep -q "version $OLD_VERSION, expected $CLI_VERSION" "$case_dir/out"; then
       case "$drift_host" in
-        claude) grep -q 'marketplace drift:.*expected v3.4.0' "$case_dir/out" ;;
+        claude) grep -q "marketplace drift:.*expected $CLI_TAG" "$case_dir/out" ;;
         codex) grep -q 'marketplace configured, pin unverified by Codex' "$case_dir/out" ;;
       esac
       if [ "$?" -eq 0 ]; then
@@ -306,7 +316,7 @@ new_case claude_managed_plugin_status
 add_host claude
 export AG_PLUGIN_TEST_MARKETPLACE=ok AG_PLUGIN_TEST_INSTALLED=managed_disabled
 if run_guard plugin status --host claude \
-   && grep -q 'managed by Jamf/managed settings (plugin installed, disabled, version 3.4.0)' "$case_dir/out"; then
+   && grep -q "managed by Jamf/managed settings (plugin installed, disabled, version $CLI_VERSION)" "$case_dir/out"; then
   ok 'Claude status identifies a managed disabled plugin and its version'
 else
   not_ok 'Claude status identifies a managed disabled plugin and its version'
@@ -315,7 +325,7 @@ fi
 new_case claude_managed_marketplace_status
 add_host claude
 export AG_PLUGIN_TEST_MARKETPLACE=ok AG_PLUGIN_TEST_INSTALLED=0
-write_managed_base '{"extraKnownMarketplaces":{"agent-guard":{"source":{"source":"github","repo":"JeongJaeSoon/agent-guard","ref":"v3.4.0"}}}}'
+write_managed_base "{\"extraKnownMarketplaces\":{\"agent-guard\":{\"source\":{\"source\":\"github\",\"repo\":\"JeongJaeSoon/agent-guard\",\"ref\":\"$CLI_TAG\"}}}}"
 if run_guard plugin status --host claude \
    && grep -q 'managed by Jamf/managed settings (Agent Guard configured, plugin not installed)' "$case_dir/out"; then
   ok 'Claude status identifies a managed settings marketplace without a plugin'
@@ -390,7 +400,7 @@ new_case claude_empty_managed_settings
 add_host claude
 : >"$case_managed/managed-settings.json"
 if run_guard plugin install --host claude \
-   && grep -Fxq 'claude plugin marketplace add JeongJaeSoon/agent-guard@v3.4.0 --scope user' "$case_log" \
+   && grep -Fxq "claude plugin marketplace add JeongJaeSoon/agent-guard@$CLI_TAG --scope user" "$case_log" \
    && grep -Fxq 'claude plugin install agent-guard@agent-guard --scope user' "$case_log"; then
   ok 'an empty managed settings file is treated as an unrelated empty object'
 else
@@ -613,7 +623,7 @@ add_host codex
 export AG_PLUGIN_TEST_MARKETPLACE=ok AG_PLUGIN_TEST_INSTALLED=old
 if run_guard plugin update --host codex \
    && tail -n 2 "$case_log" | sed 's/^codex //' >"$case_dir/tail" \
-   && printf '%s\n' 'plugin marketplace add JeongJaeSoon/agent-guard@v3.4.0' \
+   && printf '%s\n' "plugin marketplace add JeongJaeSoon/agent-guard@$CLI_TAG" \
       'plugin marketplace upgrade agent-guard' >"$case_dir/expected" \
    && cmp -s "$case_dir/expected" "$case_dir/tail"; then
   ok 'Codex update delegates to marketplace upgrade'
@@ -631,7 +641,7 @@ for update_host in claude codex; do
   esac
   if run_guard plugin update --host "$update_host"; then
     not_ok "$update_host update reports a partial manager failure"
-  elif grep -q "marketplace remains pinned to v3.4.0" "$case_dir/err" \
+  elif grep -q "marketplace remains pinned to $CLI_TAG" "$case_dir/err" \
      && grep -q "safe to retry 'agent-guard plugin update --host $update_host'" "$case_dir/err"; then
     ok "$update_host update reports retained pin and a safe retry"
   else

--- a/tests/plugin-management.sh
+++ b/tests/plugin-management.sh
@@ -17,7 +17,9 @@ new_case() {
   case_dir="$CASE_ROOT/$case_name"
   case_bin="$case_dir/bin"
   case_log="$case_dir/calls"
+  case_managed="$case_dir/managed-settings-root"
   mkdir -p "$case_bin"
+  mkdir -p "$case_managed"
   : >"$case_log"
   ln -s "$REAL_JQ" "$case_bin/jq"
   export AG_PLUGIN_TEST_LOG="$case_log"
@@ -25,6 +27,17 @@ new_case() {
   export AG_PLUGIN_TEST_INSTALLED=0
   export AG_PLUGIN_TEST_FAIL=
   export AG_PLUGIN_TEST_SCHEMA=normal
+  export AG_PLUGIN_TEST_MODE=1
+  export AG_PLUGIN_TEST_CLAUDE_MANAGED_SETTINGS_ROOT="$case_managed"
+}
+
+write_managed_base() {
+  printf '%s\n' "$1" >"$case_managed/managed-settings.json"
+}
+
+write_managed_fragment() {
+  mkdir -p "$case_managed/managed-settings.d"
+  printf '%s\n' "$2" >"$case_managed/managed-settings.d/$1.json"
 }
 
 add_host() {
@@ -179,21 +192,40 @@ fi
 
 new_case claude_managed_marketplace_status
 add_host claude
-export AG_PLUGIN_TEST_MARKETPLACE=managed AG_PLUGIN_TEST_INSTALLED=0
+export AG_PLUGIN_TEST_MARKETPLACE=ok AG_PLUGIN_TEST_INSTALLED=0
+write_managed_base '{"extraKnownMarketplaces":{"agent-guard":{"source":{"source":"github","repo":"JeongJaeSoon/agent-guard","ref":"v3.4.0"}}}}'
 if run_guard plugin status --host claude \
-   && grep -q 'managed by Jamf/managed settings (marketplace configured, plugin not installed)' "$case_dir/out"; then
-  ok 'Claude status identifies a managed marketplace without a plugin'
+   && grep -q 'managed by Jamf/managed settings (Agent Guard configured, plugin not installed)' "$case_dir/out"; then
+  ok 'Claude status identifies a managed settings marketplace without a plugin'
 else
-  not_ok 'Claude status identifies a managed marketplace without a plugin'
+  not_ok 'Claude status identifies a managed settings marketplace without a plugin'
 fi
 
-for managed_state in plugin marketplace; do
+new_case claude_managed_fragment_status
+add_host claude
+export AG_PLUGIN_TEST_MARKETPLACE=ok AG_PLUGIN_TEST_INSTALLED=0
+write_managed_fragment guard '{"enabledPlugins":{"agent-guard@agent-guard":false}}'
+if run_guard plugin status --host claude \
+   && grep -q 'managed by Jamf/managed settings (Agent Guard configured, plugin not installed)' "$case_dir/out"; then
+  ok 'Claude status reads an Agent Guard declaration from managed-settings.d'
+else
+  not_ok 'Claude status reads an Agent Guard declaration from managed-settings.d'
+fi
+
+for managed_state in plugin base fragment; do
   for managed_action in install update uninstall; do
     new_case "claude_managed_${managed_state}_${managed_action}"
     add_host claude
     case "$managed_state" in
       plugin) export AG_PLUGIN_TEST_MARKETPLACE=ok AG_PLUGIN_TEST_INSTALLED=managed ;;
-      marketplace) export AG_PLUGIN_TEST_MARKETPLACE=managed AG_PLUGIN_TEST_INSTALLED=0 ;;
+      base)
+        export AG_PLUGIN_TEST_MARKETPLACE=ok AG_PLUGIN_TEST_INSTALLED=0
+        write_managed_base '{"enabledPlugins":{"agent-guard@agent-guard":true}}'
+        ;;
+      fragment)
+        export AG_PLUGIN_TEST_MARKETPLACE=ok AG_PLUGIN_TEST_INSTALLED=0
+        write_managed_fragment guard '{"extraKnownMarketplaces":{"security":{"source":{"source":"github","repo":"JeongJaeSoon/agent-guard"}}}}'
+        ;;
     esac
     if run_guard plugin "$managed_action" --host claude; then
       not_ok "Claude $managed_action refuses a managed $managed_state"
@@ -206,6 +238,46 @@ for managed_state in plugin marketplace; do
     fi
   done
 done
+
+new_case claude_unrelated_managed_settings
+add_host claude
+export AG_PLUGIN_TEST_MARKETPLACE=ok AG_PLUGIN_TEST_INSTALLED=0
+write_managed_base '{"extraKnownMarketplaces":{"other":{"source":{"source":"github","repo":"example/other"}}},"enabledPlugins":{"other@other":true}}'
+write_managed_fragment other '{"permissions":{"deny":["Read(example)"]}}'
+if run_guard plugin install --host claude \
+   && grep -Fxq 'claude plugin install agent-guard@agent-guard --scope user' "$case_log"; then
+  ok 'unrelated managed settings do not block self-managed installation'
+else
+  not_ok 'unrelated managed settings do not block self-managed installation'
+fi
+
+new_case claude_malformed_managed_settings
+add_host claude
+export AG_PLUGIN_TEST_MARKETPLACE=ok AG_PLUGIN_TEST_INSTALLED=0
+write_managed_base '{not-json'
+if run_guard plugin status --host claude; then
+  not_ok 'malformed managed settings make status fail closed'
+elif [ "$?" -eq 2 ] \
+   && grep -q 'could not be read or safely parsed' "$case_dir/err" \
+   && ! grep -Eq 'marketplace (add|update)|plugin (install|update|uninstall)' "$case_log"; then
+  ok 'malformed managed settings make status fail closed before mutation'
+else
+  not_ok 'malformed managed settings make status fail closed before mutation'
+fi
+
+new_case claude_unreadable_managed_fragment
+add_host claude
+export AG_PLUGIN_TEST_MARKETPLACE=ok AG_PLUGIN_TEST_INSTALLED=0
+mkdir -p "$case_managed/managed-settings.d/unreadable.json"
+if run_guard plugin install --host claude; then
+  not_ok 'unreadable or non-regular managed fragments block mutation'
+elif [ "$?" -eq 2 ] \
+   && grep -q 'could not be read or safely parsed' "$case_dir/err" \
+   && ! grep -Eq 'marketplace (add|update)|plugin (install|update|uninstall)' "$case_log"; then
+  ok 'unreadable or non-regular managed fragments block before mutation'
+else
+  not_ok 'unreadable or non-regular managed fragments block before mutation'
+fi
 
 new_case claude_update
 add_host claude

--- a/tests/plugin-management.sh
+++ b/tests/plugin-management.sh
@@ -131,7 +131,7 @@ fi
 new_case claude_install
 add_host claude
 if run_guard plugin install \
-   && grep -Fxq 'claude plugin marketplace add JeongJaeSoon/agent-guard --scope user' "$case_log" \
+   && grep -Fxq 'claude plugin marketplace add JeongJaeSoon/agent-guard@v3.4.0 --scope user' "$case_log" \
    && grep -Fxq 'claude plugin install agent-guard@agent-guard --scope user' "$case_log" \
    && ! grep -Eq '(^| )(sudo|-y)( |$)' "$case_log"; then
   ok 'Claude install auto-detects, registers the remote marketplace, and retains prompts'
@@ -148,6 +148,18 @@ if run_guard plugin install --host claude \
   ok 'install is idempotent and never updates an installed plugin'
 else
   not_ok 'install is idempotent and never updates an installed plugin'
+fi
+
+new_case codex_installed_noop
+add_host codex
+export AG_PLUGIN_TEST_MARKETPLACE=ok AG_PLUGIN_TEST_INSTALLED=1
+if run_guard plugin install --host codex \
+   && grep -q 'already installed' "$case_dir/out" \
+   && grep -Fxq 'codex plugin marketplace add JeongJaeSoon/agent-guard@v3.4.0' "$case_log" \
+   && ! grep -Eq 'plugin add agent-guard@agent-guard|marketplace (upgrade|remove)' "$case_log"; then
+  ok 'Codex install uses the manager same-ref probe and remains idempotent'
+else
+  not_ok 'Codex install uses the manager same-ref probe and remains idempotent'
 fi
 
 for disabled_host in claude codex; do
@@ -181,6 +193,21 @@ for disabled_host in claude codex; do
     ok "$disabled_host update preserves installed status without implying activation"
   else
     not_ok "$disabled_host update preserves installed status without implying activation"
+  fi
+done
+
+for failed_host in claude codex; do
+  new_case "${failed_host}_marketplace_add_failure"
+  add_host "$failed_host"
+  export AG_PLUGIN_TEST_FAIL="$failed_host:plugin marketplace add"
+  if run_guard plugin install --host "$failed_host"; then
+    not_ok "$failed_host install reports marketplace registration failure"
+  elif grep -q "pinned to v3.4.0" "$case_dir/err" \
+     && grep -q "safe to retry 'agent-guard plugin install --host $failed_host'" "$case_dir/err" \
+     && ! grep -Eq 'plugin (install|add) agent-guard@agent-guard' "$case_log"; then
+    ok "$failed_host install stops before plugin installation when marketplace registration fails"
+  else
+    not_ok "$failed_host install reports marketplace registration failure"
   fi
 done
 
@@ -237,6 +264,43 @@ elif [ "$?" -eq 2 ] \
 else
   not_ok 'install refuses a same-name marketplace from another source'
 fi
+
+for drift_host in claude codex; do
+  for drift_marketplace in unpinned old; do
+    new_case "${drift_host}_${drift_marketplace}_marketplace_status"
+    add_host "$drift_host"
+    export AG_PLUGIN_TEST_MARKETPLACE="$drift_marketplace" AG_PLUGIN_TEST_INSTALLED=old
+    if run_guard plugin status --host "$drift_host" \
+       && grep -q 'version 3.3.0, expected 3.4.0' "$case_dir/out"; then
+      case "$drift_host" in
+        claude) grep -q 'marketplace drift:.*expected v3.4.0' "$case_dir/out" ;;
+        codex) grep -q 'marketplace configured, pin unverified by Codex' "$case_dir/out" ;;
+      esac
+      if [ "$?" -eq 0 ]; then
+        ok "$drift_host status reports plugin and marketplace verification state"
+      else
+        not_ok "$drift_host status reports plugin and marketplace verification state"
+      fi
+    else
+      not_ok "$drift_host status reports plugin and marketplace verification state"
+    fi
+
+    for drift_action in install update; do
+      new_case "${drift_host}_${drift_marketplace}_${drift_action}"
+      add_host "$drift_host"
+      export AG_PLUGIN_TEST_MARKETPLACE="$drift_marketplace" AG_PLUGIN_TEST_INSTALLED=old
+      if run_guard plugin "$drift_action" --host "$drift_host"; then
+        not_ok "$drift_host $drift_action refuses a $drift_marketplace marketplace"
+      elif [ "$?" -eq 2 ] \
+         && grep -q 'marketplace removal also removes its installed plugin' "$case_dir/err" \
+         && ! grep -Eq 'plugin (install|update|add) agent-guard@agent-guard|marketplace (update|upgrade|remove)' "$case_log"; then
+        ok "$drift_host $drift_action refuses a $drift_marketplace marketplace with recovery guidance"
+      else
+        not_ok "$drift_host $drift_action refuses a $drift_marketplace marketplace"
+      fi
+    done
+  done
+done
 
 new_case claude_managed_plugin_status
 add_host claude
@@ -326,7 +390,7 @@ new_case claude_empty_managed_settings
 add_host claude
 : >"$case_managed/managed-settings.json"
 if run_guard plugin install --host claude \
-   && grep -Fxq 'claude plugin marketplace add JeongJaeSoon/agent-guard --scope user' "$case_log" \
+   && grep -Fxq 'claude plugin marketplace add JeongJaeSoon/agent-guard@v3.4.0 --scope user' "$case_log" \
    && grep -Fxq 'claude plugin install agent-guard@agent-guard --scope user' "$case_log"; then
   ok 'an empty managed settings file is treated as an unrelated empty object'
 else
@@ -489,7 +553,7 @@ done
 
 new_case claude_update
 add_host claude
-export AG_PLUGIN_TEST_MARKETPLACE=ok AG_PLUGIN_TEST_INSTALLED=project
+export AG_PLUGIN_TEST_MARKETPLACE=ok AG_PLUGIN_TEST_INSTALLED=project_old
 if run_guard plugin update --host claude --scope project \
    && tail -n 2 "$case_log" | sed 's/^claude //' >"$case_dir/tail" \
    && printf '%s\n' 'plugin marketplace update agent-guard' \
@@ -502,7 +566,7 @@ fi
 
 new_case claude_project_status_absent
 add_host claude
-export AG_PLUGIN_TEST_MARKETPLACE=ok AG_PLUGIN_TEST_INSTALLED=1
+export AG_PLUGIN_TEST_MARKETPLACE=ok AG_PLUGIN_TEST_INSTALLED=old
 if run_guard plugin status --host claude --scope project \
    && grep -q '^claude: not installed' "$case_dir/out"; then
   ok 'Claude status reports the requested project scope absent when only user scope is installed'
@@ -546,13 +610,34 @@ fi
 
 new_case codex_update
 add_host codex
-export AG_PLUGIN_TEST_MARKETPLACE=ok AG_PLUGIN_TEST_INSTALLED=1
+export AG_PLUGIN_TEST_MARKETPLACE=ok AG_PLUGIN_TEST_INSTALLED=old
 if run_guard plugin update --host codex \
-   && grep -Fxq 'codex plugin marketplace upgrade agent-guard' "$case_log"; then
+   && tail -n 2 "$case_log" | sed 's/^codex //' >"$case_dir/tail" \
+   && printf '%s\n' 'plugin marketplace add JeongJaeSoon/agent-guard@v3.4.0' \
+      'plugin marketplace upgrade agent-guard' >"$case_dir/expected" \
+   && cmp -s "$case_dir/expected" "$case_dir/tail"; then
   ok 'Codex update delegates to marketplace upgrade'
 else
   not_ok 'Codex update delegates to marketplace upgrade'
 fi
+
+for update_host in claude codex; do
+  new_case "${update_host}_update_partial_failure"
+  add_host "$update_host"
+  export AG_PLUGIN_TEST_MARKETPLACE=ok AG_PLUGIN_TEST_INSTALLED=old
+  case "$update_host" in
+    claude) export AG_PLUGIN_TEST_FAIL='claude:plugin update' ;;
+    codex) export AG_PLUGIN_TEST_FAIL='codex:plugin marketplace upgrade' ;;
+  esac
+  if run_guard plugin update --host "$update_host"; then
+    not_ok "$update_host update reports a partial manager failure"
+  elif grep -q "marketplace remains pinned to v3.4.0" "$case_dir/err" \
+     && grep -q "safe to retry 'agent-guard plugin update --host $update_host'" "$case_dir/err"; then
+    ok "$update_host update reports retained pin and a safe retry"
+  else
+    not_ok "$update_host update reports a partial manager failure"
+  fi
+done
 
 new_case codex_scope
 add_host codex

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -154,6 +154,7 @@ fi
 # Stub only the release downloads; archive verification, extraction, linking,
 # setup-shell, and rc generation all run through the real implementation.
 run_expect 0 "private metadata-only audit logging contract" sh "$ROOT/tests/audit-log.sh"
+run_expect 0 "host plugin lifecycle delegates safely" sh "$ROOT/tests/plugin-management.sh"
 
 run_expect 0 "standalone update preserves executable and link destinations" \
   sh "$ROOT/tests/bootstrap-update.sh"


### PR DESCRIPTION
Homebrew and standalone installations can install and maintain Agent Guard's Claude Code and Codex plugins through one CLI. For example, `agent-guard plugin install --host all` delegates to each host's official plugin manager while preserving host prompts and scope rules.

The command supports `status`, `install`, `update`, and `uninstall`; detects a single available host when `--host` is omitted; treats disabled plugins and malformed manager state explicitly; keeps install idempotent; and reports partial installation state without writing host caches or configuration directly.

New installs pin the marketplace to the CLI's own release tag (`v3.4.1` for this release). An existing unpinned, differently pinned, or conflicting source is rejected before plugin mutation with official host-manager recovery commands. Claude exposes the configured ref for direct verification; Codex 0.153.4 does not expose it in JSON, so Codex uses an idempotent same-source add probe and reports the pin as unverified in status.

The installation guide also defines the version transition order: upgrade the standalone/Homebrew CLI, explicitly synchronize each self-managed host plugin, follow the printed remove-and-reinstall recovery when the old marketplace tag remains, restart the host, and repeat setup and acceptance. Jamf-managed Claude installations remain on the administrator rollout path.

Claude lifecycle commands also detect administrator-owned Agent Guard declarations in `managed-settings.json` and merged `managed-settings.d/*.json`. Managed, malformed, unreadable, redirected, or dynamic `policyHelper` states fail closed before host mutation, while valid unrelated settings preserve self-managed use. Temporary summaries contain only the ownership fields needed for the decision and are cleaned on normal completion and signals.

Validation:

- `sh tests/plugin-management.sh` — 71 passed, 0 failed
- `sh scripts/validate-plugin-layout.sh`
- integrated `sh tests/run.sh` — 1,408 passed, 0 failed
- POSIX syntax checks with `sh` and `dash`
- isolated live pinned install → status → idempotent install/update → uninstall using Claude Code 2.1.268 and Codex CLI 0.153.4
- isolated unpinned-source checks for both hosts — rejected before plugin mutation with recovery guidance

The live checks used temporary HOME, XDG, and Codex configuration roots. They did not modify the user's host settings. A real Jamf-managed device remains part of the staged deployment acceptance process.
