### PR TITLE
Add safe support log file export

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,19 @@ agent-guard scan-staged
 agent-guard scan-path .
 ```
 
+## Support log
+
+Save the metadata-only local support log with one command:
+
+```sh
+agent-guard logs export --output agent-guard-support.jsonl
+```
+
+The parent directory must already exist. Agent Guard creates a new mode-0600
+file and refuses to replace an existing file or symlink. Use the plugin-local
+executable printed by the setup skill when a plugin-only installation does not
+provide `agent-guard` on `PATH`. See [Support](SUPPORT.md) for what to submit.
+
 ## Requirements and scope
 
 Supported platforms are macOS and Linux on x64 and arm64. Runtime dependencies

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -16,12 +16,20 @@ summary. Never include live credentials, private keys, prompts, transcripts,
 raw stderr, full hook payloads, paths, environment variables, session IDs, or
 unredacted personal data.
 
-If your installed version provides it, attach the output of
-`agent-guard logs export` instead of raw diagnostic output. The local support
-log is metadata only. Plugin-only installations may not have `agent-guard` on
-PATH: use the absolute plugin-local executable printed by the host setup skill
-in place of `agent-guard`, followed by `logs export`. This also avoids exporting
-logs through an unrelated standalone version.
+When the installed version provides `--output`, create one private support file
+instead of attaching raw diagnostic output:
+
+```sh
+agent-guard logs export --output agent-guard-support.jsonl
+```
+
+The parent directory must already exist. This creates a new mode-0600 file and
+refuses to replace an existing file or symlink. The local support log is metadata
+only. Plugin-only installations may not have `agent-guard` on PATH: use the
+absolute plugin-local executable printed by the host setup skill in place of
+`agent-guard`. This also avoids exporting logs through an unrelated standalone
+version. If export cannot run, send only the listed metadata and a manually
+sanitized error summary; never substitute raw stderr or a host transcript.
 
 The log records a random local `run_id`, version, command/event
 category, host, start and finish time, exit status, and one of `pass`, `blocked`, `masked`,

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -108,7 +108,22 @@ Do not attach transcripts, raw stderr, `.env` files, private keys, or full hook
 payloads. Include only the host, OS/architecture, Agent Guard version, command
 or event category, outcome, and a manually sanitized error summary.
 
-The metadata log is introduced after v3.3.0. When available,
-`agent-guard logs export` provides a metadata-only JSONL report.
-It excludes content, paths, environment variables, session IDs, and arbitrary
-tool names. [Support](../SUPPORT.md) has the current submission checklist.
+When the installed version provides `agent-guard logs export --output FILE`, it
+writes a metadata-only JSONL report to a new private mode-0600 file. It excludes
+content, paths, environment variables, session IDs, and arbitrary tool names.
+The parent directory must already exist; Agent Guard refuses to replace an
+existing file or symlink. [Support](../SUPPORT.md) has the current submission
+checklist.
+
+For a standalone installation, run:
+
+```sh
+agent-guard logs status
+agent-guard logs export --output agent-guard-support.jsonl
+```
+
+For a plugin-only installation, replace `agent-guard` with the exact
+plugin-local executable path printed by the setup skill. If export cannot run,
+report only the version, host, OS/architecture, command/event category, outcome,
+and a manually sanitized error summary. Do not attach raw stderr, a transcript,
+or a hook payload.

--- a/plugins/agent-guard/SUPPORT.md
+++ b/plugins/agent-guard/SUPPORT.md
@@ -16,12 +16,20 @@ summary. Never include live credentials, private keys, prompts, transcripts,
 raw stderr, full hook payloads, paths, environment variables, session IDs, or
 unredacted personal data.
 
-If your installed version provides it, attach the output of
-`agent-guard logs export` instead of raw diagnostic output. The local support
-log is metadata only. Plugin-only installations may not have `agent-guard` on
-PATH: use the absolute plugin-local executable printed by the host setup skill
-in place of `agent-guard`, followed by `logs export`. This also avoids exporting
-logs through an unrelated standalone version.
+When the installed version provides `--output`, create one private support file
+instead of attaching raw diagnostic output:
+
+```sh
+agent-guard logs export --output agent-guard-support.jsonl
+```
+
+The parent directory must already exist. This creates a new mode-0600 file and
+refuses to replace an existing file or symlink. The local support log is metadata
+only. Plugin-only installations may not have `agent-guard` on PATH: use the
+absolute plugin-local executable printed by the host setup skill in place of
+`agent-guard`. This also avoids exporting logs through an unrelated standalone
+version. If export cannot run, send only the listed metadata and a manually
+sanitized error summary; never substitute raw stderr or a host transcript.
 
 The log records a random local `run_id`, version, command/event
 category, host, start and finish time, exit status, and one of `pass`, `blocked`, `masked`,

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -392,6 +392,11 @@ audit_export_to_file() (
 
 audit_logs() {
   case "${1:-status}" in
+    -h|--help|help)
+      [ "$#" -eq 1 ] || { printf '%s\n' 'Usage: agent-guard logs [status|export [--output FILE]]' >&2; return 2; }
+      printf '%s\n' 'Usage: agent-guard logs [status|export [--output FILE]]' >&2
+      return 0
+      ;;
     status)
       case "$#:${1:-}" in 0:|1:status) ;; *) printf '%s\n' 'Usage: agent-guard logs [status|export [--output FILE]]' >&2; return 2 ;; esac
       case "${AGENT_GUARD_LOG_MODE:-on}" in on|off) ag_mode=${AGENT_GUARD_LOG_MODE:-on} ;; *) ag_mode=invalid ;; esac

--- a/plugins/agent-guard/bin/agent-guard
+++ b/plugins/agent-guard/bin/agent-guard
@@ -173,7 +173,7 @@ Usage:
   agent-guard check
   agent-guard setup [--install --gitleaks-checksum SHA [--gitleaks-version X.Y.Z]]
   agent-guard doctor
-  agent-guard logs [status|export]
+  agent-guard logs [status|export [--output FILE]]
   agent-guard update
   agent-guard smoke-test
   agent-guard checksum [VERSION]
@@ -325,40 +325,88 @@ audit_finish() {
   return 0
 }
 
+audit_export() {
+  command -v jq >/dev/null 2>&1 || { printf '%s\n' 'agent-guard: log export requires jq.' >&2; return 2; }
+  ag_dir=$(audit_directory) || { printf '%s\n' 'agent-guard: no private diagnostic log directory is available.' >&2; return 2; }
+  for ag_file in "$ag_dir"/event-*; do
+    [ -f "$ag_file" ] && [ ! -L "$ag_file" ] || continue
+    [ "$(audit_stat "$ag_file")" = "$(id -u):600" ] || continue
+    ag_bytes=$(wc -c <"$ag_file" | tr -d ' ')
+    case "$ag_bytes" in ''|*[!0-9]*) continue ;; esac
+    [ "$ag_bytes" -le 2048 ] || continue
+    # Rebuild the schema, dropping unknown keys. Validate every field so a
+    # manually edited/corrupt log cannot smuggle source data into an export.
+    jq -c '
+      select(type == "object" and .schema == 1)
+      | select(.run_id | type == "string" and test("^[0-9]{1,12}-[A-Za-z0-9]{6}$"))
+      | select(.time | type == "number" and . >= 0 and . <= 9999999999 and floor == .)
+      | select(.version | type == "string" and test("^[0-9]{1,5}\\.[0-9]{1,5}\\.[0-9]{1,5}$"))
+      | select(.command | IN("hook-pre-tool", "hook-post-tool", "hook-stop", "hook-user-prompt", "hook-session-start", "scan-staged", "scan-working-tree", "scan-path", "exec", "pii-filter"))
+      | select(.host | IN("claude", "codex", "cli"))
+      | select(.phase | IN("started", "finished"))
+      | select(.outcome | IN("pending", "pass", "blocked", "masked", "degraded", "error", "interrupted", "warned"))
+      | select(.exit_code == null or (.exit_code | type == "number" and . >= 0 and . <= 255 and floor == .))
+      | select(.duration_seconds | type == "number" and . >= 0 and . <= 9999999999 and floor == .)
+      | {schema,run_id,time,version,command,host,phase,outcome,exit_code,duration_seconds}
+    ' "$ag_file" 2>/dev/null || :
+  done
+}
+
+# Write a complete export into a private temporary file in the requested parent,
+# then publish it with link(2). A hard-link creation fails if FILE already exists,
+# unlike mv, so an existing regular file, directory, FIFO, or symlink is never
+# overwritten. The temporary file and its final name are in one filesystem.
+audit_export_to_file() (
+  ag_output=$1
+  case "$ag_output" in '') printf '%s\n' 'agent-guard: log export output path is required.' >&2; return 2 ;; esac
+  ag_parent=$(dirname -- "$ag_output") || return 2
+  [ -d "$ag_parent" ] && [ ! -L "$ag_parent" ] || {
+    printf '%s\n' 'agent-guard: log export parent directory must already exist and not be a symlink.' >&2
+    return 2
+  }
+  [ ! -e "$ag_output" ] && [ ! -L "$ag_output" ] || {
+    printf '%s\n' 'agent-guard: refusing to overwrite an existing log export target.' >&2
+    return 2
+  }
+  ag_tmp=
+  trap '[ -z "$ag_tmp" ] || rm -f -- "$ag_tmp"' 0
+  ag_tmp=$(umask 077; mktemp "$ag_parent/.agent-guard-support.XXXXXX" 2>/dev/null) || {
+    printf '%s\n' 'agent-guard: could not create a private temporary log export file.' >&2
+    return 2
+  }
+  if [ ! -f "$ag_tmp" ] || [ -L "$ag_tmp" ] || [ "$(audit_stat "$ag_tmp")" != "$(id -u):600" ]; then
+    printf '%s\n' 'agent-guard: temporary log export file was not private.' >&2
+    return 2
+  fi
+  audit_export >"$ag_tmp" || return $?
+  ln "$ag_tmp" "$ag_output" 2>/dev/null || {
+    printf '%s\n' 'agent-guard: refusing to overwrite an existing or invalid log export target.' >&2
+    return 2
+  }
+  [ -f "$ag_output" ] && [ ! -L "$ag_output" ] && [ "$(audit_stat "$ag_output")" = "$(id -u):600" ] || {
+    printf '%s\n' 'agent-guard: log export target was not a private regular file.' >&2
+    return 2
+  }
+  printf 'agent-guard: exported metadata-only support log to %s\n' "$ag_output" >&2
+)
+
 audit_logs() {
   case "${1:-status}" in
     status)
+      case "$#:${1:-}" in 0:|1:status) ;; *) printf '%s\n' 'Usage: agent-guard logs [status|export [--output FILE]]' >&2; return 2 ;; esac
       case "${AGENT_GUARD_LOG_MODE:-on}" in on|off) ag_mode=${AGENT_GUARD_LOG_MODE:-on} ;; *) ag_mode=invalid ;; esac
       printf 'Local diagnostic logging: %s\nDirectory: ${XDG_STATE_HOME:-~/.local/state}/agent-guard\nRetention target: 7 days, 1000 invocations; bounded cleanup runs at start, so concurrency or externally added files can exceed this.\n' "$ag_mode"
       if audit_directory >/dev/null; then printf 'Storage: private directory ready\n'; else printf 'Storage: not created or unavailable\n'; fi
       ;;
     export)
-      command -v jq >/dev/null 2>&1 || { printf '%s\n' 'agent-guard: log export requires jq.' >&2; return 2; }
-      ag_dir=$(audit_directory) || { printf '%s\n' 'agent-guard: no private diagnostic log directory is available.' >&2; return 2; }
-      for ag_file in "$ag_dir"/event-*; do
-        [ -f "$ag_file" ] && [ ! -L "$ag_file" ] || continue
-        [ "$(audit_stat "$ag_file")" = "$(id -u):600" ] || continue
-        ag_bytes=$(wc -c <"$ag_file" | tr -d ' ')
-        case "$ag_bytes" in ''|*[!0-9]*) continue ;; esac
-        [ "$ag_bytes" -le 2048 ] || continue
-        # Rebuild the schema, dropping unknown keys. Validate every field so a
-        # manually edited/corrupt log cannot smuggle source data into an export.
-        jq -c '
-          select(type == "object" and .schema == 1)
-          | select(.run_id | type == "string" and test("^[0-9]{1,12}-[A-Za-z0-9]{6}$"))
-          | select(.time | type == "number" and . >= 0 and . <= 9999999999 and floor == .)
-          | select(.version | type == "string" and test("^[0-9]{1,5}\\.[0-9]{1,5}\\.[0-9]{1,5}$"))
-          | select(.command | IN("hook-pre-tool", "hook-post-tool", "hook-stop", "hook-user-prompt", "hook-session-start", "scan-staged", "scan-working-tree", "scan-path", "exec", "pii-filter"))
-          | select(.host | IN("claude", "codex", "cli"))
-          | select(.phase | IN("started", "finished"))
-          | select(.outcome | IN("pending", "pass", "blocked", "masked", "degraded", "error", "interrupted", "warned"))
-          | select(.exit_code == null or (.exit_code | type == "number" and . >= 0 and . <= 255 and floor == .))
-          | select(.duration_seconds | type == "number" and . >= 0 and . <= 9999999999 and floor == .)
-          | {schema,run_id,time,version,command,host,phase,outcome,exit_code,duration_seconds}
-        ' "$ag_file" 2>/dev/null || :
-      done
+      shift
+      case "$#" in
+        0) audit_export ;;
+        2) [ "$1" = --output ] || { printf '%s\n' 'Usage: agent-guard logs [status|export [--output FILE]]' >&2; return 2; }; audit_export_to_file "$2" ;;
+        *) printf '%s\n' 'Usage: agent-guard logs [status|export [--output FILE]]' >&2; return 2 ;;
+      esac
       ;;
-    *) printf '%s\n' 'Usage: agent-guard logs [status|export]' >&2; return 2 ;;
+    *) printf '%s\n' 'Usage: agent-guard logs [status|export [--output FILE]]' >&2; return 2 ;;
   esac
 }
 

--- a/tests/audit-log.sh
+++ b/tests/audit-log.sh
@@ -31,6 +31,12 @@ if "$GUARD" logs >"$CASE/default-status.out" 2>"$CASE/default-status.err" \
 else
   bad 'logs without a subcommand keeps the status default'
 fi
+if "$GUARD" logs --help >"$CASE/logs-help.out" 2>"$CASE/logs-help.err" \
+   && grep -Fq 'Usage: agent-guard logs' "$CASE/logs-help.err"; then
+  ok 'logs help exits successfully'
+else
+  bad 'logs help exits successfully'
+fi
 
 output_file="$CASE/agent-guard-support.jsonl"
 "$GUARD" logs export --output "$output_file" >"$CASE/output-file.out" 2>"$CASE/output-file.err"

--- a/tests/audit-log.sh
+++ b/tests/audit-log.sh
@@ -19,6 +19,12 @@ export_logs() { "$GUARD" logs export >"$CASE/export" 2>"$CASE/export.err"; }
 has_outcome() { jq -es --arg o "$1" 'any(.[]; .phase == "finished" and .outcome == $o)' "$CASE/export" >/dev/null; }
 new_case() { rm -rf "$XDG_STATE_HOME"; }
 no_export_temps() { ! find "$1" -maxdepth 1 -name '.agent-guard-support.*' -print | grep -q .; }
+file_mode() {
+  case "$(uname -s)" in
+    Darwin) stat -f '%Lp' "$1" ;;
+    *) stat -c '%a' "$1" ;;
+  esac
+}
 
 printf '%s' '{"tool_name":"FutureTool","tool_input":{}}' | "$GUARD" hook-pre-tool >"$CASE/out" 2>"$CASE/err"
 check 'clean passthrough status and stdout unchanged' test ! -s "$CASE/out"
@@ -44,7 +50,7 @@ check 'output-file export succeeds' test -f "$output_file"
 check 'output-file export preserves stdout export records' cmp "$CASE/export" "$output_file"
 check 'output-file export leaves stdout empty' test ! -s "$CASE/output-file.out"
 check 'output-file export reports its location on stderr' grep -Fq "$output_file" "$CASE/output-file.err"
-case "$(stat -f '%Lp' "$output_file" 2>/dev/null || stat -c '%a' "$output_file" 2>/dev/null)" in
+case "$(file_mode "$output_file" 2>/dev/null)" in
   600) ok 'output-file export is mode 0600' ;;
   *) bad 'output-file export is mode 0600' ;;
 esac

--- a/tests/audit-log.sh
+++ b/tests/audit-log.sh
@@ -18,12 +18,130 @@ check() { label=$1; shift; if "$@"; then ok "$label"; else bad "$label"; fi; }
 export_logs() { "$GUARD" logs export >"$CASE/export" 2>"$CASE/export.err"; }
 has_outcome() { jq -es --arg o "$1" 'any(.[]; .phase == "finished" and .outcome == $o)' "$CASE/export" >/dev/null; }
 new_case() { rm -rf "$XDG_STATE_HOME"; }
+no_export_temps() { ! find "$1" -maxdepth 1 -name '.agent-guard-support.*' -print | grep -q .; }
 
 printf '%s' '{"tool_name":"FutureTool","tool_input":{}}' | "$GUARD" hook-pre-tool >"$CASE/out" 2>"$CASE/err"
 check 'clean passthrough status and stdout unchanged' test ! -s "$CASE/out"
 check 'export succeeds' export_logs
 check 'successful invocation has start and finish linked by run ID' jq -es 'length == 2 and .[0].phase == "started" and .[1].phase == "finished" and .[0].run_id == .[1].run_id' "$CASE/export"
 check 'pass does not imply a clean scan' has_outcome pass
+if "$GUARD" logs >"$CASE/default-status.out" 2>"$CASE/default-status.err" \
+   && grep -q 'Local diagnostic logging:' "$CASE/default-status.out"; then
+  ok 'logs without a subcommand keeps the status default'
+else
+  bad 'logs without a subcommand keeps the status default'
+fi
+
+output_file="$CASE/agent-guard-support.jsonl"
+"$GUARD" logs export --output "$output_file" >"$CASE/output-file.out" 2>"$CASE/output-file.err"
+check 'output-file export succeeds' test -f "$output_file"
+check 'output-file export preserves stdout export records' cmp "$CASE/export" "$output_file"
+check 'output-file export leaves stdout empty' test ! -s "$CASE/output-file.out"
+check 'output-file export reports its location on stderr' grep -Fq "$output_file" "$CASE/output-file.err"
+case "$(stat -f '%Lp' "$output_file" 2>/dev/null || stat -c '%a' "$output_file" 2>/dev/null)" in
+  600) ok 'output-file export is mode 0600' ;;
+  *) bad 'output-file export is mode 0600' ;;
+esac
+check 'output-file export removes its temporary file' no_export_temps "$CASE"
+
+printf 'keep\n' >"$CASE/existing-output"
+if "$GUARD" logs export --output "$CASE/existing-output" >"$CASE/existing.out" 2>"$CASE/existing.err"; then
+  bad 'output-file export refuses an existing target'
+else
+  ok 'output-file export refuses an existing target'
+fi
+check 'existing output target remains unchanged' sh -c 'test "$(cat "$1")" = keep' _ "$CASE/existing-output"
+check 'existing output refusal leaves no temporary file' no_export_temps "$CASE"
+
+mkdir "$CASE/directory-output"
+if "$GUARD" logs export --output "$CASE/directory-output" >"$CASE/directory.out" 2>"$CASE/directory.err"; then
+  bad 'output-file export refuses a directory target'
+else
+  ok 'output-file export refuses a directory target'
+fi
+check 'directory target remains a directory' test -d "$CASE/directory-output"
+check 'directory target refusal leaves no temporary file' no_export_temps "$CASE"
+
+if command -v mkfifo >/dev/null 2>&1 && mkfifo "$CASE/fifo-output" 2>/dev/null; then
+  if "$GUARD" logs export --output "$CASE/fifo-output" >"$CASE/fifo.out" 2>"$CASE/fifo.err"; then
+    bad 'output-file export refuses a FIFO target'
+  else
+    ok 'output-file export refuses a FIFO target'
+  fi
+  check 'FIFO target remains a FIFO' test -p "$CASE/fifo-output"
+  check 'FIFO target refusal leaves no temporary file' no_export_temps "$CASE"
+else
+  printf '%s\n' 'skipping FIFO output test: mkfifo is unavailable'
+fi
+
+if ln -s "$CASE/existing-output" "$CASE/symlink-output" 2>/dev/null; then
+  if "$GUARD" logs export --output "$CASE/symlink-output" >"$CASE/symlink.out" 2>"$CASE/symlink.err"; then
+    bad 'output-file export refuses a symlink target'
+  else
+    ok 'output-file export refuses a symlink target'
+  fi
+else
+  printf '%s\n' 'skipping output symlink test: filesystem does not support symlinks'
+fi
+check 'symlink target refusal leaves no temporary file' no_export_temps "$CASE"
+
+if ln -s "$CASE/not-created" "$CASE/dangling-output" 2>/dev/null; then
+  if "$GUARD" logs export --output "$CASE/dangling-output" >"$CASE/dangling.out" 2>"$CASE/dangling.err"; then
+    bad 'output-file export refuses a dangling symlink target'
+  else
+    ok 'output-file export refuses a dangling symlink target'
+  fi
+  check 'dangling symlink target remains a symlink' test -L "$CASE/dangling-output"
+  check 'dangling symlink refusal leaves no temporary file' no_export_temps "$CASE"
+else
+  printf '%s\n' 'skipping dangling output symlink test: filesystem does not support symlinks'
+fi
+
+mkdir "$CASE/real-parent"
+if ln -s "$CASE/real-parent" "$CASE/symlink-parent" 2>/dev/null; then
+  if "$GUARD" logs export --output "$CASE/symlink-parent/support.jsonl" >"$CASE/parent-symlink.out" 2>"$CASE/parent-symlink.err"; then
+    bad 'output-file export refuses an immediate symlink parent'
+  else
+    ok 'output-file export refuses an immediate symlink parent'
+  fi
+  check 'symlink parent receives no completed export' test ! -e "$CASE/real-parent/support.jsonl"
+  check 'symlink parent refusal leaves no temporary file' no_export_temps "$CASE/real-parent"
+else
+  printf '%s\n' 'skipping symlink parent test: filesystem does not support symlinks'
+fi
+
+if "$GUARD" logs export --output "$CASE/missing-parent/support.jsonl" >"$CASE/missing.out" 2>"$CASE/missing.err"; then
+  bad 'output-file export requires an existing parent'
+else
+  ok 'output-file export requires an existing parent'
+fi
+check 'missing parent receives no completed export' test ! -e "$CASE/missing-parent/support.jsonl"
+
+mkdir "$CASE/no-jq-bin"
+for tool in dirname readlink mktemp id stat rm uname; do
+  tool_path=$(command -v "$tool") || exit 1
+  ln -s "$tool_path" "$CASE/no-jq-bin/$tool"
+done
+if PATH="$CASE/no-jq-bin" /bin/sh "$GUARD" logs export --output "$CASE/jq-missing.jsonl" >"$CASE/jq-missing.out" 2>"$CASE/jq-missing.err"; then
+  bad 'output-file export fails when jq is unavailable'
+else
+  ok 'output-file export fails when jq is unavailable'
+fi
+check 'jq failure leaves no completed export' test ! -e "$CASE/jq-missing.jsonl"
+check 'jq failure leaves no temporary file' no_export_temps "$CASE"
+
+mkdir "$CASE/storage-real"
+if ln -s "$CASE/storage-real" "$CASE/storage-symlink" 2>/dev/null; then
+  if XDG_STATE_HOME="$CASE/storage-symlink" "$GUARD" logs export --output "$CASE/storage-unavailable.jsonl" >"$CASE/storage-unavailable.out" 2>"$CASE/storage-unavailable.err"; then
+    bad 'output-file export fails when audit storage is unavailable'
+  else
+    ok 'output-file export fails when audit storage is unavailable'
+  fi
+  check 'storage failure leaves no completed export' test ! -e "$CASE/storage-unavailable.jsonl"
+  check 'storage failure leaves no temporary file' no_export_temps "$CASE"
+else
+  printf '%s\n' 'skipping unavailable storage test: filesystem does not support symlinks'
+fi
 
 new_case
 sentinel="private-path-$(od -An -N12 -tx1 /dev/urandom | tr -d ' \n')"


### PR DESCRIPTION
Support staff need a safe file they can ask users to submit after a blocked, masked, degraded, or failed Agent Guard event. `agent-guard logs export --output FILE` now writes the existing metadata-only JSONL export directly to a new private mode-0600 file, avoiding shell redirection and refusing to replace an existing file, link, directory, or pipe.

The export is built in a private temporary file in the destination directory and published only after sanitization completes. Standard-output export remains available for scripts.

Validation:

- `sh tests/audit-log.sh` — 64 passed, 0 failed
- integrated `sh tests/run.sh` — 1,408 passed, 0 failed
- PR CI — Ubuntu and macOS passed; the first Ubuntu run exposed and then fixed a BSD/GNU `stat` portability bug in the mode assertion, while the exported file itself was already mode 0600
- extracted v3.4.1 candidate archive: `logs export --output` produced a non-empty mode-0600 JSONL file
- independent review found no P0 or P1 issue
